### PR TITLE
WKB Marshalling

### DIFF
--- a/type_empty.go
+++ b/type_empty.go
@@ -2,23 +2,27 @@ package simplefeatures
 
 import (
 	"database/sql/driver"
+	"errors"
+	"io"
+	"math"
 )
 
 // EmptySet is a 0-dimensional geometry that represents the empty pointset.
 type EmptySet struct {
-	wkt string
+	wkt     string
+	wkbType uint32
 }
 
 func NewEmptyPoint() EmptySet {
-	return EmptySet{"POINT EMPTY"}
+	return EmptySet{"POINT EMPTY", wkbGeomTypePoint}
 }
 
 func NewEmptyLineString() EmptySet {
-	return EmptySet{"LINESTRING EMPTY"}
+	return EmptySet{"LINESTRING EMPTY", wkbGeomTypeLineString}
 }
 
 func NewEmptyPolygon() EmptySet {
-	return EmptySet{"POLYGON EMPTY"}
+	return EmptySet{"POLYGON EMPTY", wkbGeomTypePolygon}
 }
 
 func (e EmptySet) AsText() string {
@@ -59,4 +63,24 @@ func (e EmptySet) Boundary() Geometry {
 
 func (e EmptySet) Value() (driver.Value, error) {
 	return e.AsText(), nil
+}
+
+func (e EmptySet) AsBinary(w io.Writer) error {
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(e.wkbType)
+	switch e.wkbType {
+	case wkbGeomTypePoint:
+		marsh.writeFloat64(math.NaN())
+		marsh.writeFloat64(math.NaN())
+		return marsh.err
+	case wkbGeomTypeLineString, wkbGeomTypePolygon:
+		marsh.writeCount(0)
+		return marsh.err
+	default:
+		if marsh.err != nil {
+			return marsh.err
+		}
+		return errors.New("unknown empty geometry type (this shouldn't ever happen)")
+	}
 }

--- a/type_empty.go
+++ b/type_empty.go
@@ -73,14 +73,10 @@ func (e EmptySet) AsBinary(w io.Writer) error {
 	case wkbGeomTypePoint:
 		marsh.writeFloat64(math.NaN())
 		marsh.writeFloat64(math.NaN())
-		return marsh.err
 	case wkbGeomTypeLineString, wkbGeomTypePolygon:
 		marsh.writeCount(0)
-		return marsh.err
 	default:
-		if marsh.err != nil {
-			return marsh.err
-		}
-		return errors.New("unknown empty geometry type (this shouldn't ever happen)")
+		marsh.setErr(errors.New("unknown empty geometry type (this shouldn't ever happen)"))
 	}
+	return marsh.err
 }

--- a/type_geometry.go
+++ b/type_geometry.go
@@ -1,5 +1,7 @@
 package simplefeatures
 
+import "io"
+
 // Geometry is the most general type of geometry supported, and exposes common
 // behaviour. All geometry types implement this interface.
 type Geometry interface {
@@ -9,6 +11,10 @@ type Geometry interface {
 	// AppendWKT appends the WKT representation of the geometry to dst and
 	// returns the resultant slice.
 	AppendWKT(dst []byte) []byte
+
+	// AsBinary writes the WKB (Well Known Binary) representation of the
+	// geometry to the writer.
+	AsBinary(w io.Writer) error
 
 	// Intersection returns a geometric object that represents the point set
 	// intersection of this geometry with another geometry.

--- a/type_geometry_collection.go
+++ b/type_geometry_collection.go
@@ -2,6 +2,7 @@ package simplefeatures
 
 import (
 	"database/sql/driver"
+	"io"
 )
 
 // GeometryCollection is a collection of geometries.
@@ -113,4 +114,8 @@ func (c GeometryCollection) Boundary() Geometry {
 
 func (c GeometryCollection) Value() (driver.Value, error) {
 	return c.AsText(), nil
+}
+
+func (c GeometryCollection) AsBinary(w io.Writer) error {
+	return MarshalWKB(c, w)
 }

--- a/type_geometry_collection.go
+++ b/type_geometry_collection.go
@@ -117,5 +117,5 @@ func (c GeometryCollection) Value() (driver.Value, error) {
 }
 
 func (c GeometryCollection) AsBinary(w io.Writer) error {
-	return MarshalWKB(c, w)
+	return nil // TODO
 }

--- a/type_geometry_collection.go
+++ b/type_geometry_collection.go
@@ -117,5 +117,14 @@ func (c GeometryCollection) Value() (driver.Value, error) {
 }
 
 func (c GeometryCollection) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypeGeometryCollection)
+	n := c.NumGeometries()
+	marsh.writeCount(n)
+	for i := 0; i < n; i++ {
+		geom := c.GeometryN(i)
+		marsh.setErr(geom.AsBinary(w))
+	}
+	return marsh.err
 }

--- a/type_line.go
+++ b/type_line.go
@@ -3,6 +3,7 @@ package simplefeatures
 import (
 	"database/sql/driver"
 	"fmt"
+	"io"
 )
 
 // Line is a single line segment between two points.
@@ -99,4 +100,8 @@ func (n Line) Boundary() Geometry {
 
 func (n Line) Value() (driver.Value, error) {
 	return n.AsText(), nil
+}
+
+func (n Line) AsBinary(w io.Writer) error {
+	return MarshalWKB(n, w)
 }

--- a/type_line.go
+++ b/type_line.go
@@ -103,5 +103,5 @@ func (n Line) Value() (driver.Value, error) {
 }
 
 func (n Line) AsBinary(w io.Writer) error {
-	return MarshalWKB(n, w)
+	return nil // TODO
 }

--- a/type_line.go
+++ b/type_line.go
@@ -103,5 +103,13 @@ func (n Line) Value() (driver.Value, error) {
 }
 
 func (n Line) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypeLineString)
+	marsh.writeCount(2)
+	marsh.writeFloat64(n.StartPoint().XY().X.AsFloat())
+	marsh.writeFloat64(n.StartPoint().XY().Y.AsFloat())
+	marsh.writeFloat64(n.EndPoint().XY().X.AsFloat())
+	marsh.writeFloat64(n.EndPoint().XY().Y.AsFloat())
+	return marsh.err
 }

--- a/type_line_string.go
+++ b/type_line_string.go
@@ -169,5 +169,14 @@ func (s LineString) Value() (driver.Value, error) {
 }
 
 func (s LineString) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypeLineString)
+	n := s.NumPoints()
+	marsh.writeCount(n)
+	for i := 0; i < n; i++ {
+		marsh.writeFloat64(s.PointN(i).XY().X.AsFloat())
+		marsh.writeFloat64(s.PointN(i).XY().Y.AsFloat())
+	}
+	return marsh.err
 }

--- a/type_line_string.go
+++ b/type_line_string.go
@@ -3,6 +3,7 @@ package simplefeatures
 import (
 	"database/sql/driver"
 	"errors"
+	"io"
 )
 
 // LineString is a curve defined by linear interpolation between a finite set
@@ -165,4 +166,8 @@ func (s LineString) Boundary() Geometry {
 
 func (s LineString) Value() (driver.Value, error) {
 	return s.AsText(), nil
+}
+
+func (s LineString) AsBinary(w io.Writer) error {
+	return MarshalWKB(s, w)
 }

--- a/type_line_string.go
+++ b/type_line_string.go
@@ -169,5 +169,5 @@ func (s LineString) Value() (driver.Value, error) {
 }
 
 func (s LineString) AsBinary(w io.Writer) error {
-	return MarshalWKB(s, w)
+	return nil // TODO
 }

--- a/type_linear_ring.go
+++ b/type_linear_ring.go
@@ -107,5 +107,5 @@ func (r LinearRing) Value() (driver.Value, error) {
 }
 
 func (r LinearRing) AsBinary(w io.Writer) error {
-	return MarshalWKB(r, w)
+	return nil // TODO
 }

--- a/type_linear_ring.go
+++ b/type_linear_ring.go
@@ -3,6 +3,7 @@ package simplefeatures
 import (
 	"database/sql/driver"
 	"errors"
+	"io"
 )
 
 // LinearRing is a LineString that is constainted to be closed and simple.
@@ -103,4 +104,8 @@ func (r LinearRing) Boundary() Geometry {
 
 func (r LinearRing) Value() (driver.Value, error) {
 	return r.AsText(), nil
+}
+
+func (r LinearRing) AsBinary(w io.Writer) error {
+	return MarshalWKB(r, w)
 }

--- a/type_linear_ring.go
+++ b/type_linear_ring.go
@@ -107,5 +107,5 @@ func (r LinearRing) Value() (driver.Value, error) {
 }
 
 func (r LinearRing) AsBinary(w io.Writer) error {
-	return nil // TODO
+	return r.ls.AsBinary(w)
 }

--- a/type_multi_line_string.go
+++ b/type_multi_line_string.go
@@ -156,5 +156,14 @@ func (m MultiLineString) Value() (driver.Value, error) {
 }
 
 func (m MultiLineString) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypeMultiLineString)
+	n := m.NumLineStrings()
+	marsh.writeCount(n)
+	for i := 0; i < n; i++ {
+		ls := m.LineStringN(i)
+		marsh.setErr(ls.AsBinary(w))
+	}
+	return marsh.err
 }

--- a/type_multi_line_string.go
+++ b/type_multi_line_string.go
@@ -2,6 +2,7 @@ package simplefeatures
 
 import (
 	"database/sql/driver"
+	"io"
 )
 
 // MultiLineString is a multicurve whose elements are LineStrings.
@@ -152,4 +153,8 @@ func (m MultiLineString) Boundary() Geometry {
 
 func (m MultiLineString) Value() (driver.Value, error) {
 	return m.AsText(), nil
+}
+
+func (m MultiLineString) AsBinary(w io.Writer) error {
+	return MarshalWKB(m, w)
 }

--- a/type_multi_line_string.go
+++ b/type_multi_line_string.go
@@ -156,5 +156,5 @@ func (m MultiLineString) Value() (driver.Value, error) {
 }
 
 func (m MultiLineString) AsBinary(w io.Writer) error {
-	return MarshalWKB(m, w)
+	return nil // TODO
 }

--- a/type_multi_point.go
+++ b/type_multi_point.go
@@ -115,5 +115,5 @@ func (m MultiPoint) Value() (driver.Value, error) {
 }
 
 func (m MultiPoint) AsBinary(w io.Writer) error {
-	return MarshalWKB(m, w)
+	return nil // TODO
 }

--- a/type_multi_point.go
+++ b/type_multi_point.go
@@ -115,5 +115,14 @@ func (m MultiPoint) Value() (driver.Value, error) {
 }
 
 func (m MultiPoint) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypeMultiPoint)
+	n := m.NumPoints()
+	marsh.writeCount(n)
+	for i := 0; i < n; i++ {
+		pt := m.PointN(i)
+		marsh.setErr(pt.AsBinary(w))
+	}
+	return marsh.err
 }

--- a/type_multi_point.go
+++ b/type_multi_point.go
@@ -2,6 +2,7 @@ package simplefeatures
 
 import (
 	"database/sql/driver"
+	"io"
 )
 
 // MultiPoint is a 0-dimensional geometric collection of points. The points are
@@ -111,4 +112,8 @@ func (m MultiPoint) Boundary() Geometry {
 
 func (m MultiPoint) Value() (driver.Value, error) {
 	return m.AsText(), nil
+}
+
+func (m MultiPoint) AsBinary(w io.Writer) error {
+	return MarshalWKB(m, w)
 }

--- a/type_multi_polygon.go
+++ b/type_multi_polygon.go
@@ -3,6 +3,7 @@ package simplefeatures
 import (
 	"database/sql/driver"
 	"errors"
+	"io"
 	"sort"
 )
 
@@ -216,4 +217,8 @@ func (m MultiPolygon) Boundary() Geometry {
 
 func (m MultiPolygon) Value() (driver.Value, error) {
 	return m.AsText(), nil
+}
+
+func (m MultiPolygon) AsBinary(w io.Writer) error {
+	return MarshalWKB(m, w)
 }

--- a/type_multi_polygon.go
+++ b/type_multi_polygon.go
@@ -220,5 +220,14 @@ func (m MultiPolygon) Value() (driver.Value, error) {
 }
 
 func (m MultiPolygon) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypeMultiPolygon)
+	n := m.NumPolygons()
+	marsh.writeCount(n)
+	for i := 0; i < n; i++ {
+		poly := m.PolygonN(i)
+		marsh.setErr(poly.AsBinary(w))
+	}
+	return marsh.err
 }

--- a/type_multi_polygon.go
+++ b/type_multi_polygon.go
@@ -220,5 +220,5 @@ func (m MultiPolygon) Value() (driver.Value, error) {
 }
 
 func (m MultiPolygon) AsBinary(w io.Writer) error {
-	return MarshalWKB(m, w)
+	return nil // TODO
 }

--- a/type_point.go
+++ b/type_point.go
@@ -2,6 +2,7 @@ package simplefeatures
 
 import (
 	"database/sql/driver"
+	"io"
 )
 
 // Point is a 0-dimensional geometry, and represents a single location in a
@@ -85,4 +86,18 @@ func (p Point) Boundary() Geometry {
 
 func (p Point) Value() (driver.Value, error) {
 	return p.AsText(), nil
+}
+
+func (p Point) AsBinary(w io.Writer) error {
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypePoint)
+	marsh.writeFloat64(p.coords.X.AsFloat())
+	marsh.writeFloat64(p.coords.Y.AsFloat())
+	return marsh.err
+}
+
+// TODO: remove me
+func MarshalWKB(g Geometry, w io.Writer) error {
+	return nil
 }

--- a/type_point.go
+++ b/type_point.go
@@ -96,8 +96,3 @@ func (p Point) AsBinary(w io.Writer) error {
 	marsh.writeFloat64(p.coords.Y.AsFloat())
 	return marsh.err
 }
-
-// TODO: remove me
-func MarshalWKB(g Geometry, w io.Writer) error {
-	return nil
-}

--- a/type_polygon.go
+++ b/type_polygon.go
@@ -182,5 +182,5 @@ func (p Polygon) Value() (driver.Value, error) {
 }
 
 func (p Polygon) AsBinary(w io.Writer) error {
-	return MarshalWKB(p, w)
+	return nil // TODO
 }

--- a/type_polygon.go
+++ b/type_polygon.go
@@ -3,6 +3,7 @@ package simplefeatures
 import (
 	"database/sql/driver"
 	"errors"
+	"io"
 )
 
 // Polygon is a planar surface, defined by 1 exiterior boundary and 0 or more
@@ -178,4 +179,8 @@ func (p Polygon) Boundary() Geometry {
 
 func (p Polygon) Value() (driver.Value, error) {
 	return p.AsText(), nil
+}
+
+func (p Polygon) AsBinary(w io.Writer) error {
+	return MarshalWKB(p, w)
 }

--- a/type_polygon.go
+++ b/type_polygon.go
@@ -182,5 +182,19 @@ func (p Polygon) Value() (driver.Value, error) {
 }
 
 func (p Polygon) AsBinary(w io.Writer) error {
-	return nil // TODO
+	marsh := newWKBMarshaller(w)
+	marsh.writeByteOrder()
+	marsh.writeGeomType(wkbGeomTypePolygon)
+	rings := p.rings()
+	marsh.writeCount(len(rings))
+	for _, ring := range rings {
+		numPts := ring.NumPoints()
+		marsh.writeCount(numPts)
+		for i := 0; i < numPts; i++ {
+			pt := ring.PointN(i)
+			marsh.writeFloat64(pt.XY().X.AsFloat())
+			marsh.writeFloat64(pt.XY().Y.AsFloat())
+		}
+	}
+	return marsh.err
 }

--- a/wkb_marshal.go
+++ b/wkb_marshal.go
@@ -1,0 +1,49 @@
+package simplefeatures
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type wkbMarshaller struct {
+	w   io.Writer
+	err error
+}
+
+func newWKBMarshaller(w io.Writer) *wkbMarshaller {
+	return &wkbMarshaller{w: w}
+}
+
+func (m *wkbMarshaller) setErr(err error) {
+	if m.err == nil {
+		m.err = err
+	}
+}
+
+func (m *wkbMarshaller) write(data interface{}) {
+	if m.err != nil {
+		return
+	}
+	// Output byte order is an arbitrary choice (either is allowed by the
+	// WKB spec). Little endian is chosen because this is the same as
+	// Postgres.
+	err := binary.Write(m.w, binary.LittleEndian, data)
+	m.setErr(err)
+}
+
+func (m *wkbMarshaller) writeByteOrder() {
+	const littleEndian byte = 1
+	m.write(littleEndian)
+}
+
+func (m *wkbMarshaller) writeGeomType(geomType uint32) {
+	m.write(geomType)
+}
+
+func (m *wkbMarshaller) writeFloat64(f float64) {
+	m.write(f)
+}
+
+func (m *wkbMarshaller) writeCount(n int) {
+	m.write(uint32(n))
+}

--- a/wkb_test.go
+++ b/wkb_test.go
@@ -25,7 +25,7 @@ func hexStringToBytes(t *testing.T, s string) []byte {
 	return buf
 }
 
-func TestWKBParser(t *testing.T) {
+func TestWKBParseValid(t *testing.T) {
 	// Test cases generated from:
 	/*
 		SELECT
@@ -469,25 +469,25 @@ func TestWKBParserInvalidGeometryType(t *testing.T) {
 	}
 }
 
-func TestWKBMarshal(t *testing.T) {
+func TestWKBMarshalValid(t *testing.T) {
 	for i, wkt := range []string{
 		"POINT EMPTY",
 		"POINT(1 2)",
 		"LINESTRING EMPTY",
-		//"LINESTRING(1 2,3 4)",
-		//"LINESTRING(1 2,3 4,5 6)",
+		"LINESTRING(1 2,3 4)",
+		"LINESTRING(1 2,3 4,5 6)",
 		"POLYGON EMPTY",
-		//"POLYGON((0 0,4 0,0 4,0 0),(1 1,2 1,1 2,1 1))",
-		//"MULTIPOINT EMPTY",
-		//"MULTIPOINT(1 2)",
-		//"MULTIPOINT(1 2,3 4)",
-		//"MULTILINESTRING EMPTY",
-		//"MULTILINESTRING((0 1,2 3,4 5))",
-		//"MULTILINESTRING((0 1,2 3),(4 5,6 7,8 9))",
-		//"MULTIPOLYGON EMPTY",
-		//"MULTIPOLYGON(((0 0,1 0,0 1,0 0)),((1 0,2 0,1 1,1 0)))",
-		//"GEOMETRYCOLLECTION EMPTY",
-		//"GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))",
+		"POLYGON((0 0,4 0,0 4,0 0),(1 1,2 1,1 2,1 1))",
+		"MULTIPOINT EMPTY",
+		"MULTIPOINT(1 2)",
+		"MULTIPOINT(1 2,3 4)",
+		"MULTILINESTRING EMPTY",
+		"MULTILINESTRING((0 1,2 3,4 5))",
+		"MULTILINESTRING((0 1,2 3),(4 5,6 7,8 9))",
+		"MULTIPOLYGON EMPTY",
+		"MULTIPOLYGON(((0 0,1 0,0 1,0 0)),((1 0,2 0,1 1,1 0)))",
+		"GEOMETRYCOLLECTION EMPTY",
+		"GEOMETRYCOLLECTION(POINT(1 2),LINESTRING(1 2,3 4))",
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			geom := geomFromWKT(t, wkt)

--- a/wkb_test.go
+++ b/wkb_test.go
@@ -173,7 +173,6 @@ func TestWKBParser(t *testing.T) {
 			wkb: "010200000002000000000000000000f03f000000000000004000000000000008400000000000001040",
 			wkt: "LINESTRING(1 2,3 4)",
 		},
-
 		{
 			// LINESTRINGZ(1 2 3,4 5 6)
 			wkb: "01ea03000002000000000000000000f03f00000000000000400000000000000840000000000000104000000000000014400000000000001840",
@@ -467,5 +466,37 @@ func TestWKBParserInvalidGeometryType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown geometry type") {
 		t.Errorf("expected to be an error about unknown geometry type, but got: %v", err)
+	}
+}
+
+func TestWKBMarshal(t *testing.T) {
+	for i, wkt := range []string{
+		"POINT EMPTY",
+		"POINT(1 2)",
+		"LINESTRING EMPTY",
+		//"LINESTRING(1 2,3 4)",
+		//"LINESTRING(1 2,3 4,5 6)",
+		"POLYGON EMPTY",
+		//"POLYGON((0 0,4 0,0 4,0 0),(1 1,2 1,1 2,1 1))",
+		//"MULTIPOINT EMPTY",
+		//"MULTIPOINT(1 2)",
+		//"MULTIPOINT(1 2,3 4)",
+		//"MULTILINESTRING EMPTY",
+		//"MULTILINESTRING((0 1,2 3,4 5))",
+		//"MULTILINESTRING((0 1,2 3),(4 5,6 7,8 9))",
+		//"MULTIPOLYGON EMPTY",
+		//"MULTIPOLYGON(((0 0,1 0,0 1,0 0)),((1 0,2 0,1 1,1 0)))",
+		//"GEOMETRYCOLLECTION EMPTY",
+		//"GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))",
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			geom := geomFromWKT(t, wkt)
+			var buf bytes.Buffer
+			err := geom.AsBinary(&buf)
+			expectNoErr(t, err)
+			readBackGeom, err := UnmarshalWKB(&buf)
+			expectNoErr(t, err)
+			expectDeepEqual(t, readBackGeom, geom)
+		})
 	}
 }

--- a/wkb_test.go
+++ b/wkb_test.go
@@ -500,3 +500,16 @@ func TestWKBMarshalValid(t *testing.T) {
 		})
 	}
 }
+
+func TestWKBMarshalValidLinearRing(t *testing.T) {
+	const wkt = "LINEARRING(0 0,1 0,0 1,0 0)"
+	geom := geomFromWKT(t, wkt)
+
+	var buf bytes.Buffer
+	err := geom.AsBinary(&buf)
+	expectNoErr(t, err)
+
+	readBackGeom, err := UnmarshalWKB(&buf)
+	expectNoErr(t, err)
+	expectDeepEqual(t, readBackGeom, geomFromWKT(t, "LINESTRING(0 0,1 0,0 1,0 0)"))
+}


### PR DESCRIPTION
- Adds a new method `AsBinary(io.Writer) error` to the `Geometry interface.
- Adds implementations for `AsBinary` for each concrete geometry type.
- Adds unit tests for happy path cases for marshalling as WKB. No error handling cases have been added.