### PR TITLE
Errors for non implemented combinations

### DIFF
--- a/geom/alg_equals.go
+++ b/geom/alg_equals.go
@@ -5,15 +5,15 @@ import (
 	"reflect"
 )
 
-func equals(g1, g2 Geometry) bool {
+func equals(g1, g2 Geometry) (bool, error) {
 	if g1.IsEmpty() && g2.IsEmpty() {
-		return true
+		return true, nil
 	}
 	if g1.IsEmpty() || g2.IsEmpty() {
-		return false
+		return false, nil
 	}
 	if g1.Dimension() != g2.Dimension() {
-		return false
+		return false, nil
 	}
 
 	if rank(g1) > rank(g2) {
@@ -23,18 +23,18 @@ func equals(g1, g2 Geometry) bool {
 	case Point:
 		switch g2 := g2.(type) {
 		case Point:
-			return g1.coords.XY.Equals(g2.coords.XY)
+			return g1.coords.XY.Equals(g2.coords.XY), nil
 		case MultiPoint:
 			g1Set := NewMultiPoint([]Point{g1})
-			return equalsMultiPointAndMultiPoint(g1Set, g2)
+			return equalsMultiPointAndMultiPoint(g1Set, g2), nil
 		}
 	case MultiPoint:
 		switch g2 := g2.(type) {
 		case MultiPoint:
-			return equalsMultiPointAndMultiPoint(g1, g2)
+			return equalsMultiPointAndMultiPoint(g1, g2), nil
 		}
 	}
-	panic(fmt.Sprintf("not implemented: equals with %T and %T", g1, g2))
+	return false, fmt.Errorf("not implemented: equals with %T and %T", g1, g2)
 }
 
 func equalsMultiPointAndMultiPoint(mp1, mp2 MultiPoint) bool {

--- a/geom/alg_equals_test.go
+++ b/geom/alg_equals_test.go
@@ -35,7 +35,11 @@ func TestNotEquals(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if g1.Equals(g2) {
+				eq, err := g1.Equals(g2)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if eq {
 					t.Errorf("expected not be be equal")
 				}
 			})
@@ -75,7 +79,11 @@ func TestEquals(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					if !g1.Equals(g2) {
+					eq, err := g1.Equals(g2)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !eq {
 						t.Errorf("expected to be equal")
 					}
 				})

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -323,12 +323,12 @@ outer:
 	}
 }
 
-func hasIntersection(g1, g2 Geometry) (intersects bool, dimension int) {
+func hasIntersection(g1, g2 Geometry) (intersects bool, dimension int, err error) {
 	if g2.IsEmpty() {
-		return false, 0 // No intersection
+		return false, 0, nil // No intersection
 	}
 	if g1.IsEmpty() {
-		return false, 0 // No intersection
+		return false, 0, nil // No intersection
 	}
 
 	if rank(g1) > rank(g2) {
@@ -385,10 +385,10 @@ func hasIntersection(g1, g2 Geometry) (intersects bool, dimension int) {
 		}
 	}
 
-	panic(fmt.Sprintf("not implemented: hasIntersection with %T and %T", g1, g2))
+	return false, 0, fmt.Errorf("not implemented: hasIntersection with %T and %T", g1, g2)
 }
 
-func hasIntersectionLineWithLine(n1, n2 Line) (intersects bool, dimension int) {
+func hasIntersectionLineWithLine(n1, n2 Line) (intersects bool, dimension int, err error) {
 	// Speed is O(1), but there are multiplications involved.
 	a := n1.a.XY
 	b := n1.b.XY
@@ -401,12 +401,12 @@ func hasIntersectionLineWithLine(n1, n2 Line) (intersects bool, dimension int) {
 	o4 := orientation(c, d, b)
 
 	if o1 != o2 && o3 != o4 {
-		return true, 0 // Point has dimension 0
+		return true, 0, nil // Point has dimension 0
 	}
 
 	if o1 == collinear && o2 == collinear {
 		if (!onSegment(a, b, c) && !onSegment(a, b, d)) && (!onSegment(c, d, a) && !onSegment(c, d, b)) {
-			return false, 0 // No intersection
+			return false, 0, nil // No intersection
 		}
 
 		// ---------------------
@@ -418,29 +418,33 @@ func hasIntersectionLineWithLine(n1, n2 Line) (intersects bool, dimension int) {
 		ltl := leftmostThenLowestIndex(pts)
 		pts = append(pts[:ltl], pts[ltl+1:]...)
 		if pts[0].Equals(pts[1]) {
-			return true, 0 // Point has dimension 0
+			return true, 0, nil // Point has dimension 0
 		}
 		//----------------------
 
-		return true, 1 // Line has dimension 1
+		return true, 1, nil // Line has dimension 1
 	}
 
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionLineWithMultiPoint(ln Line, mp MultiPoint) (intersects bool, dimension int) {
+func hasIntersectionLineWithMultiPoint(ln Line, mp MultiPoint) (intersects bool, dimension int, err error) {
 	// Worst case speed is O(n), n is the number of points.
 	n := mp.NumPoints()
 	for i := 0; i < n; i++ {
 		pt := mp.PointN(i)
-		if intersects, _ := hasIntersectionPointWithLine(pt, ln); intersects {
-			return true, 0 // Point and MultiPoint both have dimension 0
+		intersects, _, err := hasIntersectionPointWithLine(pt, ln)
+		if err != nil {
+			return false, 0, err
+		}
+		if intersects {
+			return true, 0, nil // Point and MultiPoint both have dimension 0
 		}
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) (intersects bool, dimension int) {
+func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) (intersects bool, dimension int, err error) {
 	// Speed is O(n * m) where n, m are the number of lines in each input.
 	// This may be the best case, because we must visit all combinations in case
 	// any colinear line overlaps exist which would raise the dimensionality.
@@ -448,7 +452,11 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		for _, ln1 := range ls1.lines {
 			for _, ls2 := range mls2.lines {
 				for _, ln2 := range ls2.lines {
-					if inter, dim := hasIntersectionLineWithLine(ln1, ln2); inter {
+					inter, dim, err := hasIntersectionLineWithLine(ln1, ln2)
+					if err != nil {
+						return false, 0, err
+					}
+					if inter {
 						intersects = true
 						if dim > dimension {
 							dimension = dim
@@ -458,86 +466,98 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 			}
 		}
 	}
-	return intersects, dimension
+	return intersects, dimension, nil
 }
 
-func hasIntersectionPointWithLine(point Point, line Line) (intersects bool, dimension int) {
+func hasIntersectionPointWithLine(point Point, line Line) (intersects bool, dimension int, err error) {
 	// Speed is O(1) using a bounding box check then a point-on-line check.
 	env := mustEnvelope(line)
 	if !env.Contains(point.coords.XY) {
-		return false, 0 // No intersection
+		return false, 0, nil // No intersection
 	}
 	lhs := (point.coords.X - line.a.X) * (line.b.Y - line.a.Y)
 	rhs := (point.coords.Y - line.a.Y) * (line.b.X - line.a.X)
 	if lhs == rhs {
-		return true, 0 // Point has dimension 0
+		return true, 0, nil // Point has dimension 0
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionPointWithLineString(pt Point, ls LineString) (intersects bool, dimension int) {
+func hasIntersectionPointWithLineString(pt Point, ls LineString) (intersects bool, dimension int, err error) {
 	// Worst case speed is O(n), n is the number of lines.
 	for _, ln := range ls.lines {
-		if intersects, dimension = hasIntersectionPointWithLine(pt, ln); intersects {
-			return true, 0 // Point has dimension 0
+		intersects, dimension, err = hasIntersectionPointWithLine(pt, ln)
+		if err != nil {
+			return false, 0, err
+		}
+		if intersects {
+			return true, 0, nil // Point has dimension 0
 		}
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionMultiPointWithMultiPoint(mp1, mp2 MultiPoint) (intersects bool, dimension int) {
+func hasIntersectionMultiPointWithMultiPoint(mp1, mp2 MultiPoint) (intersects bool, dimension int, err error) {
 	// To do: improve the speed efficiency, it's currently O(n1*n2)
 	for _, pt := range mp1.pts {
-		if intersects, dimension = hasIntersectionPointWithMultiPoint(pt, mp2); intersects {
-			return true, 0 // Point and MultiPoint both have dimension 0
+		intersects, dimension, err = hasIntersectionPointWithMultiPoint(pt, mp2)
+		if err != nil {
+			return false, 0, err
+		}
+		if intersects {
+			return true, 0, nil // Point and MultiPoint both have dimension 0
 		}
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionPointWithMultiPoint(point Point, mp MultiPoint) (intersects bool, dimension int) {
+func hasIntersectionPointWithMultiPoint(point Point, mp MultiPoint) (intersects bool, dimension int, err error) {
 	// Worst case speed is O(n) but that's optimal because mp is not sorted.
 	for _, pt := range mp.pts {
 		if pt.Equals(point) {
-			return true, 0 // Point and MultiPoint both have dimension 0
+			return true, 0, nil // Point and MultiPoint both have dimension 0
 		}
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionPointWithPoint(pt1, pt2 Point) (intersects bool, dimension int) {
+func hasIntersectionPointWithPoint(pt1, pt2 Point) (intersects bool, dimension int, err error) {
 	// Speed is O(1).
 	if pt1.Equals(pt2) {
-		return true, 0 // Point has dimension 0
+		return true, 0, nil // Point has dimension 0
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }
 
-func hasIntersectionPointWithPolygon(pt Point, p Polygon) (intersects bool, dimension int) {
+func hasIntersectionPointWithPolygon(pt Point, p Polygon) (intersects bool, dimension int, err error) {
 	// Speed is O(m), m is the number of holes in the polygon.
 	m := p.NumInteriorRings()
 
 	if pointRingSide(pt.XY(), p.ExteriorRing()) == exterior {
-		return false, 0 // No intersection (outside the exterior)
+		return false, 0, nil // No intersection (outside the exterior)
 	}
 	for j := 0; j < m; j++ {
 		ring := p.InteriorRingN(j)
 		if pointRingSide(pt.XY(), ring) == interior {
-			return false, 0 // No intersection (inside a hole)
+			return false, 0, nil // No intersection (inside a hole)
 		}
 	}
-	return true, 0 // Point has dimension 0
+	return true, 0, nil // Point has dimension 0
 }
 
-func hasIntersectionMultiPointWithPolygon(mp MultiPoint, p Polygon) (intersects bool, dimension int) {
+func hasIntersectionMultiPointWithPolygon(mp MultiPoint, p Polygon) (intersects bool, dimension int, err error) {
 	// Speed is O(n*m), n is the number of points, m is the number of holes in the polygon.
 	n := mp.NumPoints()
 
 	for i := 0; i < n; i++ {
 		pt := mp.PointN(i)
-		if intersects, dimension = hasIntersectionPointWithPolygon(pt, p); intersects {
-			return // Point and MultiPoint have dimension 0
+		intersects, dimension, err = hasIntersectionPointWithPolygon(pt, p)
+		if err != nil {
+			return false, 0, err
+		}
+		if intersects {
+			return true, dimension, nil // Point and MultiPoint have dimension 0
 		}
 	}
-	return false, 0 // No intersection
+	return false, 0, nil // No intersection
 }

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -151,10 +151,6 @@ func intersectLineWithMultiPoint(ln Line, mp MultiPoint) Geometry {
 	return NewMultiPoint(pts)
 }
 
-type bbox struct {
-	min, max XY
-}
-
 func intersectMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) Geometry {
 	var collection []Geometry
 	for _, ls1 := range mls1.lines {

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -441,8 +441,7 @@ func hasIntersectionLineWithMultiPoint(ln Line, mp MultiPoint) (intersects bool,
 	n := mp.NumPoints()
 	for i := 0; i < n; i++ {
 		pt := mp.PointN(i)
-		intersects, _ = hasIntersectionPointWithLine(pt, ln)
-		if intersects {
+		if intersects, _ = hasIntersectionPointWithLine(pt, ln); intersects {
 			return true, 0 // Point and MultiPoint both have dimension 0
 		}
 	}
@@ -457,8 +456,7 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		for _, ln1 := range ls1.lines {
 			for _, ls2 := range mls2.lines {
 				for _, ln2 := range ls2.lines {
-					inter, dim := hasIntersectionLineWithLine(ln1, ln2)
-					if inter {
+					if inter, dim := hasIntersectionLineWithLine(ln1, ln2); inter {
 						intersects = true
 						if dim > dimension {
 							dimension = dim
@@ -488,8 +486,7 @@ func hasIntersectionPointWithLine(point Point, line Line) (intersects bool, dime
 func hasIntersectionPointWithLineString(pt Point, ls LineString) (intersects bool, dimension int) {
 	// Worst case speed is O(n), n is the number of lines.
 	for _, ln := range ls.lines {
-		intersects, _ = hasIntersectionPointWithLine(pt, ln)
-		if intersects {
+		if intersects, _ = hasIntersectionPointWithLine(pt, ln); intersects {
 			return true, 0 // Point has dimension 0
 		}
 	}
@@ -547,8 +544,7 @@ func hasIntersectionMultiPointWithPolygon(mp MultiPoint, p Polygon) (intersects 
 
 	for i := 0; i < n; i++ {
 		pt := mp.PointN(i)
-		intersects, _ = hasIntersectionPointWithPolygon(pt, p)
-		if intersects {
+		if intersects, _ = hasIntersectionPointWithPolygon(pt, p); intersects {
 			return true, 0 // Point and MultiPoint have dimension 0
 		}
 	}

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -236,7 +236,7 @@ func intersectPointWithMultiPoint(point Point, mp MultiPoint) Geometry {
 		return mp
 	}
 	for _, pt := range mp.pts {
-		if pt.Equals(point) {
+		if pt.EqualsExact(point) {
 			return NewPointXY(point.coords.XY)
 		}
 	}
@@ -244,7 +244,7 @@ func intersectPointWithMultiPoint(point Point, mp MultiPoint) Geometry {
 }
 
 func intersectPointWithPoint(pt1, pt2 Point) Geometry {
-	if pt1.Equals(pt2) {
+	if pt1.EqualsExact(pt2) {
 		return NewPointXY(pt1.coords.XY)
 	}
 	return NewGeometryCollection(nil)
@@ -514,7 +514,7 @@ func hasIntersectionMultiPointWithMultiPoint(mp1, mp2 MultiPoint) (intersects bo
 func hasIntersectionPointWithMultiPoint(point Point, mp MultiPoint) (intersects bool, dimension int, err error) {
 	// Worst case speed is O(n) but that's optimal because mp is not sorted.
 	for _, pt := range mp.pts {
-		if pt.Equals(point) {
+		if pt.EqualsExact(point) {
 			return true, 0, nil // Point and MultiPoint both have dimension 0
 		}
 	}
@@ -523,7 +523,7 @@ func hasIntersectionPointWithMultiPoint(point Point, mp MultiPoint) (intersects 
 
 func hasIntersectionPointWithPoint(pt1, pt2 Point) (intersects bool, dimension int, err error) {
 	// Speed is O(1).
-	if pt1.Equals(pt2) {
+	if pt1.EqualsExact(pt2) {
 		return true, 0, nil // Point has dimension 0
 	}
 	return false, 0, nil // No intersection

--- a/geom/alg_intersection_test.go
+++ b/geom/alg_intersection_test.go
@@ -158,7 +158,10 @@ func TestIntersection(t *testing.T) {
 			}
 
 			t.Run("forward", func(t *testing.T) {
-				got := in1g.Intersection(in2g)
+				got, err := in1g.Intersection(in2g)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in1, tt.in2, tt.out, got.AsText())
 				}
@@ -176,7 +179,10 @@ func TestIntersection(t *testing.T) {
 				return
 			}
 			t.Run("reversed", func(t *testing.T) {
-				got := in2g.Intersection(in1g)
+				got, err := in2g.Intersection(in1g)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in2, tt.in1, tt.out, got.AsText())
 				}

--- a/geom/alg_intersection_test.go
+++ b/geom/alg_intersection_test.go
@@ -165,7 +165,10 @@ func TestIntersection(t *testing.T) {
 				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in1, tt.in2, tt.out, got.AsText())
 				}
-				intersects := in1g.Intersects(in2g)
+				intersects, err := in1g.Intersects(in2g)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if intersects == got.IsEmpty() {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v\nintersects: %v", tt.in1, tt.in2, tt.out, got, intersects)
 				}
@@ -186,7 +189,10 @@ func TestIntersection(t *testing.T) {
 				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in2, tt.in1, tt.out, got.AsText())
 				}
-				intersects := in2g.Intersects(in1g)
+				intersects, err := in2g.Intersects(in1g)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if intersects == got.IsEmpty() {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v\nintersects: %v", tt.in1, tt.in2, tt.out, got, intersects)
 				}

--- a/geom/alg_point_in_ring.go
+++ b/geom/alg_point_in_ring.go
@@ -19,7 +19,7 @@ func pointRingSide(pt XY, ring LineString) side {
 	maxX := ring.lines[0].a.X
 	for _, ln := range ring.lines {
 		maxX = math.Max(maxX, ln.b.X)
-		if !ln.Intersection(ptg).IsEmpty() {
+		if !mustIntersection(ln, ptg).IsEmpty() {
 			return boundary
 		}
 	}
@@ -30,7 +30,7 @@ func pointRingSide(pt XY, ring LineString) side {
 	ray := must(NewLineC(Coordinates{pt}, Coordinates{XY{maxX + 1, pt.Y}})).(Line)
 	var count int
 	for _, seg := range ring.lines {
-		inter := seg.Intersection(ray)
+		inter := mustIntersection(seg, ray)
 		if inter.IsEmpty() {
 			continue
 		}

--- a/geom/alg_point_in_ring.go
+++ b/geom/alg_point_in_ring.go
@@ -39,9 +39,9 @@ func pointRingSide(pt XY, ring LineString) side {
 		}
 		ep1 := NewPointC(seg.a)
 		ep2 := NewPointC(seg.b)
-		if inter.Equals(ep1) || inter.Equals(ep2) {
+		if inter.EqualsExact(ep1) || inter.EqualsExact(ep2) {
 			otherY := ep1.coords.Y
-			if inter.Equals(ep1) {
+			if inter.EqualsExact(ep1) {
 				otherY = ep2.coords.Y
 			}
 			if otherY < pt.Y {

--- a/geom/type_empty.go
+++ b/geom/type_empty.go
@@ -56,7 +56,7 @@ func (e EmptySet) Dimension() int {
 	return e.dimension
 }
 
-func (e EmptySet) Equals(other Geometry) bool {
+func (e EmptySet) Equals(other Geometry) (bool, error) {
 	return equals(e, other)
 }
 

--- a/geom/type_empty.go
+++ b/geom/type_empty.go
@@ -43,9 +43,9 @@ func (e EmptySet) Intersection(g Geometry) (Geometry, error) {
 	return intersection(e, g)
 }
 
-func (e EmptySet) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(e, g)
-	return has
+func (e EmptySet) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(e, g)
+	return has, err
 }
 
 func (e EmptySet) IsEmpty() bool {

--- a/geom/type_empty.go
+++ b/geom/type_empty.go
@@ -39,7 +39,7 @@ func (e EmptySet) IsSimple() bool {
 	return true
 }
 
-func (e EmptySet) Intersection(g Geometry) Geometry {
+func (e EmptySet) Intersection(g Geometry) (Geometry, error) {
 	return intersection(e, g)
 }
 

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -28,7 +28,10 @@ type Geometry interface {
 
 	// Intersects returns true if the intersection of this gemoetry with the
 	// specified other geometry is not empty, or false if it is empty.
-	Intersects(Geometry) bool
+	//
+	// It is not implemented for all possible pairs of geometries, and returns
+	// an error in those cases.
+	Intersects(Geometry) (bool, error)
 
 	// IsEmpty returns true if this object an empty geometry.
 	IsEmpty() bool

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -21,7 +21,10 @@ type Geometry interface {
 
 	// Intersection returns a geometric object that represents the point set
 	// intersection of this geometry with another geometry.
-	Intersection(Geometry) Geometry
+	//
+	// It is not implemented for all possible pairs of geometries, and returns
+	// an error in those cases.
+	Intersection(Geometry) (Geometry, error)
 
 	// Intersects returns true if the intersection of this gemoetry with the
 	// specified other geometry is not empty, or false if it is empty.

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -46,9 +46,12 @@ type Geometry interface {
 	// in which case the returned flag will be false.
 	Envelope() (Envelope, bool)
 
-	// Equals checks if this geometry is equal to another geometrie. Two
+	// Equals checks if this geometry is equal to another geometry. Two
 	// geometries are equal if they contain exactly the same points.
-	Equals(Geometry) bool
+	//
+	// It is not implemented for all possible pairs of geometries, and returns
+	// an error in those cases.
+	Equals(Geometry) (bool, error)
 
 	// Boundary returns the Geometry representing the limit of this geometry.
 	Boundary() Geometry

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -82,7 +82,7 @@ func (c GeometryCollection) Dimension() int {
 	return dim
 }
 
-func (c GeometryCollection) Equals(other Geometry) bool {
+func (c GeometryCollection) Equals(other Geometry) (bool, error) {
 	return equals(c, other)
 }
 

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -60,9 +60,9 @@ func (c GeometryCollection) Intersection(g Geometry) (Geometry, error) {
 	return intersection(c, g)
 }
 
-func (c GeometryCollection) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(c, g)
-	return has
+func (c GeometryCollection) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(c, g)
+	return has, err
 }
 
 func (c GeometryCollection) IsEmpty() bool {

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -56,7 +56,7 @@ func (c GeometryCollection) AppendWKT(dst []byte) []byte {
 	return append(dst, ')')
 }
 
-func (c GeometryCollection) Intersection(g Geometry) Geometry {
+func (c GeometryCollection) Intersection(g Geometry) (Geometry, error) {
 	return intersection(c, g)
 }
 

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -75,9 +75,9 @@ func (n Line) Intersection(g Geometry) (Geometry, error) {
 	return intersection(n, g)
 }
 
-func (n Line) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(n, g)
-	return has
+func (n Line) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(n, g)
+	return has, err
 }
 
 func (n Line) IsEmpty() bool {

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -71,7 +71,7 @@ func (n Line) IsSimple() bool {
 	return true
 }
 
-func (n Line) Intersection(g Geometry) Geometry {
+func (n Line) Intersection(g Geometry) (Geometry, error) {
 	return intersection(n, g)
 }
 

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -88,7 +88,7 @@ func (n Line) Dimension() int {
 	return 1
 }
 
-func (n Line) Equals(other Geometry) bool {
+func (n Line) Equals(other Geometry) (bool, error) {
 	return equals(n, other)
 }
 

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -83,7 +83,7 @@ func (s LineString) appendWKTBody(dst []byte) []byte {
 
 // IsSimple returns true iff the curve defined by the LineString doesn't pass
 // through the same point twice (with the possible exception of the two
-// endpoints).
+// endpoints being coincident).
 func (s LineString) IsSimple() bool {
 	// 1. Check for pairwise intersection.
 	//  a. Point is allowed if lines adjacent.
@@ -112,7 +112,7 @@ func (s LineString) IsSimple() bool {
 				// ring).
 				aPt := NewPointC(s.lines[i].a)
 				bPt := NewPointC(s.lines[j].b)
-				if !intersection.Equals(aPt) || !intersection.Equals(bPt) {
+				if !intersection.EqualsExact(aPt) || !intersection.EqualsExact(bPt) {
 					return false
 				}
 			} else {
@@ -146,7 +146,7 @@ func (s LineString) Dimension() int {
 	return 1
 }
 
-func (s LineString) Equals(other Geometry) bool {
+func (s LineString) Equals(other Geometry) (bool, error) {
 	return equals(s, other)
 }
 

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -133,9 +133,9 @@ func (s LineString) Intersection(g Geometry) (Geometry, error) {
 	return intersection(s, g)
 }
 
-func (s LineString) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(s, g)
-	return has
+func (s LineString) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(s, g)
+	return has, err
 }
 
 func (s LineString) IsEmpty() bool {

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -91,7 +91,7 @@ func (s LineString) IsSimple() bool {
 	n := len(s.lines)
 	for i := 0; i < n; i++ {
 		for j := i + 1; j < n; j++ {
-			intersection := s.lines[i].Intersection(s.lines[j])
+			intersection := mustIntersection(s.lines[i], s.lines[j])
 			if intersection.IsEmpty() {
 				continue
 			}
@@ -129,7 +129,7 @@ func (s LineString) IsClosed() bool {
 	return s.lines[0].a.XY.Equals(s.lines[len(s.lines)-1].b.XY)
 }
 
-func (s LineString) Intersection(g Geometry) Geometry {
+func (s LineString) Intersection(g Geometry) (Geometry, error) {
 	return intersection(s, g)
 }
 

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -84,7 +84,11 @@ func (m MultiLineString) IsSimple() bool {
 		for j := i + 1; j < len(m.lines); j++ {
 			inter := mustIntersection(m.lines[i], m.lines[j])
 			bound := mustIntersection(m.lines[i].Boundary(), m.lines[j].Boundary())
-			if !inter.Equals(mustIntersection(inter, bound)) {
+			eq, err := inter.Equals(mustIntersection(inter, bound))
+			if err != nil {
+				panic(err) // Equals is implemented for all of the required types here.
+			}
+			if !eq {
 				return false
 			}
 		}
@@ -109,7 +113,7 @@ func (m MultiLineString) Dimension() int {
 	return 1
 }
 
-func (m MultiLineString) Equals(other Geometry) bool {
+func (m MultiLineString) Equals(other Geometry) (bool, error) {
 	return equals(m, other)
 }
 

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -82,9 +82,9 @@ func (m MultiLineString) IsSimple() bool {
 	}
 	for i := 0; i < len(m.lines); i++ {
 		for j := i + 1; j < len(m.lines); j++ {
-			inter := m.lines[i].Intersection(m.lines[j])
-			bound := m.lines[i].Boundary().Intersection(m.lines[j].Boundary())
-			if !inter.Equals(inter.Intersection(bound)) {
+			inter := mustIntersection(m.lines[i], m.lines[j])
+			bound := mustIntersection(m.lines[i].Boundary(), m.lines[j].Boundary())
+			if !inter.Equals(mustIntersection(inter, bound)) {
 				return false
 			}
 		}
@@ -92,7 +92,7 @@ func (m MultiLineString) IsSimple() bool {
 	return true
 }
 
-func (m MultiLineString) Intersection(g Geometry) Geometry {
+func (m MultiLineString) Intersection(g Geometry) (Geometry, error) {
 	return intersection(m, g)
 }
 

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -96,9 +96,9 @@ func (m MultiLineString) Intersection(g Geometry) (Geometry, error) {
 	return intersection(m, g)
 }
 
-func (m MultiLineString) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(m, g)
-	return has
+func (m MultiLineString) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(m, g)
+	return has, err
 }
 
 func (m MultiLineString) IsEmpty() bool {

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -84,7 +84,7 @@ func (m MultiPoint) IsSimple() bool {
 	return true
 }
 
-func (m MultiPoint) Intersection(g Geometry) Geometry {
+func (m MultiPoint) Intersection(g Geometry) (Geometry, error) {
 	return intersection(m, g)
 }
 

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -101,7 +101,7 @@ func (m MultiPoint) Dimension() int {
 	return 0
 }
 
-func (m MultiPoint) Equals(other Geometry) bool {
+func (m MultiPoint) Equals(other Geometry) (bool, error) {
 	return equals(m, other)
 }
 

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -88,9 +88,9 @@ func (m MultiPoint) Intersection(g Geometry) (Geometry, error) {
 	return intersection(m, g)
 }
 
-func (m MultiPoint) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(m, g)
-	return has
+func (m MultiPoint) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(m, g)
+	return has, err
 }
 
 func (m MultiPoint) IsEmpty() bool {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -30,7 +30,7 @@ func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, 
 		for j := i + 1; j < len(polys); j++ {
 			bound1 := polys[i].Boundary()
 			bound2 := polys[j].Boundary()
-			inter := bound1.Intersection(bound2)
+			inter := mustIntersection(bound1, bound2)
 			if inter.Dimension() > 0 {
 				return MultiPolygon{}, errors.New("the boundaries of the polygon elements of multipolygons must only intersect at points")
 			}
@@ -63,7 +63,7 @@ func polyInteriorsIntersect(p1, p2 Polygon) bool {
 				linePts[line1.b.XY] = struct{}{}
 				for _, r2 := range p2.rings() {
 					for _, line2 := range r2.lines {
-						env, ok := line1.Intersection(line2).Envelope()
+						env, ok := mustIntersection(line1, line2).Envelope()
 						if !ok {
 							continue
 						}
@@ -182,7 +182,7 @@ func (m MultiPolygon) Intersects(g Geometry) bool {
 	return has
 }
 
-func (m MultiPolygon) Intersection(g Geometry) Geometry {
+func (m MultiPolygon) Intersection(g Geometry) (Geometry, error) {
 	return intersection(m, g)
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -194,7 +194,7 @@ func (m MultiPolygon) Dimension() int {
 	return 2
 }
 
-func (m MultiPolygon) Equals(other Geometry) bool {
+func (m MultiPolygon) Equals(other Geometry) (bool, error) {
 	return equals(m, other)
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -177,9 +177,9 @@ func (m MultiPolygon) IsSimple() bool {
 	return true
 }
 
-func (m MultiPolygon) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(m, g)
-	return has
+func (m MultiPolygon) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(m, g)
+	return has, err
 }
 
 func (m MultiPolygon) Intersection(g Geometry) (Geometry, error) {

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -60,7 +60,7 @@ func (p Point) IsSimple() bool {
 	return true
 }
 
-func (p Point) Intersection(g Geometry) Geometry {
+func (p Point) Intersection(g Geometry) (Geometry, error) {
 	return intersection(p, g)
 }
 

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -77,7 +77,7 @@ func (p Point) Dimension() int {
 	return 0
 }
 
-func (p Point) Equals(other Geometry) bool {
+func (p Point) Equals(other Geometry) (bool, error) {
 	return equals(p, other)
 }
 

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -64,9 +64,9 @@ func (p Point) Intersection(g Geometry) (Geometry, error) {
 	return intersection(p, g)
 }
 
-func (p Point) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(p, g)
-	return has
+func (p Point) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(p, g)
+	return has, err
 }
 
 func (p Point) IsEmpty() bool {

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -153,9 +153,9 @@ func (p Polygon) Intersection(g Geometry) (Geometry, error) {
 	return intersection(p, g)
 }
 
-func (p Polygon) Intersects(g Geometry) bool {
-	has, _ := hasIntersection(p, g)
-	return has
+func (p Polygon) Intersects(g Geometry) (bool, error) {
+	has, _, err := hasIntersection(p, g)
+	return has, err
 }
 
 func (p Polygon) IsEmpty() bool {

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -166,7 +166,7 @@ func (p Polygon) Dimension() int {
 	return 2
 }
 
-func (p Polygon) Equals(other Geometry) bool {
+func (p Polygon) Equals(other Geometry) (bool, error) {
 	return equals(p, other)
 }
 

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -49,7 +49,7 @@ func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption)
 	// Rings may intersect, but only at a single point.
 	for i := 0; i < len(allRings); i++ {
 		for j := i + 1; j < len(allRings); j++ {
-			inter := allRings[i].Intersection(allRings[j])
+			inter := mustIntersection(allRings[i], allRings[j])
 			env, has := inter.Envelope()
 			if !has {
 				continue // no intersection
@@ -149,7 +149,7 @@ func (p Polygon) IsSimple() bool {
 	return true
 }
 
-func (p Polygon) Intersection(g Geometry) Geometry {
+func (p Polygon) Intersection(g Geometry) (Geometry, error) {
 	return intersection(p, g)
 }
 


### PR DESCRIPTION
Rather than panicking, the `Equals`, `Intersection`, and `Intersects` methods now return errors if the algorithm for the input pair hasn't been implemented yet.