### PR TITLE
Add fuzz tests for EqualsExact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 script:
-  - docker-compose up --abort-on-container-exit
+  - docker-compose up -f docker-compose-full.yml --abort-on-container-exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 script:
-  - docker-compose up -f docker-compose-full.yml --abort-on-container-exit
+  - docker-compose -f docker-compose-full.yml up --abort-on-container-exit

--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ locally, it's easier to run the tests using docker-compose:
 ```
 docker-compose up --abort-on-container-exit
 ```
+
+There is also an additional suite of tests utilising an automatically generated
+test corpus. This test suite tests every function against every input
+combination exhaustively, and compares the result against PostGIS.  These take
+much longer to run, and are designed to be used as a final double check for
+correctness. They can be run using:
+
+```
+docker-compose -f docker-compose-all.yml up --abort-on-container-exit
+```

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -10,7 +10,7 @@ services:
   tests:
     image: golang:1
     working_dir: /go/src/github.com/peterstace/simplefeatures
-    entrypoint: go test -v -test.count=1 -test.run=. ./geom
+    entrypoint: go test -test.count=1 -test.run=. ./...
     volumes:
       - .:/go/src/github.com/peterstace/simplefeatures
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   tests:
     image: golang:1
     working_dir: /go/src/github.com/peterstace/simplefeatures
-    entrypoint: go test -v -test.count=1 -test.run=. ./...
+    entrypoint: go test -test.count=1 -test.run=. ./...
     volumes:
       - .:/go/src/github.com/peterstace/simplefeatures
     environment:

--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -336,3 +336,15 @@ func CheckIsRing(t *testing.T, pg PostGIS, g geom.Geometry) {
 		}
 	})
 }
+
+func CheckEqualsExact(t *testing.T, pg PostGIS, g1, g2 geom.Geometry) {
+	t.Run("CheckEqualsExact", func(t *testing.T) {
+		got := g1.EqualsExact(g2)
+		want := pg.OrderingEquals(t, g1, g2)
+		if got != want {
+			t.Logf("got:  %t", got)
+			t.Logf("want: %t", want)
+			t.Error("mismatch")
+		}
+	})
+}

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -47,6 +47,13 @@ func TestFuzz(t *testing.T) {
 			CheckIsRing(t, pg, g)
 		})
 	}
+	for i, g1 := range geoms {
+		for j, g2 := range geoms {
+			t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
+				CheckEqualsExact(t, pg, g1, g2)
+			})
+		}
+	}
 
 	// TODO: Intersection
 	// TODO: Equals

--- a/geom/alg_equals_exact_test.go
+++ b/geom/alg_equals_exact_test.go
@@ -104,6 +104,10 @@ func TestEqualsExact(t *testing.T) {
 		"g_2_b":   "GEOMETRYCOLLECTION(LINESTRING(1 2,3 4),POINT(1 3))",
 		"g_2_c":   "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(1 5),LINESTRING(1 2,3 4)))",
 		"g_2_d":   "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(LINESTRING(1 2,3 4),POINT(1 5)))",
+
+		// Reproduces bugs from fuzz tests:
+		"b_1": "LINESTRING(0 0,1 1)",
+		"b_2": "MULTIPOINT(0 0,1 1)",
 	}
 
 	type pair struct{ keyA, keyB string }

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -149,7 +149,7 @@ func (n Line) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, 
 // EqualsExact checks if this Line is exactly equal to another curve.
 func (n Line) EqualsExact(other Geometry, opts ...EqualsExactOption) bool {
 	c, ok := other.(curve)
-	return ok && curvesExactEqual(n, c, opts)
+	return ok && other.Dimension() == 1 && curvesExactEqual(n, c, opts)
 }
 
 // IsValid checks if this Line is valid

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -223,7 +223,7 @@ func (s LineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geom
 // EqualsExact checks if this LineString is exactly equal to another curve.
 func (s LineString) EqualsExact(other Geometry, opts ...EqualsExactOption) bool {
 	c, ok := other.(curve)
-	return ok && curvesExactEqual(s, c, opts)
+	return ok && other.Dimension() == 1 && curvesExactEqual(s, c, opts)
 }
 
 // IsValid checks if this LineString is valid


### PR DESCRIPTION
Also fixes a bug in EqualsExact where multipoints were erroneously allowed to be equal to linestrings.