### PR TITLE
Sweep linestring intersection

### DIFF
--- a/geom/alg_intersects_test.go
+++ b/geom/alg_intersects_test.go
@@ -162,6 +162,7 @@ func TestIntersects(t *testing.T) {
 		{"LINESTRING(0 0,1 0,0 1,0 0)", "LINESTRING(1 0,1 1,0 1,1 0)", true},
 		{"LINESTRING(0 0,1 0,1 1,0 1,0 0)", "LINESTRING(0.5 0.5,1.5 0.5,1.5 1.5,0.5 1.5,0.5 0.5)", true},
 		{"LINESTRING(0 0,1 0,1 1,0 1,0 0)", "LINESTRING(1 0,2 0,2 1,1 1,1.5 0.5,1 0.5,1 0)", true},
+		{"LINESTRING(-1 1,1 -1)", "LINESTRING(0 0,2 0,2 2,0 2,0 0)", true},
 
 		// LineString/Polygon
 		{"LINESTRING(3 0,3 1,3 2)", "POLYGON((0 0,2 0,2 2,0 2,0 0))", false},

--- a/geom/alg_intersects_test.go
+++ b/geom/alg_intersects_test.go
@@ -297,3 +297,29 @@ func TestIntersects(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkIntersectsLineStringWithLineString(b *testing.B) {
+	const sz = 1000
+	xys1 := make([]geom.XY, sz)
+	xys2 := make([]geom.XY, sz)
+	for i := 0; i < sz; i++ {
+		x := float64(i) / float64(sz)
+		xys1[i] = geom.XY{X: x, Y: 1}
+		xys2[i] = geom.XY{X: x, Y: 2}
+	}
+	ls1, err := geom.NewLineStringXY(xys1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ls2, err := geom.NewLineStringXY(xys2)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if ls1.Intersects(ls2) {
+			b.Fatal("should not intersect")
+		}
+	}
+}

--- a/geom/alg_intersects_test.go
+++ b/geom/alg_intersects_test.go
@@ -1,6 +1,7 @@
 package geom_test
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -300,27 +301,30 @@ func TestIntersects(t *testing.T) {
 }
 
 func BenchmarkIntersectsLineStringWithLineString(b *testing.B) {
-	const sz = 1000
-	xys1 := make([]geom.XY, sz)
-	xys2 := make([]geom.XY, sz)
-	for i := 0; i < sz; i++ {
-		x := float64(i) / float64(sz)
-		xys1[i] = geom.XY{X: x, Y: 1}
-		xys2[i] = geom.XY{X: x, Y: 2}
-	}
-	ls1, err := geom.NewLineStringXY(xys1)
-	if err != nil {
-		b.Fatal(err)
-	}
-	ls2, err := geom.NewLineStringXY(xys2)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+			xys1 := make([]geom.XY, sz)
+			xys2 := make([]geom.XY, sz)
+			for i := 0; i < sz; i++ {
+				x := float64(i) / float64(sz)
+				xys1[i] = geom.XY{X: x, Y: 1}
+				xys2[i] = geom.XY{X: x, Y: 2}
+			}
+			ls1, err := geom.NewLineStringXY(xys1)
+			if err != nil {
+				b.Fatal(err)
+			}
+			ls2, err := geom.NewLineStringXY(xys2)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		if ls1.Intersects(ls2) {
-			b.Fatal("should not intersect")
-		}
+			for i := 0; i < b.N; i++ {
+				if ls1.Intersects(ls2) {
+					b.Fatal("should not intersect")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Benchmark change:

```
benchmark                                               old ns/op      new ns/op     delta
BenchmarkIntersectsLineStringWithLineString/n=10        1051           7877          +649.48%
BenchmarkIntersectsLineStringWithLineString/n=100       108504         88597         -18.35%
BenchmarkIntersectsLineStringWithLineString/n=1000      12071435       937373        -92.23%
BenchmarkIntersectsLineStringWithLineString/n=10000     1103327828     11241364      -98.98%
```

The breakeven-point seems to be around n=~100. However, that would only apply to the particular input case from the benchmark. The main thing that the benchmark confirms is that the complexity class has improved. 