### PR TITLE
MultiLineString/MultiLineString intersects performance improvements

### DIFF
--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -233,11 +233,8 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		newSegments []Line
 	}
 	var sides [2]*side
-	less := func(a, b Line) bool {
-		return a.EndPoint().XY().X < b.EndPoint().XY().X
-	}
-	sides[0] = &side{mls: mls1, active: lineHeap{less: less}}
-	sides[1] = &side{mls: mls2, active: lineHeap{less: less}}
+	sides[0] = &side{mls: mls1}
+	sides[1] = &side{mls: mls2}
 
 	// Create a list of line segments from each MultiLineString, in ascending
 	// order by X coordinate.
@@ -277,7 +274,7 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		// segments that can no longer possibly intersect with any unprocessed
 		// line segments, and adding any new line segments to the active sets.
 		for _, side := range sides {
-			for !side.active.empty() && side.active.peek().EndPoint().XY().X < sweepX {
+			for len(side.active) != 0 && side.active[0].EndPoint().XY().X < sweepX {
 				side.active.pop()
 			}
 			side.newSegments = side.newSegments[:0]
@@ -293,7 +290,7 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		for i, side := range sides {
 			other := sides[1-i]
 			for _, checkLine := range side.newSegments {
-				for _, ln := range other.active.data {
+				for _, ln := range other.active {
 					if hasIntersectionLineWithLine(ln, checkLine) {
 						return true
 					}

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -1,7 +1,6 @@
 package geom
 
 import (
-	"container/heap"
 	"fmt"
 	"math"
 	"sort"
@@ -218,26 +217,6 @@ func hasIntersectionMultiPointWithMultiLineString(mp MultiPoint, mls MultiLineSt
 	return false
 }
 
-type lineHeap []Line
-
-func (h *lineHeap) Push(x interface{}) {
-	*h = append(*h, x.(Line))
-}
-func (h *lineHeap) Pop() interface{} {
-	e := (*h)[len(*h)-1]
-	*h = (*h)[:len(*h)-1]
-	return e
-}
-func (h *lineHeap) Len() int {
-	return len(*h)
-}
-func (h *lineHeap) Less(i, j int) bool {
-	return (*h)[i].EndPoint().XY().X < (*h)[j].EndPoint().XY().X
-}
-func (h *lineHeap) Swap(i, j int) {
-	(*h)[i], (*h)[j] = (*h)[j], (*h)[i]
-}
-
 func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) bool {
 	// A Sweep-Line-Algorithm approach is used to reduce the number of raw line
 	// segment intersection tests that must be performed. A vertical sweep line
@@ -254,12 +233,20 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		newSegments []Line
 	}
 	var sides [2]*side
-	sides[0] = &side{mls: mls1}
-	sides[1] = &side{mls: mls2}
+	less := func(a, b Line) bool {
+		return a.EndPoint().XY().X < b.EndPoint().XY().X
+	}
+	sides[0] = &side{mls: mls1, active: lineHeap{less: less}}
+	sides[1] = &side{mls: mls2, active: lineHeap{less: less}}
 
 	// Create a list of line segments from each MultiLineString, in ascending
 	// order by X coordinate.
 	for _, side := range sides {
+		var n int
+		for _, ls := range side.mls.lines {
+			n += ls.NumPoints() - 1
+		}
+		side.unprocessed = make([]Line, 0, n)
 		for _, ls := range side.mls.lines {
 			for _, ln := range ls.lines {
 				if ln.StartPoint().XY().X > ln.EndPoint().XY().X {
@@ -290,13 +277,13 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		// segments that can no longer possibly intersect with any unprocessed
 		// line segments, and adding any new line segments to the active sets.
 		for _, side := range sides {
-			for len(side.active) > 0 && side.active[0].EndPoint().XY().X < sweepX {
-				heap.Pop(&side.active)
+			for !side.active.empty() && side.active.peek().EndPoint().XY().X < sweepX {
+				side.active.pop()
 			}
 			side.newSegments = side.newSegments[:0]
 			for len(side.unprocessed) > 0 && side.unprocessed[0].StartPoint().XY().X == sweepX {
 				side.newSegments = append(side.newSegments, side.unprocessed[0])
-				heap.Push(&side.active, side.unprocessed[0])
+				side.active.push(side.unprocessed[0])
 				side.unprocessed = side.unprocessed[1:]
 			}
 		}
@@ -306,8 +293,8 @@ func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineStrin
 		for i, side := range sides {
 			other := sides[1-i]
 			for _, checkLine := range side.newSegments {
-				for _, ln := range other.active {
-					if ln.Intersects(checkLine) {
+				for _, ln := range other.active.data {
+					if hasIntersectionLineWithLine(ln, checkLine) {
 						return true
 					}
 				}

--- a/geom/line_heap.go
+++ b/geom/line_heap.go
@@ -1,0 +1,62 @@
+package geom
+
+type lineHeap struct {
+	less func(a, b Line) bool
+	data []Line
+}
+
+func (h *lineHeap) peek() Line {
+	return h.data[0]
+}
+
+func (h *lineHeap) empty() bool {
+	return len(h.data) == 0
+}
+
+func (h *lineHeap) push(ln Line) {
+	h.data = append(h.data, ln)
+	i := len(h.data) - 1
+	for i > 0 {
+		parent := (i - 1) / 2
+		if h.lt(parent, i) {
+			break
+		}
+		h.data[parent], h.data[i] = h.data[i], h.data[parent]
+		i = parent
+	}
+}
+
+func (h *lineHeap) pop() {
+	h.data[0] = h.data[len(h.data)-1]
+	h.data = h.data[:len(h.data)-1]
+	i := 0
+	for {
+		swapWith := -1
+		childA := 2*i + 1
+		childB := 2*i + 2
+		switch {
+		case childA < len(h.data) && childB < len(h.data):
+			swapWith = childA
+			if h.lt(childB, childA) {
+				swapWith = childB
+			}
+		case childA < len(h.data):
+			if h.lt(childA, i) {
+				swapWith = childA
+			}
+		case childB < len(h.data):
+			if h.lt(childB, i) {
+				swapWith = childB
+			}
+		}
+		if swapWith == -1 {
+			break
+		}
+		h.data[swapWith], h.data[i] = h.data[i], h.data[swapWith]
+		i = swapWith
+	}
+}
+
+func (h *lineHeap) lt(i, j int) bool {
+	return h.less(h.data[i], h.data[j])
+}

--- a/geom/line_heap.go
+++ b/geom/line_heap.go
@@ -31,9 +31,15 @@ func (h *lineHeap) pop() {
 		childB := 2*i + 2
 		switch {
 		case childA < len((*h)) && childB < len((*h)):
-			swapWith = childA
-			if h.less(childB, childA) {
-				swapWith = childB
+			if h.less(i, childA) {
+				if h.less(childB, i) {
+					swapWith = childB
+				}
+			} else {
+				swapWith = childA
+				if h.less(childB, childA) {
+					swapWith = childB
+				}
 			}
 		case childA < len((*h)):
 			if h.less(childA, i) {

--- a/geom/line_heap.go
+++ b/geom/line_heap.go
@@ -1,62 +1,59 @@
 package geom
 
-type lineHeap struct {
-	less func(a, b Line) bool
-	data []Line
-}
-
-func (h *lineHeap) peek() Line {
-	return h.data[0]
-}
-
-func (h *lineHeap) empty() bool {
-	return len(h.data) == 0
-}
+// lineHeap is a binary heap data structure that contains Lines. The advantage
+// of this implementation of a heap over the the standard container/heap
+// package is that it doesn't use interface{} (and therefore doesn't allocate
+// memory on each heap operation). The obvious disadvantage is that it is a
+// non-trivial implementation of something that already exists. The trade off
+// is worth it because the heap is used within tight loops.
+type lineHeap []Line
 
 func (h *lineHeap) push(ln Line) {
-	h.data = append(h.data, ln)
-	i := len(h.data) - 1
+	*h = append(*h, ln)
+	i := len(*h) - 1
 	for i > 0 {
 		parent := (i - 1) / 2
-		if h.lt(parent, i) {
+		if h.less(parent, i) {
 			break
 		}
-		h.data[parent], h.data[i] = h.data[i], h.data[parent]
+		(*h)[parent], (*h)[i] = (*h)[i], (*h)[parent]
 		i = parent
 	}
 }
 
 func (h *lineHeap) pop() {
-	h.data[0] = h.data[len(h.data)-1]
-	h.data = h.data[:len(h.data)-1]
+	(*h)[0] = (*h)[len((*h))-1]
+	(*h) = (*h)[:len((*h))-1]
 	i := 0
 	for {
 		swapWith := -1
 		childA := 2*i + 1
 		childB := 2*i + 2
 		switch {
-		case childA < len(h.data) && childB < len(h.data):
+		case childA < len((*h)) && childB < len((*h)):
 			swapWith = childA
-			if h.lt(childB, childA) {
+			if h.less(childB, childA) {
 				swapWith = childB
 			}
-		case childA < len(h.data):
-			if h.lt(childA, i) {
+		case childA < len((*h)):
+			if h.less(childA, i) {
 				swapWith = childA
 			}
-		case childB < len(h.data):
-			if h.lt(childB, i) {
+		case childB < len((*h)):
+			if h.less(childB, i) {
 				swapWith = childB
 			}
 		}
 		if swapWith == -1 {
 			break
 		}
-		h.data[swapWith], h.data[i] = h.data[i], h.data[swapWith]
+		(*h)[swapWith], (*h)[i] = (*h)[i], (*h)[swapWith]
 		i = swapWith
 	}
 }
 
-func (h *lineHeap) lt(i, j int) bool {
-	return h.less(h.data[i], h.data[j])
+func (h *lineHeap) less(i, j int) bool {
+	// If the lineHeap needs to be used in more than one place with a different
+	// less function, then this will need to be made generic.
+	return (*h)[i].EndPoint().XY().X < (*h)[j].EndPoint().XY().X
 }

--- a/geom/line_heap_test.go
+++ b/geom/line_heap_test.go
@@ -1,0 +1,74 @@
+package geom
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestLineHeap(t *testing.T) {
+	var heap lineHeap
+
+	seed := int64(1577816310618750611)
+	rnd := rand.New(rand.NewSource(seed))
+	t.Logf("seed %v", seed)
+
+	check := func() {
+		for i := range heap {
+			childA := 2*i + 1
+			childB := 2*i + 2
+			le := func(i, j int) bool {
+				return heap[i].EndPoint().XY().X <= heap[j].EndPoint().XY().X
+			}
+			if childA < len(heap) {
+				if !le(i, childA) {
+					t.Fatal("heap invariant doesn't hold")
+				}
+			}
+			if childB < len(heap) {
+				if !le(i, childB) {
+					t.Fatal("heap invariant doesn't hold")
+				}
+			}
+		}
+	}
+	push := func() {
+		ln, err := NewLineXY(
+			XY{
+				X: math.Round(10 + 90*rnd.Float64()),
+				Y: math.Round(10 + 90*rnd.Float64()),
+			},
+			XY{
+				X: math.Round(10 + 90*rnd.Float64()),
+				Y: math.Round(10 + 90*rnd.Float64()),
+			},
+		)
+		if err != nil {
+			t.Fatalf("could not make line: %v", err)
+		}
+		heap.push(ln)
+	}
+	pop := func() {
+		heap.pop()
+	}
+
+	const n = 100
+
+	for i := 0; i < n; i++ {
+		push()
+		check()
+		push()
+		check()
+		pop()
+		check()
+	}
+
+	for i := 0; i < n; i++ {
+		pop()
+		check()
+	}
+
+	if len(heap) != 0 {
+		t.Fatalf("not empty: %d", len(heap))
+	}
+}


### PR DESCRIPTION
There were two main places where memory was being allocated:

1. In the `a.Intersects(b)` call, where both `a` and `b` where `Line`s. Because both `a` and `b` get stored inside a `Geometry` interface, they get allocated to the heap rather than the stack.
2. In each stack push/pop operation, a `Line` gets stored as an `interface{}` which causes it to get stored on the heap rather than the stack.

I solved 1 by calling `intersectsLineWithLine` directly.

I solved 2 by implementing a custom heap operation which doesn't use `interface{}`.

Performance deltas are:

```
benchmark                                               old ns/op     new ns/op     delta
BenchmarkIntersectsLineStringWithLineString/n=10        7504          2186          -70.87%
BenchmarkIntersectsLineStringWithLineString/n=100       84679         21512         -74.60%
BenchmarkIntersectsLineStringWithLineString/n=1000      898498        267713        -70.20%
BenchmarkIntersectsLineStringWithLineString/n=10000     11004875      3144332       -71.43%

benchmark                                               old allocs     new allocs     delta
BenchmarkIntersectsLineStringWithLineString/n=10        128            18             -85.94%
BenchmarkIntersectsLineStringWithLineString/n=100       1214           18             -98.52%
BenchmarkIntersectsLineStringWithLineString/n=1000      12020          18             -99.85%
BenchmarkIntersectsLineStringWithLineString/n=10000     120040         18             -99.99%

benchmark                                               old bytes     new bytes     delta
BenchmarkIntersectsLineStringWithLineString/n=10        5984          1184          -80.21%
BenchmarkIntersectsLineStringWithLineString/n=100       54880         7008          -87.23%
BenchmarkIntersectsLineStringWithLineString/n=1000      515168        66144         -87.16%
BenchmarkIntersectsLineStringWithLineString/n=10000     7362656       655968        -91.09%
```

- Throughput operation speed has been reduced by ~70% (~3x speedup). This reduction would be due to decrease in memory management overhead (allocations and GC).
- The _number_ of allocations is now constant rather than linear.
- The _total amount_ allocated is still linear (although has a much smaller constant factor).