### PR TITLE
Use Linesweep for Linestring IsSimple

### DIFF
--- a/geom/util.go
+++ b/geom/util.go
@@ -9,6 +9,13 @@ func max(a, b int) int {
 	return b
 }
 
+func abs(i int) int {
+	if i < 0 {
+		return -i
+	}
+	return i
+}
+
 func rank(g Geometry) int {
 	switch g.tag {
 	case emptySetTag:

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -2,6 +2,7 @@ package geom_test
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -160,6 +161,28 @@ func TestMultiPolygonValidation(t *testing.T) {
 			_, err := UnmarshalWKT(strings.NewReader(wkt))
 			if err == nil {
 				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func BenchmarkPolygonSingleRingValidation(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+			coords := [][]Coordinates{{}}
+			coords[0] = make([]Coordinates, sz+1)
+			for i := 0; i < sz; i++ {
+				angle := float64(i) / float64(sz) * 2 * math.Pi
+				coords[0][i].X = math.Cos(angle)
+				coords[0][i].Y = math.Sin(angle)
+			}
+			coords[0][sz] = coords[0][0]
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := NewPolygonC(coords); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -3,6 +3,7 @@ package geom_test
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
@@ -181,6 +182,38 @@ func BenchmarkPolygonSingleRingValidation(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if _, err := NewPolygonC(coords); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
+	for _, sz := range []int{2, 6, 20, 64} {
+		b.Run(fmt.Sprintf("n=%d", sz*sz), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(0))
+			coords := make([][]XY, sz*sz+1)
+			coords[0] = []XY{XY{0, 0}, XY{0, 1}, XY{1, 1}, XY{1, 0}, XY{0, 0}}
+			for i := 0; i < sz*sz; i++ {
+				center := XY{
+					X: (0.5 + float64(i/sz)) / float64(sz),
+					Y: (0.5 + float64(i%sz)) / float64(sz),
+				}
+				dx := rnd.Float64() * 0.5 / float64(sz)
+				dy := rnd.Float64() * 0.5 / float64(sz)
+				coords[1+i] = []XY{
+					center.Add(XY{-dx, -dy}),
+					center.Add(XY{dx, -dy}),
+					center.Add(XY{dx, dy}),
+					center.Add(XY{-dx, dy}),
+					center.Add(XY{-dx, -dy}),
+				}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := NewPolygonXY(coords); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
The main part of this change is to use a linesweep algorithm for LineString IsSimple (rather than exhaustively checking for intersections between each pair of line segments).

Benchmark numbers are a bit noisy, but in particular show significantly better behaviour (time and memory usage) for `BenchmarkPolygonSingleRingValidation`. This benchmark is just testing if a polygon with a single ring (made of an increasing number of line segments) is valid or not. Internally, this uses `IsSimple` on the polygon rings.

I haven't done any performance analysis using pprof yet, so there are likely some wins still that can be made WRT micro-optimisations.

```
benchmark                                               old ns/op       new ns/op       delta
BenchmarkIntersectsLineStringWithLineString/n=10        2406            2297            -4.53%
BenchmarkIntersectsLineStringWithLineString/n=100       22914           22902           -0.05%
BenchmarkIntersectsLineStringWithLineString/n=1000      331670          293550          -11.49%
BenchmarkIntersectsLineStringWithLineString/n=10000     3339903         3382322         +1.27%
BenchmarkPolygonSingleRingValidation/n=10               8505            7644            -10.12%
BenchmarkPolygonSingleRingValidation/n=100              790249          108959          -86.21%
BenchmarkPolygonSingleRingValidation/n=1000             81407496        979844          -98.80%
BenchmarkPolygonSingleRingValidation/n=10000            8306103613      10869523        -99.87%
BenchmarkPolygonMultipleRingsValidation/n=4             57655           63350           +9.88%
BenchmarkPolygonMultipleRingsValidation/n=36            2343242         2448954         +4.51%
BenchmarkPolygonMultipleRingsValidation/n=400           266714522       271292225       +1.72%
BenchmarkPolygonMultipleRingsValidation/n=4096          32014830210     31947148328     -0.21%

benchmark                                               old allocs     new allocs     delta
BenchmarkIntersectsLineStringWithLineString/n=10        17             17             +0.00%
BenchmarkIntersectsLineStringWithLineString/n=100       17             17             +0.00%
BenchmarkIntersectsLineStringWithLineString/n=1000      17             17             +0.00%
BenchmarkIntersectsLineStringWithLineString/n=10000     17             17             +0.00%
BenchmarkPolygonSingleRingValidation/n=10               158            99             -37.34%
BenchmarkPolygonSingleRingValidation/n=100              14966          900            -93.99%
BenchmarkPolygonSingleRingValidation/n=1000             1499519        8907           -99.41%
BenchmarkPolygonSingleRingValidation/n=10000            149995029      89704          -99.94%
BenchmarkPolygonMultipleRingsValidation/n=4             909            934            +2.75%
BenchmarkPolygonMultipleRingsValidation/n=36            37277          37462          +0.50%
BenchmarkPolygonMultipleRingsValidation/n=400           4126635        4128640        +0.05%
BenchmarkPolygonMultipleRingsValidation/n=4096          428296227      428316712      +0.00%

benchmark                                               old bytes       new bytes       delta
BenchmarkIntersectsLineStringWithLineString/n=10        1152            1152            +0.00%
BenchmarkIntersectsLineStringWithLineString/n=100       6976            6976            +0.00%
BenchmarkIntersectsLineStringWithLineString/n=1000      66112           66112           +0.00%
BenchmarkIntersectsLineStringWithLineString/n=10000     655936          655936          +0.00%
BenchmarkPolygonSingleRingValidation/n=10               5276            4300            -18.50%
BenchmarkPolygonSingleRingValidation/n=100              482064          39632           -91.78%
BenchmarkPolygonSingleRingValidation/n=1000             48003617        379272          -99.21%
BenchmarkPolygonSingleRingValidation/n=10000            4801141376      4910661         -99.90%
BenchmarkPolygonMultipleRingsValidation/n=4             27512           30712           +11.63%
BenchmarkPolygonMultipleRingsValidation/n=36            1180281         1203961         +2.01%
BenchmarkPolygonMultipleRingsValidation/n=400           131915204       132171840       +0.19%
BenchmarkPolygonMultipleRingsValidation/n=4096          13704004464     13706626576     +0.02%
```