### PR TITLE
Linesweep for polygon validation (ring intersection)

### DIFF
--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -59,6 +59,10 @@ func (h *lineStringHeap) Pop() interface{} {
 // NewPolygon creates a polygon given its outer and inner rings. No rings may
 // cross each other, and can only intersect each with each other at a point.
 func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption) (Polygon, error) {
+	if !doCheapValidations(opts) && !doExpensiveValidations(opts) {
+		return Polygon{outer, holes}, nil
+	}
+
 	allRings := make([]lineStringWithMaxX, 1+len(holes))
 	outerEnv, ok := outer.Envelope()
 	if !ok {

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -30,13 +30,13 @@ type Polygon struct {
 	holes []LineString
 }
 
-type lineStringWithMaxX struct {
+type lineStringWithEnv struct {
 	ls  LineString
 	env Envelope
 	idx int
 }
 
-type lineStringHeap []lineStringWithMaxX
+type lineStringHeap []lineStringWithEnv
 
 func (h *lineStringHeap) Len() int {
 	return len(*h)
@@ -48,7 +48,7 @@ func (h *lineStringHeap) Swap(i, j int) {
 	(*h)[i], (*h)[j] = (*h)[j], (*h)[i]
 }
 func (h *lineStringHeap) Push(x interface{}) {
-	*h = append(*h, x.(lineStringWithMaxX))
+	*h = append(*h, x.(lineStringWithEnv))
 }
 func (h *lineStringHeap) Pop() interface{} {
 	e := (*h)[len(*h)-1]
@@ -63,18 +63,27 @@ func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption)
 		return Polygon{outer, holes}, nil
 	}
 
-	allRings := make([]lineStringWithMaxX, 1+len(holes))
+	// Overview:
+	//
+	// 1. Create slice of all rings, ordered by min X coordinate.
+	// 2. Loop over each ring.
+	//    a. Remove any ring from the heap that has max X coordinate less than
+	//       the min X of the current ring.
+	//    b. Check to see if the current ring intersects with any in the heap.
+	//    c. Insert the current ring into the heap.
+
+	allRings := make([]lineStringWithEnv, 1+len(holes))
 	outerEnv, ok := outer.Envelope()
 	if !ok {
 		return Polygon{}, errors.New("polygon outer ring must not be empty")
 	}
-	allRings[0] = lineStringWithMaxX{outer, outerEnv, 0}
+	allRings[0] = lineStringWithEnv{outer, outerEnv, 0}
 	for i := range holes {
 		innerEnv, ok := holes[i].Envelope()
 		if !ok {
 			return Polygon{}, errors.New("polygon inner rings must not be empty")
 		}
-		allRings[1+i] = lineStringWithMaxX{holes[i], innerEnv, 1 + i}
+		allRings[1+i] = lineStringWithEnv{holes[i], innerEnv, 1 + i}
 	}
 
 	for _, r := range allRings {
@@ -90,22 +99,13 @@ func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption)
 		return Polygon{outer, holes}, nil
 	}
 
-	nextInterVert := len(allRings)
-	interVerts := make(map[XY]int)
-	graph := newGraph()
-
-	// Overview:
-	//
-	// 1. Create slice of all rings, ordered by min X coordinate.
-	// 2. Loop over each ring.
-	//    a. Remove any ring from the heap that has max X coordinate less than
-	//       the min X of the current ring.
-	//    b. Check to see if the current ring intersects with any in the heap.
-	//    c. Insert the current ring into the heap.
-
 	sort.Slice(allRings, func(i, j int) bool {
 		return allRings[i].env.Min().X < allRings[j].env.Min().X
 	})
+
+	nextInterVert := len(allRings)
+	interVerts := make(map[XY]int)
+	graph := newGraph()
 
 	var h lineStringHeap
 
@@ -116,16 +116,16 @@ func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption)
 		}
 		for _, other := range h {
 			if current.idx != 0 && other.idx != 0 {
-				// Check if skipped if the outer ring is involved.
-				nestInner := pointRingSide(
+				// Check is skipped if the outer ring is involved.
+				nestedFwd := pointRingSide(
 					current.ls.StartPoint().XY(),
 					other.ls,
 				) == interior
-				nestOuter := pointRingSide(
+				nestedRev := pointRingSide(
 					other.ls.StartPoint().XY(),
 					current.ls,
 				) == interior
-				if nestInner || nestOuter {
+				if nestedFwd || nestedRev {
 					return Polygon{}, errors.New("polygon must not have nested rings")
 				}
 			}
@@ -135,7 +135,7 @@ func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption)
 			if !has {
 				continue // no intersection
 			}
-			if !env.Min().Equals(env.Max()) {
+			if env.Min() != env.Max() {
 				return Polygon{}, errors.New("polygon rings must not intersect at multiple points")
 			}
 


### PR DESCRIPTION
There is a significant performance improvement for polygons that have many interior rings.
```
benchmark                                          old ns/op       new ns/op     delta
BenchmarkPolygonSingleRingValidation/n=10          7356            7608          +3.43%
BenchmarkPolygonSingleRingValidation/n=100         80764           82238         +1.83%
BenchmarkPolygonSingleRingValidation/n=1000        934011          898161        -3.84%
BenchmarkPolygonSingleRingValidation/n=10000       10582933        10235399      -3.28%
BenchmarkPolygonMultipleRingsValidation/n=4        66580           64021         -3.84%
BenchmarkPolygonMultipleRingsValidation/n=36       3912332         774824        -80.20%
BenchmarkPolygonMultipleRingsValidation/n=400      326315405       22045400      -93.24%
BenchmarkPolygonMultipleRingsValidation/n=4096     39136093164     896526026     -97.71%

benchmark                                          old allocs     new allocs     delta
BenchmarkPolygonSingleRingValidation/n=10          99             104            +5.05%
BenchmarkPolygonSingleRingValidation/n=100         900            905            +0.56%
BenchmarkPolygonSingleRingValidation/n=1000        8907           8912           +0.06%
BenchmarkPolygonSingleRingValidation/n=10000       89704          89709          +0.01%
BenchmarkPolygonMultipleRingsValidation/n=4        1046           797            -23.80%
BenchmarkPolygonMultipleRingsValidation/n=36       47042          12338          -73.77%
BenchmarkPolygonMultipleRingsValidation/n=400      5223220        352232         -93.26%
BenchmarkPolygonMultipleRingsValidation/n=4096     539280124      10545142       -98.04%

benchmark                                          old bytes       new bytes     delta
BenchmarkPolygonSingleRingValidation/n=10          4300            4526          +5.26%
BenchmarkPolygonSingleRingValidation/n=100         39632           39858         +0.57%
BenchmarkPolygonSingleRingValidation/n=1000        379272          379498        +0.06%
BenchmarkPolygonSingleRingValidation/n=10000       4910661         4910886       +0.00%
BenchmarkPolygonMultipleRingsValidation/n=4        33864           26930         -20.48%
BenchmarkPolygonMultipleRingsValidation/n=36       1483642         398482        -73.14%
BenchmarkPolygonMultipleRingsValidation/n=400      164503972       11134442      -93.23%
BenchmarkPolygonMultipleRingsValidation/n=4096     16995780992     330619032     -98.05%
```