### PR TITLE
Improve performance of multipolygon validation

### DIFF
--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -253,20 +253,20 @@ func intersectMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) (Ge
 		for _, ln1 := range ls1.lines {
 			for _, ls2 := range mls2.lines {
 				for _, ln2 := range ls2.lines {
-					inter, err := ln1.Intersection(ln2.AsGeometry())
-					if err != nil {
-						return Geometry{}, err
-					}
-					if inter.IsEmpty() {
-						continue
-					}
+					inter := intersectLineWithLineNoAlloc(ln1, ln2)
 					switch {
-					case inter.IsPoint():
-						points = append(points, inter.AsPoint())
-					case inter.IsLine():
-						lines = append(lines, inter.AsLine())
+					case inter.empty:
+						continue
+					case inter.ptA == inter.ptB:
+						points = append(points, NewPointXY(inter.ptA))
 					default:
-						return Geometry{}, fmt.Errorf("unhandled intersection result type: %T", inter)
+						ln, err := NewLineXY(inter.ptA, inter.ptB)
+						if err != nil {
+							// The case where ptA and ptB are coincident
+							// has already been handled.
+							panic(err)
+						}
+						lines = append(lines, ln)
 					}
 				}
 			}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -22,7 +22,11 @@ type LineString struct {
 // NewLineStringC creates a line string from the coordinates defining its
 // points.
 func NewLineStringC(pts []Coordinates, opts ...ConstructorOption) (LineString, error) {
-	var lines []Line
+	// Fewer lines than len(pts)-1 _may_ be used, however the normal case is
+	// for there to be no coincident control points, so the full capacity would
+	// be utilised.
+	lines := make([]Line, 0, len(pts)-1)
+
 	for i := 0; i < len(pts)-1; i++ {
 		if pts[i].XY.Equals(pts[i+1].XY) {
 			continue

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -109,14 +109,16 @@ func polyInteriorsIntersect(p1, p2 Polygon) bool {
 		// then each midpoint between those points. These are enough points
 		// that one of the points will be inside the other polygon iff the
 		// interior of the polygons intersect.
+		var p2rings []LineString
 		allPts := make(map[XY]struct{})
-		for _, r1 := range p1.rings() {
+		for _, r1 := range p1.appendRings(nil) {
 			for _, line1 := range r1.lines {
 				// Collect boundary control points and intersection points.
 				linePts := make(map[XY]struct{})
 				linePts[line1.a.XY] = struct{}{}
 				linePts[line1.b.XY] = struct{}{}
-				for _, r2 := range p2.rings() {
+				p2rings = p2.appendRings(p2rings[:0])
+				for _, r2 := range p2rings {
 					for _, line2 := range r2.lines {
 						inter := intersectLineWithLineNoAlloc(line1, line2)
 						if inter.empty {
@@ -294,7 +296,7 @@ func (m MultiPolygon) Coordinates() [][][]Coordinates {
 	numPolys := m.NumPolygons()
 	coords := make([][][]Coordinates, numPolys)
 	for i := 0; i < numPolys; i++ {
-		rings := m.PolygonN(i).rings()
+		rings := m.PolygonN(i).appendRings(nil)
 		coords[i] = make([][]Coordinates, len(rings))
 		for j, r := range rings {
 			n := r.NumPoints()

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -117,7 +117,7 @@ func polyInteriorsIntersect(p1, p2 Polygon) bool {
 				linePts := make(map[XY]struct{})
 				linePts[line1.a.XY] = struct{}{}
 				linePts[line1.b.XY] = struct{}{}
-				p2rings = p2.appendRings(p2rings[:0])
+				p2rings = appendRings(p2rings[:0], p2)
 				for _, r2 := range p2rings {
 					for _, line2 := range r2.lines {
 						inter := intersectLineWithLineNoAlloc(line1, line2)

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -28,8 +28,38 @@ func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, 
 	if !doExpensiveValidations(opts) {
 		return MultiPolygon{polys}, nil
 	}
-	for i := 0; i < len(polys); i++ {
-		for j := i + 1; j < len(polys); j++ {
+
+	type interval struct {
+		minX, maxX float64
+	}
+	intervals := make([]interval, len(polys))
+	for i := range intervals {
+		env, ok := polys[i].Envelope()
+		if !ok {
+			return MultiPolygon{}, errors.New("polygon in multiploygon not allowed to be empty")
+		}
+		intervals[i].minX = env.Min().X
+		intervals[i].maxX = env.Max().X
+	}
+	indexes := seq(len(polys))
+	sort.Slice(indexes, func(i, j int) bool {
+		xi := intervals[indexes[i]].minX
+		xj := intervals[indexes[j]].minX
+		return xi < xj
+	})
+
+	active := intHeap{less: func(i, j int) bool {
+		xi := intervals[i].maxX
+		xj := intervals[j].maxX
+		return xi < xj
+	}}
+
+	for _, i := range indexes {
+		currentX := intervals[i].minX
+		for len(active.data) > 0 && intervals[active.data[0]].maxX < currentX {
+			active.pop()
+		}
+		for _, j := range active.data {
 			bound1 := polys[i].Boundary()
 			bound2 := polys[j].Boundary()
 			inter := mustIntersection(bound1, bound2)
@@ -40,7 +70,9 @@ func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, 
 				return MultiPolygon{}, errors.New("polygon interiors must not intersect")
 			}
 		}
+		active.push(i)
 	}
+
 	return MultiPolygon{polys}, nil
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -111,7 +111,7 @@ func polyInteriorsIntersect(p1, p2 Polygon) bool {
 		// interior of the polygons intersect.
 		var p2rings []LineString
 		allPts := make(map[XY]struct{})
-		for _, r1 := range p1.appendRings(nil) {
+		for _, r1 := range p1.rings() {
 			for _, line1 := range r1.lines {
 				// Collect boundary control points and intersection points.
 				linePts := make(map[XY]struct{})
@@ -296,7 +296,7 @@ func (m MultiPolygon) Coordinates() [][][]Coordinates {
 	numPolys := m.NumPolygons()
 	coords := make([][][]Coordinates, numPolys)
 	for i := 0; i < numPolys; i++ {
-		rings := m.PolygonN(i).appendRings(nil)
+		rings := m.PolygonN(i).rings()
 		coords[i] = make([][]Coordinates, len(rings))
 		for j, r := range rings {
 			n := r.NumPoints()

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -118,16 +118,15 @@ func polyInteriorsIntersect(p1, p2 Polygon) bool {
 				linePts[line1.b.XY] = struct{}{}
 				for _, r2 := range p2.rings() {
 					for _, line2 := range r2.lines {
-						env, ok := mustIntersection(line1.AsGeometry(), line2.AsGeometry()).Envelope()
-						if !ok {
+						inter := intersectLineWithLineNoAlloc(line1, line2)
+						if inter.empty {
 							continue
 						}
-						if !env.Min().Equals(env.Max()) {
+						if inter.ptA != inter.ptB {
 							continue
 						}
-						inter := env.Min()
-						if !inter.Equals(line1.a.XY) && !inter.Equals(line1.b.XY) {
-							linePts[inter] = struct{}{}
+						if inter.ptA != line1.StartPoint().XY() && inter.ptA != line1.EndPoint().XY() {
+							linePts[inter.ptA] = struct{}{}
 						}
 					}
 				}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -254,10 +254,10 @@ func (p Polygon) Envelope() (Envelope, bool) {
 
 func (p Polygon) rings() []LineString {
 	dst := make([]LineString, 0, 1+len(p.holes))
-	return p.appendRings(dst)
+	return appendRings(dst, p)
 }
 
-func (p Polygon) appendRings(dst []LineString) []LineString {
+func appendRings(dst []LineString, p Polygon) []LineString {
 	dst = append(dst, p.outer)
 	dst = append(dst, p.holes...)
 	return dst


### PR DESCRIPTION
Main changes:

- Use linesweep algorithm when determining which (sub)polygons to check for intersection. The old algorithm was the naive O(n^2) "check every pair" strategy.
- Some micro optimisations, mainly relating to reducing memory allocations.

Perf diff:

```
benchmark                                                 old ns/op      new ns/op     delta
BenchmarkIntersectsLineStringWithLineString/n=10-2        1832           1894          +3.38%
BenchmarkIntersectsLineStringWithLineString/n=100-2       16316          16613         +1.82%
BenchmarkIntersectsLineStringWithLineString/n=1000-2      194317         195022        +0.36%
BenchmarkIntersectsLineStringWithLineString/n=10000-2     2160753        2165766       +0.23%
BenchmarkPolygonSingleRingValidation/n=10-2               2171           1972          -9.17%
BenchmarkPolygonSingleRingValidation/n=100-2              24628          21594         -12.32%
BenchmarkPolygonSingleRingValidation/n=1000-2             285073         272031        -4.57%
BenchmarkPolygonSingleRingValidation/n=10000-2            3437431        3218969       -6.36%
BenchmarkPolygonMultipleRingsValidation/n=4-2             13837          13174         -4.79%
BenchmarkPolygonMultipleRingsValidation/n=36-2            229384         235612        +2.72%
BenchmarkPolygonMultipleRingsValidation/n=400-2           7882748        8637718       +9.58%
BenchmarkPolygonMultipleRingsValidation/n=4096-2          242356506      238706411     -1.51%
BenchmarkMultipolygonValidation/n=1-2                     1234           1429          +15.80%
BenchmarkMultipolygonValidation/n=4-2                     74022          15137         -79.55%
BenchmarkMultipolygonValidation/n=16-2                    1502411        136865        -90.89%
BenchmarkMultipolygonValidation/n=64-2                    25203805       1196663       -95.25%
BenchmarkMultipolygonValidation/n=256-2                   374222039      9820994       -97.38%
BenchmarkMultipolygonValidation/n=1024-2                  6088898206     78850656      -98.71%

benchmark                                                 old allocs     new allocs     delta
BenchmarkIntersectsLineStringWithLineString/n=10-2        21             21             +0.00%
BenchmarkIntersectsLineStringWithLineString/n=100-2       21             21             +0.00%
BenchmarkIntersectsLineStringWithLineString/n=1000-2      21             21             +0.00%
BenchmarkIntersectsLineStringWithLineString/n=10000-2     21             21             +0.00%
BenchmarkPolygonSingleRingValidation/n=10-2               18             14             -22.22%
BenchmarkPolygonSingleRingValidation/n=100-2              21             14             -33.33%
BenchmarkPolygonSingleRingValidation/n=1000-2             24             14             -41.67%
BenchmarkPolygonSingleRingValidation/n=10000-2            34             14             -58.82%
BenchmarkPolygonMultipleRingsValidation/n=4-2             169            159            -5.92%
BenchmarkPolygonMultipleRingsValidation/n=36-2            3096           3022           -2.39%
BenchmarkPolygonMultipleRingsValidation/n=400-2           114274         113472         -0.70%
BenchmarkPolygonMultipleRingsValidation/n=4096-2          3463225        3455030        -0.24%
BenchmarkMultipolygonValidation/n=1-2                     20             23             +15.00%
BenchmarkMultipolygonValidation/n=4-2                     1138           129            -88.66%
BenchmarkMultipolygonValidation/n=16-2                    21534          918            -95.74%
BenchmarkMultipolygonValidation/n=64-2                    357992         7089           -98.02%
BenchmarkMultipolygonValidation/n=256-2                   5781898        55956          -99.03%
BenchmarkMultipolygonValidation/n=1024-2                  92726799       444951         -99.52%

benchmark                                                 old bytes      new bytes     delta
BenchmarkIntersectsLineStringWithLineString/n=10-2        1216           1216          +0.00%
BenchmarkIntersectsLineStringWithLineString/n=100-2       7040           7040          +0.00%
BenchmarkIntersectsLineStringWithLineString/n=1000-2      66176          66176         +0.00%
BenchmarkIntersectsLineStringWithLineString/n=10000-2     656000         656000        +0.00%
BenchmarkPolygonSingleRingValidation/n=10-2               1352           680           -49.70%
BenchmarkPolygonSingleRingValidation/n=100-2              9336           4376          -53.13%
BenchmarkPolygonSingleRingValidation/n=1000-2             73976          41240         -44.25%
BenchmarkPolygonSingleRingValidation/n=10000-2            1843449        409880        -77.77%
BenchmarkPolygonMultipleRingsValidation/n=4-2             7072           6592          -6.79%
BenchmarkPolygonMultipleRingsValidation/n=36-2            126496         122944        -2.81%
BenchmarkPolygonMultipleRingsValidation/n=400-2           4552129        4513633       -0.85%
BenchmarkPolygonMultipleRingsValidation/n=4096-2          136951555      136558108     -0.29%
BenchmarkMultipolygonValidation/n=1-2                     728            728           +0.00%
BenchmarkMultipolygonValidation/n=4-2                     37008          4584          -87.61%
BenchmarkMultipolygonValidation/n=16-2                    691920         31976         -95.38%
BenchmarkMultipolygonValidation/n=64-2                    11467728       238248        -97.92%
BenchmarkMultipolygonValidation/n=256-2                   185069520      1837352       -99.01%
BenchmarkMultipolygonValidation/n=1024-2                  2967453936     14426672      -99.51%
```