### PR TITLE
Store only pts in line string

### DIFF
--- a/geom/accessor_test.go
+++ b/geom/accessor_test.go
@@ -78,6 +78,25 @@ func TestLineStringAccessor(t *testing.T) {
 	})
 }
 
+func TestLineStringAccessorWithDuplicates(t *testing.T) {
+	ls := geomFromWKT(t, "LINESTRING(1 2,3 4,3 4,5 6)").AsLineString()
+	pt12 := geomFromWKT(t, "POINT(1 2)")
+	pt34 := geomFromWKT(t, "POINT(3 4)")
+	pt56 := geomFromWKT(t, "POINT(5 6)")
+
+	t.Run("num points", func(t *testing.T) {
+		expectIntEq(t, ls.NumPoints(), 4)
+	})
+	t.Run("point n", func(t *testing.T) {
+		expectPanics(t, func() { ls.PointN(-1) })
+		expectGeomEq(t, ls.PointN(0).AsGeometry(), pt12)
+		expectGeomEq(t, ls.PointN(1).AsGeometry(), pt34)
+		expectGeomEq(t, ls.PointN(2).AsGeometry(), pt34)
+		expectGeomEq(t, ls.PointN(3).AsGeometry(), pt56)
+		expectPanics(t, func() { ls.PointN(4) })
+	})
+}
+
 func TestPolygonAccessor(t *testing.T) {
 	poly := geomFromWKT(t, "POLYGON((0 0,5 0,5 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1),(3 1,4 1,4 2,3 2,3 1))").AsPolygon()
 	outer := geomFromWKT(t, "LINESTRING(0 0,5 0,5 3,0 3,0 0)")

--- a/geom/accessor_test.go
+++ b/geom/accessor_test.go
@@ -97,6 +97,28 @@ func TestLineStringAccessorWithDuplicates(t *testing.T) {
 	})
 }
 
+func TestLineStringAccessorWithMoreDuplicates(t *testing.T) {
+	ls := geomFromWKT(t, "LINESTRING(1 2,1 2,3 4,3 4,3 4,5 6,5 6)").AsLineString()
+	pt12 := geomFromWKT(t, "POINT(1 2)")
+	pt34 := geomFromWKT(t, "POINT(3 4)")
+	pt56 := geomFromWKT(t, "POINT(5 6)")
+
+	t.Run("num points", func(t *testing.T) {
+		expectIntEq(t, ls.NumPoints(), 7)
+	})
+	t.Run("point n", func(t *testing.T) {
+		expectPanics(t, func() { ls.PointN(-1) })
+		expectGeomEq(t, ls.PointN(0).AsGeometry(), pt12)
+		expectGeomEq(t, ls.PointN(1).AsGeometry(), pt12)
+		expectGeomEq(t, ls.PointN(2).AsGeometry(), pt34)
+		expectGeomEq(t, ls.PointN(3).AsGeometry(), pt34)
+		expectGeomEq(t, ls.PointN(4).AsGeometry(), pt34)
+		expectGeomEq(t, ls.PointN(5).AsGeometry(), pt56)
+		expectGeomEq(t, ls.PointN(6).AsGeometry(), pt56)
+		expectPanics(t, func() { ls.PointN(7) })
+	})
+}
+
 func TestPolygonAccessor(t *testing.T) {
 	poly := geomFromWKT(t, "POLYGON((0 0,5 0,5 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1),(3 1,4 1,4 2,3 2,3 1))").AsPolygon()
 	outer := geomFromWKT(t, "LINESTRING(0 0,5 0,5 3,0 3,0 0)")

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -250,9 +250,11 @@ func intersectMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) (Ge
 	var points []Point
 	var lines []Line
 	for _, ls1 := range mls1.lines {
-		for _, ln1 := range ls1.lines {
+		for i := 0; i < ls1.NumLines(); i++ {
+			ln1 := ls1.LineN(i)
 			for _, ls2 := range mls2.lines {
-				for _, ln2 := range ls2.lines {
+				for j := 0; j < ls2.NumLines(); j++ {
+					ln2 := ls2.LineN(j)
 					inter := intersectLineWithLineNoAlloc(ln1, ln2)
 					switch {
 					case inter.empty:
@@ -289,7 +291,8 @@ func intersectPointWithLine(point Point, line Line) Geometry {
 }
 
 func intersectPointWithLineString(pt Point, ls LineString) Geometry {
-	for _, ln := range ls.lines {
+	for i := 0; i < ls.NumLines(); i++ {
+		ln := ls.LineN(i)
 		g := intersectPointWithLine(pt, ln)
 		if !g.IsEmpty() {
 			return g

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -295,11 +295,12 @@ func hasIntersectionMultiLineStringWithMultiLineString(
 	for _, side := range sides {
 		var n int
 		for _, ls := range side.mls.lines {
-			n += len(ls.lines)
+			n += ls.NumLines()
 		}
 		side.lines = make([]Line, 0, n)
 		for _, ls := range side.mls.lines {
-			for _, ln := range ls.lines {
+			for i := 0; i < ls.NumLines(); i++ {
+				ln := ls.LineN(i)
 				if ln.StartPoint().XY().X > ln.EndPoint().XY().X {
 					// TODO: Use ST_Reverse
 					ln.a, ln.b = ln.b, ln.a
@@ -423,8 +424,8 @@ func hasIntersectionPointWithLine(point Point, line Line) bool {
 
 func hasIntersectionPointWithLineString(pt Point, ls LineString) bool {
 	// Worst case speed is O(n), n is the number of lines.
-	for _, ln := range ls.lines {
-		if hasIntersectionPointWithLine(pt, ln) {
+	for i := 0; i < ls.NumLines(); i++ {
+		if hasIntersectionPointWithLine(pt, ls.LineN(i)) {
 			return true
 		}
 	}

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -233,22 +233,12 @@ func hasIntersectionLineWithMultiPoint(ln Line, mp MultiPoint) bool {
 }
 
 func hasIntersectionMultiPointWithMultiLineString(mp MultiPoint, mls MultiLineString) bool {
-	numPts := mp.NumPoints()
-	for i := 0; i < numPts; i++ {
+	for i := 0; i < mp.NumPoints(); i++ {
 		pt := mp.PointN(i)
-		numLSs := mls.NumLineStrings()
-		for j := 0; j < numLSs; j++ {
+		for j := 0; j < mls.NumLineStrings(); j++ {
 			ls := mls.LineStringN(j)
-			numLSPts := ls.NumPoints()
-			for k := 0; k < numLSPts-1; k++ {
-				ln, err := NewLineC(
-					ls.PointN(k).Coordinates(),
-					ls.PointN(k+1).Coordinates(),
-				)
-				if err != nil {
-					// Should never occur due to construction.
-					panic(err)
-				}
+			for k := 0; k < ls.NumLines(); k++ {
+				ln := ls.LineN(k)
 				if hasIntersectionPointWithLine(pt, ln) {
 					return true
 				}

--- a/geom/alg_intersects_test.go
+++ b/geom/alg_intersects_test.go
@@ -248,6 +248,7 @@ func TestIntersects(t *testing.T) {
 		// MultiPoint/MultiLineString
 		{"MULTIPOINT(0 0,1 0)", "MULTILINESTRING((0 1,1 1),(1 0,2 -1))", true},
 		{"MULTIPOINT(0 0,1 0)", "MULTILINESTRING((0 1,1 1),(1 0.5,2 -0.5))", false},
+		{"MULTIPOINT(0.5 0.5)", "MULTILINESTRING((0 0,0 0,1 1))", true},
 
 		// MultiPoint/MultiPolygon
 		{"MULTIPOINT((1 1))", "MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)))", true},

--- a/geom/alg_point_in_ring.go
+++ b/geom/alg_point_in_ring.go
@@ -16,9 +16,10 @@ func pointRingSide(pt XY, ring LineString) side {
 	ptg := NewPointC(Coordinates{pt})
 	// find max x coordinate
 	// TODO: should be able to use envelope for this
-	maxX := ring.lines[0].a.X
-	for _, ln := range ring.lines {
-		maxX = math.Max(maxX, ln.b.X)
+	maxX := ring.LineN(0).StartPoint().XY().X
+	for i := 0; i < ring.NumLines(); i++ {
+		ln := ring.LineN(i)
+		maxX = math.Max(maxX, ln.EndPoint().XY().X)
 		if hasIntersectionPointWithLine(ptg, ln) {
 			return boundary
 		}
@@ -34,7 +35,8 @@ func pointRingSide(pt XY, ring LineString) side {
 	}
 
 	var count int
-	for _, seg := range ring.lines {
+	for i := 0; i < ring.NumLines(); i++ {
+		seg := ring.LineN(i)
 		inter := intersectLineWithLineNoAlloc(seg, ray)
 		if inter.empty {
 			continue

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -24,7 +24,7 @@ type LineString struct {
 // NewLineStringC creates a line string from the coordinates defining its
 // points.
 func NewLineStringC(pts []Coordinates, opts ...ConstructorOption) (LineString, error) {
-	segments := make([]int, len(pts)-1)
+	segments := make([]int, 0, len(pts)-1)
 	coords := make([]Coordinates, len(pts))
 	copy(coords, pts)
 

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -75,15 +75,14 @@ func (s LineString) NumLines() int {
 }
 
 func (s LineString) LineN(n int) Line {
-	ln, err := NewLineC(
-		s.coords[s.segments[n]],
-		s.coords[s.segments[n]+1],
-	)
-	if err != nil {
-		// Cannot occur due to the way that the segments array is constructed.
-		panic(err)
-	}
-	return ln
+	// Line is constructed directly here, rather than via NewLineC. This is
+	// because LineN is called in a tight loop in many places, and skipping the
+	// constructor significantly speeds up the benchmarks.
+	//
+	// The two coordinates are guarenteed to not be conincident due to the way
+	// that the segments slice is constructed, so this is safe.
+	i := s.segments[n]
+	return Line{s.coords[i], s.coords[i+1]}
 }
 
 func (s LineString) AsText() string {

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -79,7 +79,7 @@ func (s LineString) LineN(n int) Line {
 	// because LineN is called in a tight loop in many places, and skipping the
 	// constructor significantly speeds up the benchmarks.
 	//
-	// The two coordinates are guarenteed to not be conincident due to the way
+	// The two coordinates are guaranteed to not be coincident due to the way
 	// that the segments slice is constructed, so this is safe.
 	i := s.segments[n]
 	return Line{s.coords[i], s.coords[i+1]}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -146,8 +146,8 @@ func (m MultiLineString) Boundary() Geometry {
 			continue
 		}
 		for _, pt := range [2]Point{
-			NewPointC(ls.lines[0].a),
-			NewPointC(ls.lines[len(ls.lines)-1].b),
+			ls.StartPoint(),
+			ls.EndPoint(),
 		} {
 			_, seen := counts[pt.coords.XY]
 			if !seen {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -112,14 +112,16 @@ func polyInteriorsIntersect(p1, p2 Polygon) bool {
 		var p2rings []LineString
 		allPts := make(map[XY]struct{})
 		for _, r1 := range p1.rings() {
-			for _, line1 := range r1.lines {
+			for ln1 := 0; ln1 < r1.NumLines(); ln1++ {
+				line1 := r1.LineN(ln1)
 				// Collect boundary control points and intersection points.
 				linePts := make(map[XY]struct{})
 				linePts[line1.a.XY] = struct{}{}
 				linePts[line1.b.XY] = struct{}{}
 				p2rings = appendRings(p2rings[:0], p2)
 				for _, r2 := range p2rings {
-					for _, line2 := range r2.lines {
+					for ln2 := 0; ln2 < r2.NumLines(); ln2++ {
+						line2 := r2.LineN(ln2)
 						inter := intersectLineWithLineNoAlloc(line1, line2)
 						if inter.empty {
 							continue

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -142,8 +142,9 @@ func NewPolygon(outer LineString, holes []LineString, opts ...ConstructorOption)
 
 	// All inner rings must be inside the outer ring.
 	for _, hole := range holes {
-		for _, line := range hole.lines {
-			if pointRingSide(line.a.XY, outer) == exterior {
+		for i := 0; i < hole.NumPoints(); i++ {
+			pt := hole.PointN(i)
+			if pointRingSide(pt.XY(), outer) == exterior {
 				return Polygon{}, errors.New("hole must be inside outer ring")
 			}
 		}

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -17,6 +17,7 @@ func geomFromWKT(t *testing.T, wkt string) Geometry {
 }
 
 func expectPanics(t *testing.T, fn func()) {
+	t.Helper()
 	defer func() {
 		if r := recover(); r != nil {
 			return
@@ -36,7 +37,7 @@ func expectNoErr(t *testing.T, err error) {
 func expectGeomEq(t *testing.T, got, want Geometry, opts ...EqualsExactOption) {
 	t.Helper()
 	if !got.EqualsExact(want, opts...) {
-		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
+		t.Errorf("\ngot:  %v\nwant: %v\n", got.AsText(), want.AsText())
 	}
 }
 


### PR DESCRIPTION
This has two main effects:

- LineString geometries with adjacent points that are coincident are now handled correctly. Previously the coincident points were discarded, which isn't correct behaviour.

- The memory usage has been reduced by 25% (we are no longer duplicating points, but now also have to track which points are duplicated).

There is a slight performance degradation, but seems to be less than 5%.