### PR TITLE
Implement Length() for all types.

### DIFF
--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -340,17 +340,8 @@ func CheckIsRing(t *testing.T, pg PostGIS, g geom.Geometry) {
 }
 
 func CheckLength(t *testing.T, pg PostGIS, g geom.Geometry) {
-	if !g.IsLine() && !g.IsLineString() && !g.IsMultiLineString() {
-		if _, ok := g.Length(); ok {
-			t.Error("didn't expect to be able to get length but could")
-		}
-		return
-	}
 	t.Run("CheckLength", func(t *testing.T) {
-		got, ok := g.Length()
-		if !ok {
-			t.Error("could not get length")
-		}
+		got := g.Length()
 		want := pg.Length(t, g)
 		if math.Abs(got-want) > 1e-6 {
 			t.Logf("got:  %v", got)

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -440,12 +440,24 @@ func TestLength(t *testing.T) {
 		{"LINESTRING(0 0,0 1,1 3)", 1 + math.Sqrt(5)},
 		{"MULTILINESTRING((4 2,5 1),(9 2,7 1))", math.Sqrt(2) + math.Sqrt(5)},
 		{"MULTILINESTRING((0 0,2 0),(1 0,3 0))", 4},
+		{"POINT(1 3)", 0},
+		{"MULTIPOINT(0 0,0 1,1 0,0 0)", 0},
+		{"POLYGON((0 0,1 1,0 1,0 0))", 0},
+		{"POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1))", 0},
+		{"MULTIPOLYGON(((0 0,1 0,0 1,0 0)),((2 1,1 1,2 0,2 1)))", 0},
+		{"GEOMETRYCOLLECTION EMPTY", 0},
+		{"GEOMETRYCOLLECTION(POINT EMPTY)", 0},
+		{"GEOMETRYCOLLECTION(POINT(1 2))", 0},
+		{"GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(1 2)))", 0},
+		{`GEOMETRYCOLLECTION(
+			LINESTRING(0 0,0 1,1 3),
+			POINT(2 3),
+			MULTILINESTRING((4 2,5 1),(9 2,7 1)),
+			POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1))
+		)`, 1 + math.Sqrt(5) + math.Sqrt(2) + math.Sqrt(5)},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got, ok := geomFromWKT(t, tt.wkt).Length()
-			if !ok {
-				t.Fatal("could not calculate length")
-			}
+			got := geomFromWKT(t, tt.wkt).Length()
 			if math.Abs(tt.want-got) > 1e-6 {
 				t.Errorf("got=%v want=%v", got, tt.want)
 			}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -213,6 +213,17 @@ func (c GeometryCollection) Reverse() GeometryCollection {
 	return NewGeometryCollection(geoms)
 }
 
+// Length of a GeometryCollection is the sum of the lengths of its parts.
+func (c GeometryCollection) Length() float64 {
+	var sum float64
+	n := c.NumGeometries()
+	for i := 0; i < n; i++ {
+		geom := c.GeometryN(i)
+		sum += geom.Length()
+	}
+	return sum
+}
+
 // Area in the case of a GeometryCollection is the sum of the areas of its parts.
 func (c GeometryCollection) Area() float64 {
 	var sum float64

--- a/geom/type_sum.go
+++ b/geom/type_sum.go
@@ -548,22 +548,31 @@ func (g Geometry) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geomet
 	}
 }
 
-// Length gives the length of the geometry, if defined. It is only defined for
-// Lines, LineStrings, and MultiLineStrings. The returned flag indicates if the
-// length is defined.
-//
-// TODO: This doesn't match PostGIS behaviour. See
-// https://github.com/peterstace/simplefeatures/issues/86
-func (g Geometry) Length() (float64, bool) {
+// Length gives the length of a Line, LineString, or MultiLineString
+// or the sum of the lengths of the components of a GeometryCollection.
+// Other Geometries are defined to return a length of zero.
+func (g Geometry) Length() float64 {
 	switch {
+	case g.IsEmpty():
+		return 0
+	case g.IsGeometryCollection():
+		return g.AsGeometryCollection().Length()
 	case g.IsLine():
-		return g.AsLine().Length(), true
+		return g.AsLine().Length()
 	case g.IsLineString():
-		return g.AsLineString().Length(), true
+		return g.AsLineString().Length()
 	case g.IsMultiLineString():
-		return g.AsMultiLineString().Length(), true
+		return g.AsMultiLineString().Length()
+	case g.IsPoint():
+		return 0
+	case g.IsMultiPoint():
+		return 0
+	case g.IsPolygon():
+		return 0
+	case g.IsMultiPolygon():
+		return 0
 	default:
-		return 0, false
+		return 0
 	}
 }
 


### PR DESCRIPTION
Most non-Line types return 0, except GeometryCollection recurses.
Fixed #86 