### PR TITLE
Batch fuzz

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -10,7 +10,7 @@ services:
   tests:
     image: golang:1
     working_dir: /go/src/github.com/peterstace/simplefeatures
-    entrypoint: go test -v -test.count=1 -test.timeout=30m -test.run=. ./fuzztests
+    entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./...
     volumes:
       - .:/go/src/github.com/peterstace/simplefeatures
     environment:

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -10,7 +10,7 @@ services:
   tests:
     image: golang:1
     working_dir: /go/src/github.com/peterstace/simplefeatures
-    entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./...
+    entrypoint: go test -v -test.count=1 -test.timeout=30m -test.run=. ./fuzztests
     volumes:
       - .:/go/src/github.com/peterstace/simplefeatures
     environment:

--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -117,7 +117,7 @@ func CheckGeoJSONParse(t *testing.T, pg PostGIS, candidates []string) {
 	}
 }
 
-func CheckWKT(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckWKT(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckWKT", func(t *testing.T) {
 		got := g.AsText()
 		if strings.Contains(got, "MULTIPOINT") {
@@ -126,7 +126,7 @@ func CheckWKT(t *testing.T, pg PostGIS, g geom.Geometry) {
 			// The simplefeatures library follows the spec correctly.
 			return
 		}
-		want := pg.AsText(t, g)
+		want := want.AsText
 		if want != got {
 			t.Logf("got:  %v", got)
 			t.Logf("want: %v", want)
@@ -135,7 +135,7 @@ func CheckWKT(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckWKB(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckWKB(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckWKB", func(t *testing.T) {
 		if g.IsEmptySet() && g.AsText() == "POINT EMPTY" {
 			// Empty point WKB use NaN as part of their representation.
@@ -154,7 +154,7 @@ func CheckWKB(t *testing.T, pg PostGIS, g geom.Geometry) {
 		if err := g.AsBinary(&got); err != nil {
 			t.Fatalf("writing wkb: %v", err)
 		}
-		want := pg.AsBinary(t, g)
+		want := want.AsBinary
 		if !bytes.Equal(got.Bytes(), want) {
 			t.Logf("got:  %v", got.Bytes())
 			t.Logf("want: %v", want)
@@ -163,7 +163,7 @@ func CheckWKB(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckGeoJSON(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckGeoJSON(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckGeoJSON", func(t *testing.T) {
 
 		// PostGIS cannot convert to geojson in the case where it has
@@ -189,7 +189,7 @@ func CheckGeoJSON(t *testing.T, pg PostGIS, g geom.Geometry) {
 		if err != nil {
 			t.Fatalf("could not convert to geojson: %v", err)
 		}
-		want := pg.AsGeoJSON(t, g)
+		want := want.AsGeoJSON
 		if !bytes.Equal(got, want) {
 			t.Logf("got:  %v", string(got))
 			t.Logf("want: %v", string(want))
@@ -198,10 +198,10 @@ func CheckGeoJSON(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckIsEmpty(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckIsEmpty(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckIsEmpty", func(t *testing.T) {
 		got := g.IsEmpty()
-		want := pg.IsEmpty(t, g)
+		want := want.IsEmpty
 		if got != want {
 			t.Logf("got:  %v", got)
 			t.Logf("want: %v", want)
@@ -210,10 +210,10 @@ func CheckIsEmpty(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckDimension(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckDimension(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckDimension", func(t *testing.T) {
 		got := g.Dimension()
-		want := pg.Dimension(t, g)
+		want := want.Dimension
 		if got != want {
 			t.Logf("got:  %v", got)
 			t.Logf("want: %v", want)
@@ -222,7 +222,7 @@ func CheckDimension(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckEnvelope(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckEnvelope(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckEnvelope", func(t *testing.T) {
 		if g.IsEmpty() {
 			// PostGIS allows envelopes on empty geometries, but they are empty
@@ -236,7 +236,7 @@ func CheckEnvelope(t *testing.T, pg PostGIS, g geom.Geometry) {
 			panic("could not get envelope")
 		}
 		got := env.AsGeometry()
-		want := pg.Envelope(t, g)
+		want := want.Envelope
 
 		if !got.EqualsExact(want) {
 			t.Logf("got:  %v", got.AsText())
@@ -246,7 +246,7 @@ func CheckEnvelope(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckIsSimple(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckIsSimple(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckIsSimple", func(t *testing.T) {
 		got, ok := g.IsSimple()
 		if ok == g.IsGeometryCollection() {
@@ -274,7 +274,7 @@ func CheckIsSimple(t *testing.T, pg PostGIS, g geom.Geometry) {
 			}
 		}
 
-		want := pg.IsSimple(t, g)
+		want := want.IsSimple
 		if got != want {
 			t.Logf("got:  %v", got)
 			t.Logf("want: %v", want)
@@ -283,7 +283,7 @@ func CheckIsSimple(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckBoundary(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckBoundary(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckBoundary", func(t *testing.T) {
 		if g.IsGeometryCollection() {
 			// PostGIS cannot calculate the boundary of GeometryCollections.
@@ -291,7 +291,7 @@ func CheckBoundary(t *testing.T, pg PostGIS, g geom.Geometry) {
 			return
 		}
 		got := g.Boundary()
-		want := pg.Boundary(t, g)
+		want := want.Boundary
 		if !got.EqualsExact(want, geom.IgnoreOrder) {
 			t.Logf("got:  %v", got.AsText())
 			t.Logf("want: %v", want.AsText())
@@ -300,10 +300,10 @@ func CheckBoundary(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckConvexHull(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckConvexHull(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckConvexHull", func(t *testing.T) {
 		got := g.ConvexHull()
-		want := pg.ConvexHull(t, g)
+		want := want.ConvexHull
 		if !got.EqualsExact(want, geom.IgnoreOrder) {
 			t.Logf("got:  %v", got.AsText())
 			t.Logf("want: %v", want.AsText())
@@ -312,10 +312,10 @@ func CheckConvexHull(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckIsValid(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckIsValid(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckIsValid", func(t *testing.T) {
 		got := g.IsValid()
-		want := pg.IsValid(t, g)
+		want := want.IsValid
 		if got != want {
 			t.Logf("got:  %t", got)
 			t.Logf("want: %t", want)
@@ -324,13 +324,13 @@ func CheckIsValid(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckIsRing(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckIsRing(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckIsRing", func(t *testing.T) {
 		var got bool
 		if g.IsLineString() {
 			got = g.AsLineString().IsRing()
 		}
-		want := pg.IsRing(t, g)
+		want := want.IsRing
 		if got != want {
 			t.Logf("got:  %t", got)
 			t.Logf("want: %t", want)
@@ -339,7 +339,7 @@ func CheckIsRing(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckLength(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckLength(t *testing.T, want UnaryResult, g geom.Geometry) {
 	if !g.IsLine() && !g.IsLineString() && !g.IsMultiLineString() {
 		if _, ok := g.Length(); ok {
 			t.Error("didn't expect to be able to get length but could")
@@ -351,7 +351,7 @@ func CheckLength(t *testing.T, pg PostGIS, g geom.Geometry) {
 		if !ok {
 			t.Error("could not get length")
 		}
-		want := pg.Length(t, g)
+		want := want.Length
 		if math.Abs(got-want) > 1e-6 {
 			t.Logf("got:  %v", got)
 			t.Logf("want: %v", want)
@@ -435,10 +435,10 @@ func CheckIntersection(t *testing.T, pg PostGIS, g1, g2 geom.Geometry) {
 	})
 }
 
-func CheckArea(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckArea(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckArea", func(t *testing.T) {
 		got := g.Area()
-		want := pg.Area(t, g)
+		want := want.Area
 		const eps = 0.000000001
 		if math.Abs(got-want) > eps {
 			t.Logf("got:  %v", got)
@@ -448,14 +448,14 @@ func CheckArea(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckCentroid(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckCentroid(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckCentroid", func(t *testing.T) {
 		if !g.IsPolygon() && !g.IsMultiPolygon() {
 			return
 		}
 
 		got, ok := g.Centroid()
-		want := pg.Centroid(t, g)
+		want := want.Cetroid
 
 		if !ok {
 			if !want.IsEmpty() {
@@ -473,10 +473,10 @@ func CheckCentroid(t *testing.T, pg PostGIS, g geom.Geometry) {
 	})
 }
 
-func CheckReverse(t *testing.T, pg PostGIS, g geom.Geometry) {
+func CheckReverse(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckReverse", func(t *testing.T) {
 		got := g.Reverse()
-		want := pg.Reverse(t, g)
+		want := want.Reverse
 		if !got.EqualsExact(want) {
 			t.Logf("got:  %v", got.AsText())
 			t.Logf("want: %v", want.AsText())

--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -311,14 +311,21 @@ func CheckIsValid(t *testing.T, want UnaryResult, g geom.Geometry) {
 
 func CheckIsRing(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckIsRing", func(t *testing.T) {
-		if want.IsRing.Valid != g.IsLineString() {
-			t.Fatal("Unexpected IsString definition: IsLineString=%v "+
-				"PostGISDefined=%v", g.IsLineString(), want.IsRing.Valid)
+		isDefined := g.IsLine() ||
+			g.IsLineString() ||
+			(g.IsEmptySet() && g.AsEmptySet().AsText() == "LINESTRING EMPTY")
+		if want.IsRing.Valid != isDefined {
+			t.Fatalf("Unexpected IsString definition: "+
+				"IsLineString=%v PostGISDefined=%v",
+				isDefined, want.IsRing.Valid)
 		}
 		if !want.IsRing.Valid {
 			return
 		}
-		got := g.AsLineString().IsRing()
+		var got bool
+		if g.IsLineString() {
+			got = g.AsLineString().IsRing()
+		}
 		want := want.IsRing.Bool
 		if got != want {
 			t.Logf("got:  %t", got)

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -33,32 +33,30 @@ func TestFuzz(t *testing.T) {
 		fmt.Printf("index=%d WKT=%v\n", i, g.AsText())
 	}
 	for i, g := range geoms {
-		//fmt.Printf("unary %d/%d\n", i+1, len(geoms))
 		t.Run(fmt.Sprintf("geom_%d_", i), func(t *testing.T) {
-			got, err := PG{pg.db}.Unary(g)
+			want, err := BatchPostGIS{pg.db}.Unary(g)
 			if err != nil {
 				t.Fatalf("could not get result from postgis: %v", err)
 			}
-			CheckWKT(t, got, g)
-			CheckWKB(t, got, g)
-			CheckGeoJSON(t, got, g)
-			CheckIsEmpty(t, got, g)
-			CheckDimension(t, got, g)
-			CheckEnvelope(t, got, g)
-			CheckIsSimple(t, got, g)
-			CheckBoundary(t, got, g)
-			CheckConvexHull(t, got, g)
-			CheckIsValid(t, got, g)
-			CheckIsRing(t, got, g)
-			CheckLength(t, got, g)
-			CheckArea(t, got, g)
-			CheckCentroid(t, got, g)
-			CheckReverse(t, got, g)
+			CheckWKT(t, want, g)
+			CheckWKB(t, want, g)
+			CheckGeoJSON(t, want, g)
+			CheckIsEmpty(t, want, g)
+			CheckDimension(t, want, g)
+			CheckEnvelope(t, want, g)
+			CheckIsSimple(t, want, g)
+			CheckBoundary(t, want, g)
+			CheckConvexHull(t, want, g)
+			CheckIsValid(t, want, g)
+			CheckIsRing(t, want, g)
+			CheckLength(t, want, g)
+			CheckArea(t, want, g)
+			CheckCentroid(t, want, g)
+			CheckReverse(t, want, g)
 		})
 	}
 	for i, g1 := range geoms {
 		for j, g2 := range geoms {
-			//fmt.Printf("binary %d/%d\n", (i*len(geoms) + j + 1), len(geoms)*len(geoms))
 			t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
 				CheckEqualsExact(t, pg, g1, g2)
 				CheckEquals(t, pg, g1, g2)

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -33,6 +33,7 @@ func TestFuzz(t *testing.T) {
 		fmt.Printf("index=%d WKT=%v\n", i, g.AsText())
 	}
 	for i, g := range geoms {
+		//fmt.Printf("unary %d/%d\n", i+1, len(geoms))
 		t.Run(fmt.Sprintf("geom_%d_", i), func(t *testing.T) {
 			got, err := PG{pg.db}.Unary(g)
 			if err != nil {
@@ -55,16 +56,17 @@ func TestFuzz(t *testing.T) {
 			CheckReverse(t, got, g)
 		})
 	}
-	for i, g1 := range geoms {
-		for j, g2 := range geoms {
-			t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
-				CheckEqualsExact(t, pg, g1, g2)
-				CheckEquals(t, pg, g1, g2)
-				CheckIntersects(t, pg, g1, g2)
-				CheckIntersection(t, pg, g1, g2)
-			})
-		}
-	}
+	//for i, g1 := range geoms {
+	//	for j, g2 := range geoms {
+	//		//fmt.Printf("binary %d/%d\n", (i*len(geoms) + j + 1), len(geoms)*len(geoms))
+	//		t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
+	//			CheckEqualsExact(t, pg, g1, g2)
+	//			CheckEquals(t, pg, g1, g2)
+	//			CheckIntersects(t, pg, g1, g2)
+	//			CheckIntersection(t, pg, g1, g2)
+	//		})
+	//	}
+	//}
 
 }
 

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -56,17 +56,17 @@ func TestFuzz(t *testing.T) {
 			CheckReverse(t, got, g)
 		})
 	}
-	//for i, g1 := range geoms {
-	//	for j, g2 := range geoms {
-	//		//fmt.Printf("binary %d/%d\n", (i*len(geoms) + j + 1), len(geoms)*len(geoms))
-	//		t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
-	//			CheckEqualsExact(t, pg, g1, g2)
-	//			CheckEquals(t, pg, g1, g2)
-	//			CheckIntersects(t, pg, g1, g2)
-	//			CheckIntersection(t, pg, g1, g2)
-	//		})
-	//	}
-	//}
+	for i, g1 := range geoms {
+		for j, g2 := range geoms {
+			//fmt.Printf("binary %d/%d\n", (i*len(geoms) + j + 1), len(geoms)*len(geoms))
+			t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
+				CheckEqualsExact(t, pg, g1, g2)
+				CheckEquals(t, pg, g1, g2)
+				CheckIntersects(t, pg, g1, g2)
+				CheckIntersection(t, pg, g1, g2)
+			})
+		}
+	}
 
 }
 

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -34,21 +34,25 @@ func TestFuzz(t *testing.T) {
 	}
 	for i, g := range geoms {
 		t.Run(fmt.Sprintf("geom_%d_", i), func(t *testing.T) {
-			CheckWKT(t, pg, g)
-			CheckWKB(t, pg, g)
-			CheckGeoJSON(t, pg, g)
-			CheckIsEmpty(t, pg, g)
-			CheckDimension(t, pg, g)
-			CheckEnvelope(t, pg, g)
-			CheckIsSimple(t, pg, g)
-			CheckBoundary(t, pg, g)
-			CheckConvexHull(t, pg, g)
-			CheckIsValid(t, pg, g)
-			CheckIsRing(t, pg, g)
-			CheckLength(t, pg, g)
-			CheckArea(t, pg, g)
-			CheckCentroid(t, pg, g)
-			CheckReverse(t, pg, g)
+			got, err := PG{pg.db}.Unary(g)
+			if err != nil {
+				t.Fatalf("could not get result from postgis: %v", err)
+			}
+			CheckWKT(t, got, g)
+			CheckWKB(t, got, g)
+			CheckGeoJSON(t, got, g)
+			CheckIsEmpty(t, got, g)
+			CheckDimension(t, got, g)
+			CheckEnvelope(t, got, g)
+			CheckIsSimple(t, got, g)
+			CheckBoundary(t, got, g)
+			CheckConvexHull(t, got, g)
+			CheckIsValid(t, got, g)
+			CheckIsRing(t, got, g)
+			CheckLength(t, got, g)
+			CheckArea(t, got, g)
+			CheckCentroid(t, got, g)
+			CheckReverse(t, got, g)
 		})
 	}
 	for i, g1 := range geoms {

--- a/fuzztests/pg.go
+++ b/fuzztests/pg.go
@@ -73,8 +73,9 @@ func (p PG) Unary(g geom.Geometry) (UnaryResult, error) {
 		ST_AsBinary(ST_ConvexHull(ST_GeomFromWKB($1))),
 		ST_IsValid(ST_GeomFromWKB($1)),
 
+		-- IsRing only defined for LineStrings.
 		CASE
-			WHEN ST_GeometryType(ST_GeomFromWKB($1)) = 'ST_LineString'
+			WHEN ST_GeometryType(ST_GeomFromWKB($1)) != 'ST_LineString'
 			THEN NULL
 			ELSE ST_IsRing(ST_GeomFromWKB($1))
 		END,

--- a/fuzztests/pg.go
+++ b/fuzztests/pg.go
@@ -6,7 +6,7 @@ import (
 	"github.com/peterstace/simplefeatures/geom"
 )
 
-type PG struct {
+type BatchPostGIS struct {
 	db *sql.DB
 }
 
@@ -28,7 +28,7 @@ type UnaryResult struct {
 	Reverse    geom.Geometry
 }
 
-func (p PG) Unary(g geom.Geometry) (UnaryResult, error) {
+func (p BatchPostGIS) Unary(g geom.Geometry) (UnaryResult, error) {
 	var result UnaryResult
 	err := p.db.QueryRow(`
 		SELECT

--- a/fuzztests/pg.go
+++ b/fuzztests/pg.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"database/sql"
+
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+type PG struct {
+	db *sql.DB
+}
+
+type UnaryResult struct {
+	AsText     string
+	AsBinary   []byte
+	AsGeoJSON  []byte
+	IsEmpty    bool
+	Dimension  int
+	Envelope   geom.Geometry
+	IsSimple   bool
+	Boundary   geom.Geometry
+	ConvexHull geom.Geometry
+	IsValid    bool
+	IsRing     bool
+	Length     float64
+	Area       float64
+	Cetroid    geom.Geometry
+	Reverse    geom.Geometry
+}
+
+func (p PG) Unary(g geom.Geometry) (UnaryResult, error) {
+	var result UnaryResult
+	err := p.db.QueryRow(`
+		SELECT
+		ST_AsText(ST_GeomFromWKB($1)),
+		ST_AsBinary(ST_GeomFromWKB($1)),
+		ST_AsGeoJSON(ST_GeomFromWKB($1)),
+		ST_IsEmpty(ST_GeomFromWKB($1)),
+		ST_Dimension(ST_GeomFromWKB($1)),
+		ST_AsBinary(ST_Envelope(ST_GeomFromWKB($1))),
+		ST_IsSimple(ST_GeomFromWKB($1)),
+		ST_AsBinary(ST_Boundary(ST_GeomFromWKB($1))),
+		ST_AsBinary(ST_ConvexHull(ST_GeomFromWKB($1))),
+		ST_IsValid(ST_GeomFromWKB($1)),
+		ST_GeometryType(ST_GeomFromWKB($1)) = 'ST_LineString' AND ST_IsRing(ST_GeomFromWKB($1)), -- ST_IsRing returns an error whenever it gets anything other than an ST_LineString
+		ST_Length(ST_GeomFromWKB($1)),
+		ST_Area(ST_GeomFromWKB($1)),
+		ST_AsBinary(ST_Centroid(ST_GeomFromWKB($1))),
+		ST_AsBinary(ST_Reverse(ST_GeomFromWKB($1)))
+		`, g,
+	).Scan(
+		&result.AsText,
+		&result.AsBinary,
+		&result.AsGeoJSON,
+		&result.IsEmpty,
+		&result.Dimension,
+		&result.Envelope,
+		&result.IsSimple,
+		&result.Boundary,
+		&result.ConvexHull,
+		&result.IsValid,
+		&result.IsRing,
+		&result.Length,
+		&result.Area,
+		&result.Cetroid,
+		&result.Reverse,
+	)
+	return result, err
+}

--- a/geom/type_null_geometry.go
+++ b/geom/type_null_geometry.go
@@ -1,0 +1,29 @@
+package geom
+
+import "database/sql/driver"
+
+// NullGeometry represents a Geometry that may be NULL. It implements the
+// database/sql.Scanner interface, so may be used as a scan destination.
+type NullGeometry struct {
+	Geometry Geometry
+	Valid    bool // Valid is true iff Geometry is not NULL
+}
+
+// Scan implements the the database/sql.Scanner interface.
+func (ng *NullGeometry) Scan(value interface{}) error {
+	if value == nil {
+		ng.Geometry = Geometry{}
+		ng.Valid = false
+		return nil
+	}
+	ng.Valid = true
+	return ng.Geometry.Scan(value)
+}
+
+// Value implements the database/sql.Valuer interface.
+func (ng NullGeometry) Value() (driver.Value, error) {
+	if !ng.Valid {
+		return nil, nil
+	}
+	return ng.Geometry.Value()
+}

--- a/geom/type_null_geometry.go
+++ b/geom/type_null_geometry.go
@@ -3,7 +3,8 @@ package geom
 import "database/sql/driver"
 
 // NullGeometry represents a Geometry that may be NULL. It implements the
-// database/sql.Scanner interface, so may be used as a scan destination.
+// database/sql.Scanner and database/sql.Valuer interfaces, so may be used as a
+// scan destination or query argument in SQL queries.
 type NullGeometry struct {
 	Geometry Geometry
 	Valid    bool // Valid is true iff Geometry is not NULL


### PR DESCRIPTION
- Adds a `NullGeometry` type, which can be used as a scan target that might be `NULL`.
- Batches together calls to PostGIS to increase speed of fuzz tests (will be used later for procedurally generated inputs).