### PR TITLE
Change the behaviour of Empty checking in Reverse for GeometryCollection

### DIFF
--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -137,7 +137,7 @@ func CheckWKT(t *testing.T, want UnaryResult, g geom.Geometry) {
 
 func CheckWKB(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckWKB", func(t *testing.T) {
-		if g.IsEmptySet() && g.AsText() == "POINT EMPTY" {
+		if containsEmptyPoint(g) {
 			// Empty point WKB use NaN as part of their representation.
 			// Go's math.NaN() and Postgis use slightly different (but
 			// compatible) representations of NaN.
@@ -161,6 +161,20 @@ func CheckWKB(t *testing.T, want UnaryResult, g geom.Geometry) {
 			t.Error("mismatch")
 		}
 	})
+}
+
+func containsEmptyPoint(g geom.Geometry) bool {
+	if g.IsEmptySet() && g.AsText() == "POINT EMPTY" {
+		return true
+	}
+	if !g.IsGeometryCollection() {
+		return false
+	}
+	gc := g.AsGeometryCollection()
+	for i := 0; i < gc.NumGeometries(); i++ {
+		return containsEmptyPoint(gc.GeometryN(i))
+	}
+	return false
 }
 
 func CheckGeoJSON(t *testing.T, want UnaryResult, g geom.Geometry) {

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -705,6 +705,40 @@ func TestReverse(t *testing.T) {
 				POLYGON((0 0,0 1,1 0,0 0))
 			)`,
 		},
+		{
+			`GEOMETRYCOLLECTION(
+				POINT(1 2),
+				POINT EMPTY,
+				LINESTRING(1 2,3 4),
+				GEOMETRYCOLLECTION(
+					POINT EMPTY,
+					LINESTRING(5 6,7 8),
+					GEOMETRYCOLLECTION(POINT EMPTY, POINT(5 6)),
+					POINT(3 4)
+				),
+				GEOMETRYCOLLECTION(
+					GEOMETRYCOLLECTION(POINT(9 10), POINT EMPTY),
+					POINT(11 12),
+					POINT EMPTY
+				)
+			) `,
+			`GEOMETRYCOLLECTION(
+				POINT(1 2),
+				POINT EMPTY,
+				LINESTRING(3 4,1 2),
+				GEOMETRYCOLLECTION(
+					POINT EMPTY,
+					LINESTRING(7 8,5 6),
+					GEOMETRYCOLLECTION(POINT EMPTY,POINT(5 6)),
+					POINT(3 4)
+				),
+				GEOMETRYCOLLECTION(
+					GEOMETRYCOLLECTION(POINT(9 10), POINT EMPTY),
+					POINT(11 12),
+					POINT EMPTY
+				)
+			)`,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			want := geomFromWKT(t, tt.boundary)

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -199,15 +199,17 @@ func (c GeometryCollection) IsValid() bool {
 	return all
 }
 
-// Reverse in the case of GeometryCollection reverses each component and
-// also returns them in the original order. It also omits empty components.
+// Reverse in the case of GeometryCollection reverses each component and also
+// returns them in the original order. As a special case, if the input
+// GeometryCollection has no elements or only contains empty elements, then the
+// returned GeometryCollection doesn't contain any elements.
 func (c GeometryCollection) Reverse() GeometryCollection {
+	if c.IsEmpty() {
+		return NewGeometryCollection(nil)
+	}
 	var geoms []Geometry
 	for n := 0; n < c.NumGeometries(); n++ {
 		rev := c.GeometryN(n).Reverse()
-		if rev.IsEmpty() {
-			continue // Omit empty sub-geometries.
-		}
 		geoms = append(geoms, rev)
 	}
 	return NewGeometryCollection(geoms)


### PR DESCRIPTION
This is to match the behaviour of PostGIS.

I noticed this while adding some additional test cases as part of an unrelated change (the fuzz checker noticed that the behaviour didn't match).