### PR TITLE
Make MultiLineString's IsSimple match PostGIS and libgeos

### DIFF
--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -236,25 +236,6 @@ func CheckIsSimple(t *testing.T, want UnaryResult, g geom.Geometry) {
 		if !want.IsSimple.Valid {
 			return
 		}
-
-		// PostGIS doesn't treat MultiLineStrings containing duplicated
-		// LineStrings as non-simple, e.g. MULTILINESTRING((0 0,1 1),(0 0,1
-		// 1)). This doesn't seem like correct behaviour to me. It must be
-		// deduplicating the LineStrings before checking simplicity. This
-		// library doesn't do that, so skip any LineStrings that contain
-		// duplicates.
-		if g.IsMultiLineString() {
-			mls := g.AsMultiLineString()
-			n := mls.NumLineStrings()
-			for i := 0; i < n; i++ {
-				for j := 0; j < n; j++ {
-					if mls.LineStringN(i).EqualsExact(mls.LineStringN(j).AsGeometry()) {
-						return
-					}
-				}
-			}
-		}
-
 		want := want.IsSimple.Bool // want.IsSimple.Valid already checked
 		if got != want {
 			t.Logf("got:  %v", got)

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -155,9 +155,20 @@ func TestIsSimple(t *testing.T) {
 		{"MULTILINESTRING((0 0,1 1,2 2),(0 2,1 1,2 0))", false},
 		{"MULTILINESTRING((0 0,2 1,4 2),(4 2,2 3,0 4))", true},
 		{"MULTILINESTRING((0 0,2 0,4 0),(2 0,2 1))", false},
-		{"MULTILINESTRING((0 0,0 1,1 1),(0 1,0 0,1 0))", false}, // reproduced a bug
-		{"MULTILINESTRING((0 0,1 0),(0 1,1 1))", true},          // reproduced a bug
-		{"MULTILINESTRING((1 1,2 2),(1 1,2 2))", false},
+
+		// Cases for reproducing bugs.
+		{"MULTILINESTRING((0 0,0 1,1 1),(0 1,0 0,1 0))", false},
+		{"MULTILINESTRING((0 0,1 0),(0 1,1 1))", true},
+		{"MULTILINESTRING((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))", true},
+		{"MULTILINESTRING((1 1,1 0,0 0),(1 1,0 1,0 0))", true},
+
+		// Cases for behaviour around duplicated lines. These cases are to
+		// match PostGIS and libgeos behaviour (the OGC spec is unclear about
+		// what the behaviour should be).
+		{"MULTILINESTRING((1 1,2 2),(1 1,2 2))", true},
+		{"MULTILINESTRING((1 1,2 2),(2 2,1 1))", true},
+		{"MULTILINESTRING((1 1,2 2),(1 1,2 2,3 3))", false},
+		{"MULTILINESTRING((1 1,2 2),(2 2,1 1,3 1))", false},
 
 		{"MULTIPOLYGON(((0 0,1 0,0 1,0 0)))", true},
 	} {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -86,8 +86,8 @@ func (m MultiLineString) AppendWKT(dst []byte) []byte {
 //
 // 1. Each element (a LineString) is simple.
 //
-// 2. The intersection between any two elements occurs at points that are on
-// the boundaries of both elements.
+// 2. The intersection between any two distinct elements occurs at points that
+// are on the boundaries of both elements.
 func (m MultiLineString) IsSimple() bool {
 	for _, ls := range m.lines {
 		if !ls.IsSimple() {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -96,9 +96,27 @@ func (m MultiLineString) IsSimple() bool {
 	}
 	for i := 0; i < len(m.lines); i++ {
 		for j := i + 1; j < len(m.lines); j++ {
-			inter := mustIntersection(m.lines[i].AsGeometry(), m.lines[j].AsGeometry())
-			bound := mustIntersection(m.lines[i].Boundary().AsGeometry(), m.lines[j].Boundary().AsGeometry())
-			if !inter.EqualsExact(mustIntersection(inter, bound)) {
+			// Ignore any intersections if the lines are *exactly* the same
+			// (ignoring order). This is to match PostGIS and libgeos
+			// behaviour. The OGC spec is ambiguous around this case, so it's
+			// just easier to follow other implementations for better
+			// interoperability.
+			if m.lines[i].EqualsExact(m.lines[j].AsGeometry(), IgnoreOrder) {
+				continue
+			}
+
+			inter := mustIntersection(
+				m.lines[i].AsGeometry(),
+				m.lines[j].AsGeometry(),
+			)
+			if inter.IsEmpty() {
+				continue
+			}
+			bound := mustIntersection(
+				m.lines[i].Boundary().AsGeometry(),
+				m.lines[j].Boundary().AsGeometry(),
+			)
+			if !inter.EqualsExact(mustIntersection(inter, bound), IgnoreOrder) {
 				return false
 			}
 		}


### PR DESCRIPTION
The case where there is a difference is when the multilinestring contains duplicated elements. The original implementation would mark these multilinestrings as NOT simple, since the two duplicated elements (trivially) intersect with each other at points other than the boundary of each linestring.

This isn't the behaviour of PostGIS and libgeos though. They ignore intersections during the issimple check between duplicated elements. This seems reasonable enough to me, and the OGC spec isn't 100% clear on the expected behaviour.