### PR TITLE
Move test helpers into separate package

### DIFF
--- a/geom/accessor_test.go
+++ b/geom/accessor_test.go
@@ -4,30 +4,31 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestPointAccessorNonEmpty(t *testing.T) {
-	xy, ok := geomFromWKT(t, "POINT(1 2)").AsPoint().XY()
-	expectBoolEq(t, ok, true)
-	expectXYEq(t, xy, XY{1, 2})
+	xy, ok := GeomFromWKT(t, "POINT(1 2)").AsPoint().XY()
+	ExpectBoolEq(t, ok, true)
+	ExpectXYEq(t, xy, XY{1, 2})
 }
 
 func TestPointAccessorEmpty(t *testing.T) {
-	_, ok := geomFromWKT(t, "POINT EMPTY").AsPoint().XY()
-	expectBoolEq(t, ok, false)
+	_, ok := GeomFromWKT(t, "POINT EMPTY").AsPoint().XY()
+	ExpectBoolEq(t, ok, false)
 }
 
 func TestLineAccessor(t *testing.T) {
-	line := geomFromWKT(t, "LINESTRING(1 2,3 4)").AsLine()
+	line := GeomFromWKT(t, "LINESTRING(1 2,3 4)").AsLine()
 	t.Run("start", func(t *testing.T) {
 		got := line.StartPoint()
 		want := Coordinates{XY{1, 2}}
-		expectCoordsEq(t, got, want)
+		ExpectCoordsEq(t, got, want)
 	})
 	t.Run("end", func(t *testing.T) {
 		got := line.EndPoint()
 		want := Coordinates{XY{3, 4}}
-		expectCoordsEq(t, got, want)
+		ExpectCoordsEq(t, got, want)
 	})
 	t.Run("num points", func(t *testing.T) {
 		if line.NumPoints() != 2 {
@@ -37,193 +38,193 @@ func TestLineAccessor(t *testing.T) {
 	t.Run("point 0", func(t *testing.T) {
 		got := line.PointN(0)
 		want := Coordinates{XY{1, 2}}
-		expectCoordsEq(t, got, want)
+		ExpectCoordsEq(t, got, want)
 	})
 	t.Run("point 1", func(t *testing.T) {
 		got := line.PointN(1)
 		want := Coordinates{XY{3, 4}}
-		expectCoordsEq(t, got, want)
+		ExpectCoordsEq(t, got, want)
 	})
 	t.Run("point 2", func(t *testing.T) {
-		expectPanics(t, func() {
+		ExpectPanics(t, func() {
 			line.PointN(2)
 		})
 	})
 	t.Run("point -1", func(t *testing.T) {
-		expectPanics(t, func() {
+		ExpectPanics(t, func() {
 			line.PointN(-1)
 		})
 	})
 }
 
 func TestLineStringAccessor(t *testing.T) {
-	ls := geomFromWKT(t, "LINESTRING(1 2,3 4,5 6)").AsLineString()
+	ls := GeomFromWKT(t, "LINESTRING(1 2,3 4,5 6)").AsLineString()
 	pt12 := Coordinates{XY{1, 2}}
 	pt34 := Coordinates{XY{3, 4}}
 	pt56 := Coordinates{XY{5, 6}}
 
 	t.Run("start", func(t *testing.T) {
-		expectGeomEq(t, ls.StartPoint().AsGeometry(), NewPointC(pt12).AsGeometry())
+		ExpectGeomEq(t, ls.StartPoint().AsGeometry(), NewPointC(pt12).AsGeometry())
 	})
 	t.Run("end", func(t *testing.T) {
-		expectGeomEq(t, ls.EndPoint().AsGeometry(), NewPointC(pt56).AsGeometry())
+		ExpectGeomEq(t, ls.EndPoint().AsGeometry(), NewPointC(pt56).AsGeometry())
 	})
 	t.Run("num points", func(t *testing.T) {
-		expectIntEq(t, ls.NumPoints(), 3)
+		ExpectIntEq(t, ls.NumPoints(), 3)
 	})
 	t.Run("point n", func(t *testing.T) {
-		expectPanics(t, func() { ls.PointN(-1) })
-		expectCoordsEq(t, ls.PointN(0), pt12)
-		expectCoordsEq(t, ls.PointN(1), pt34)
-		expectCoordsEq(t, ls.PointN(2), pt56)
-		expectPanics(t, func() { ls.PointN(3) })
+		ExpectPanics(t, func() { ls.PointN(-1) })
+		ExpectCoordsEq(t, ls.PointN(0), pt12)
+		ExpectCoordsEq(t, ls.PointN(1), pt34)
+		ExpectCoordsEq(t, ls.PointN(2), pt56)
+		ExpectPanics(t, func() { ls.PointN(3) })
 	})
 	t.Run("num lines", func(t *testing.T) {
-		expectIntEq(t, ls.NumLines(), 2)
+		ExpectIntEq(t, ls.NumLines(), 2)
 	})
 	t.Run("line n", func(t *testing.T) {
-		expectPanics(t, func() { ls.LineN(-1) })
-		expectGeomEq(t,
+		ExpectPanics(t, func() { ls.LineN(-1) })
+		ExpectGeomEq(t,
 			ls.LineN(0).AsGeometry(),
-			geomFromWKT(t, "LINESTRING(1 2,3 4)"),
+			GeomFromWKT(t, "LINESTRING(1 2,3 4)"),
 		)
-		expectGeomEq(t,
+		ExpectGeomEq(t,
 			ls.LineN(1).AsGeometry(),
-			geomFromWKT(t, "LINESTRING(3 4,5 6)"),
+			GeomFromWKT(t, "LINESTRING(3 4,5 6)"),
 		)
-		expectPanics(t, func() { ls.LineN(2) })
+		ExpectPanics(t, func() { ls.LineN(2) })
 	})
 }
 
 func TestLineStringEmptyAccessor(t *testing.T) {
-	ls := geomFromWKT(t, "LINESTRING EMPTY").AsLineString()
-	emptyPoint := geomFromWKT(t, "POINT EMPTY")
+	ls := GeomFromWKT(t, "LINESTRING EMPTY").AsLineString()
+	emptyPoint := GeomFromWKT(t, "POINT EMPTY")
 
 	t.Run("start", func(t *testing.T) {
-		expectGeomEq(t, ls.StartPoint().AsGeometry(), emptyPoint)
+		ExpectGeomEq(t, ls.StartPoint().AsGeometry(), emptyPoint)
 	})
 	t.Run("end", func(t *testing.T) {
-		expectGeomEq(t, ls.EndPoint().AsGeometry(), emptyPoint)
+		ExpectGeomEq(t, ls.EndPoint().AsGeometry(), emptyPoint)
 	})
 	t.Run("num points", func(t *testing.T) {
-		expectIntEq(t, ls.NumPoints(), 0)
+		ExpectIntEq(t, ls.NumPoints(), 0)
 	})
 	t.Run("point n", func(t *testing.T) {
-		expectPanics(t, func() { ls.PointN(-1) })
-		expectPanics(t, func() { ls.PointN(0) })
-		expectPanics(t, func() { ls.PointN(1) })
+		ExpectPanics(t, func() { ls.PointN(-1) })
+		ExpectPanics(t, func() { ls.PointN(0) })
+		ExpectPanics(t, func() { ls.PointN(1) })
 	})
 	t.Run("num lines", func(t *testing.T) {
-		expectIntEq(t, ls.NumLines(), 0)
+		ExpectIntEq(t, ls.NumLines(), 0)
 	})
 	t.Run("line n", func(t *testing.T) {
-		expectPanics(t, func() { ls.LineN(-1) })
-		expectPanics(t, func() { ls.LineN(0) })
-		expectPanics(t, func() { ls.LineN(1) })
+		ExpectPanics(t, func() { ls.LineN(-1) })
+		ExpectPanics(t, func() { ls.LineN(0) })
+		ExpectPanics(t, func() { ls.LineN(1) })
 	})
 }
 
 func TestLineStringAccessorWithDuplicates(t *testing.T) {
-	ls := geomFromWKT(t, "LINESTRING(1 2,3 4,3 4,5 6)").AsLineString()
+	ls := GeomFromWKT(t, "LINESTRING(1 2,3 4,3 4,5 6)").AsLineString()
 	pt12 := Coordinates{XY{1, 2}}
 	pt34 := Coordinates{XY{3, 4}}
 	pt56 := Coordinates{XY{5, 6}}
 
 	t.Run("num points", func(t *testing.T) {
-		expectIntEq(t, ls.NumPoints(), 4)
+		ExpectIntEq(t, ls.NumPoints(), 4)
 	})
 	t.Run("point n", func(t *testing.T) {
-		expectPanics(t, func() { ls.PointN(-1) })
-		expectCoordsEq(t, ls.PointN(0), pt12)
-		expectCoordsEq(t, ls.PointN(1), pt34)
-		expectCoordsEq(t, ls.PointN(2), pt34)
-		expectCoordsEq(t, ls.PointN(3), pt56)
-		expectPanics(t, func() { ls.PointN(4) })
+		ExpectPanics(t, func() { ls.PointN(-1) })
+		ExpectCoordsEq(t, ls.PointN(0), pt12)
+		ExpectCoordsEq(t, ls.PointN(1), pt34)
+		ExpectCoordsEq(t, ls.PointN(2), pt34)
+		ExpectCoordsEq(t, ls.PointN(3), pt56)
+		ExpectPanics(t, func() { ls.PointN(4) })
 	})
 }
 
 func TestLineStringAccessorWithMoreDuplicates(t *testing.T) {
-	ls := geomFromWKT(t, "LINESTRING(1 2,1 2,3 4,3 4,3 4,5 6,5 6)").AsLineString()
+	ls := GeomFromWKT(t, "LINESTRING(1 2,1 2,3 4,3 4,3 4,5 6,5 6)").AsLineString()
 	pt12 := Coordinates{XY{1, 2}}
 	pt34 := Coordinates{XY{3, 4}}
 	pt56 := Coordinates{XY{5, 6}}
 
 	t.Run("num points", func(t *testing.T) {
-		expectIntEq(t, ls.NumPoints(), 7)
+		ExpectIntEq(t, ls.NumPoints(), 7)
 	})
 	t.Run("point n", func(t *testing.T) {
-		expectPanics(t, func() { ls.PointN(-1) })
-		expectCoordsEq(t, ls.PointN(0), pt12)
-		expectCoordsEq(t, ls.PointN(1), pt12)
-		expectCoordsEq(t, ls.PointN(2), pt34)
-		expectCoordsEq(t, ls.PointN(3), pt34)
-		expectCoordsEq(t, ls.PointN(4), pt34)
-		expectCoordsEq(t, ls.PointN(5), pt56)
-		expectCoordsEq(t, ls.PointN(6), pt56)
-		expectPanics(t, func() { ls.PointN(7) })
+		ExpectPanics(t, func() { ls.PointN(-1) })
+		ExpectCoordsEq(t, ls.PointN(0), pt12)
+		ExpectCoordsEq(t, ls.PointN(1), pt12)
+		ExpectCoordsEq(t, ls.PointN(2), pt34)
+		ExpectCoordsEq(t, ls.PointN(3), pt34)
+		ExpectCoordsEq(t, ls.PointN(4), pt34)
+		ExpectCoordsEq(t, ls.PointN(5), pt56)
+		ExpectCoordsEq(t, ls.PointN(6), pt56)
+		ExpectPanics(t, func() { ls.PointN(7) })
 	})
 }
 
 func TestPolygonAccessor(t *testing.T) {
-	poly := geomFromWKT(t, "POLYGON((0 0,5 0,5 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1),(3 1,4 1,4 2,3 2,3 1))").AsPolygon()
-	outer := geomFromWKT(t, "LINESTRING(0 0,5 0,5 3,0 3,0 0)")
-	inner0 := geomFromWKT(t, "LINESTRING(1 1,2 1,2 2,1 2,1 1)")
-	inner1 := geomFromWKT(t, "LINESTRING(3 1,4 1,4 2,3 2,3 1)")
+	poly := GeomFromWKT(t, "POLYGON((0 0,5 0,5 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1),(3 1,4 1,4 2,3 2,3 1))").AsPolygon()
+	outer := GeomFromWKT(t, "LINESTRING(0 0,5 0,5 3,0 3,0 0)")
+	inner0 := GeomFromWKT(t, "LINESTRING(1 1,2 1,2 2,1 2,1 1)")
+	inner1 := GeomFromWKT(t, "LINESTRING(3 1,4 1,4 2,3 2,3 1)")
 
-	expectGeomEq(t, poly.ExteriorRing().AsGeometry(), outer)
-	expectIntEq(t, poly.NumInteriorRings(), 2)
-	expectPanics(t, func() { poly.InteriorRingN(-1) })
-	expectGeomEq(t, poly.InteriorRingN(0).AsGeometry(), inner0)
-	expectGeomEq(t, poly.InteriorRingN(1).AsGeometry(), inner1)
-	expectPanics(t, func() { poly.InteriorRingN(2) })
+	ExpectGeomEq(t, poly.ExteriorRing().AsGeometry(), outer)
+	ExpectIntEq(t, poly.NumInteriorRings(), 2)
+	ExpectPanics(t, func() { poly.InteriorRingN(-1) })
+	ExpectGeomEq(t, poly.InteriorRingN(0).AsGeometry(), inner0)
+	ExpectGeomEq(t, poly.InteriorRingN(1).AsGeometry(), inner1)
+	ExpectPanics(t, func() { poly.InteriorRingN(2) })
 }
 
 func TestMultiPointAccessor(t *testing.T) {
-	mp := geomFromWKT(t, "MULTIPOINT((4 5),(2 3),(8 7))").AsMultiPoint()
-	pt0 := geomFromWKT(t, "POINT(4 5)")
-	pt1 := geomFromWKT(t, "POINT(2 3)")
-	pt2 := geomFromWKT(t, "POINT(8 7)")
+	mp := GeomFromWKT(t, "MULTIPOINT((4 5),(2 3),(8 7))").AsMultiPoint()
+	pt0 := GeomFromWKT(t, "POINT(4 5)")
+	pt1 := GeomFromWKT(t, "POINT(2 3)")
+	pt2 := GeomFromWKT(t, "POINT(8 7)")
 
-	expectIntEq(t, mp.NumPoints(), 3)
-	expectPanics(t, func() { mp.PointN(-1) })
-	expectGeomEq(t, mp.PointN(0).AsGeometry(), pt0)
-	expectGeomEq(t, mp.PointN(1).AsGeometry(), pt1)
-	expectGeomEq(t, mp.PointN(2).AsGeometry(), pt2)
-	expectPanics(t, func() { mp.PointN(3) })
+	ExpectIntEq(t, mp.NumPoints(), 3)
+	ExpectPanics(t, func() { mp.PointN(-1) })
+	ExpectGeomEq(t, mp.PointN(0).AsGeometry(), pt0)
+	ExpectGeomEq(t, mp.PointN(1).AsGeometry(), pt1)
+	ExpectGeomEq(t, mp.PointN(2).AsGeometry(), pt2)
+	ExpectPanics(t, func() { mp.PointN(3) })
 }
 
 func TestMultiLineStringAccessors(t *testing.T) {
-	mls := geomFromWKT(t, "MULTILINESTRING((1 2,3 4,5 6),(7 8,9 10,11 12))").AsMultiLineString()
-	ls0 := geomFromWKT(t, "LINESTRING(1 2,3 4,5 6)")
-	ls1 := geomFromWKT(t, "LINESTRING(7 8,9 10,11 12)")
+	mls := GeomFromWKT(t, "MULTILINESTRING((1 2,3 4,5 6),(7 8,9 10,11 12))").AsMultiLineString()
+	ls0 := GeomFromWKT(t, "LINESTRING(1 2,3 4,5 6)")
+	ls1 := GeomFromWKT(t, "LINESTRING(7 8,9 10,11 12)")
 
-	expectIntEq(t, mls.NumLineStrings(), 2)
-	expectPanics(t, func() { mls.LineStringN(-1) })
-	expectGeomEq(t, mls.LineStringN(0).AsGeometry(), ls0)
-	expectGeomEq(t, mls.LineStringN(1).AsGeometry(), ls1)
-	expectPanics(t, func() { mls.LineStringN(2) })
+	ExpectIntEq(t, mls.NumLineStrings(), 2)
+	ExpectPanics(t, func() { mls.LineStringN(-1) })
+	ExpectGeomEq(t, mls.LineStringN(0).AsGeometry(), ls0)
+	ExpectGeomEq(t, mls.LineStringN(1).AsGeometry(), ls1)
+	ExpectPanics(t, func() { mls.LineStringN(2) })
 }
 
 func TestMultiPolygonAccessors(t *testing.T) {
-	polys := geomFromWKT(t, "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((2 0,2 1,3 0,2 0)))").AsMultiPolygon()
-	poly0 := geomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))")
-	poly1 := geomFromWKT(t, "POLYGON((2 0,2 1,3 0,2 0))")
+	polys := GeomFromWKT(t, "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((2 0,2 1,3 0,2 0)))").AsMultiPolygon()
+	poly0 := GeomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))")
+	poly1 := GeomFromWKT(t, "POLYGON((2 0,2 1,3 0,2 0))")
 
-	expectIntEq(t, polys.NumPolygons(), 2)
-	expectPanics(t, func() { polys.PolygonN(-1) })
-	expectGeomEq(t, polys.PolygonN(0).AsGeometry(), poly0)
-	expectGeomEq(t, polys.PolygonN(1).AsGeometry(), poly1)
-	expectPanics(t, func() { polys.PolygonN(2) })
+	ExpectIntEq(t, polys.NumPolygons(), 2)
+	ExpectPanics(t, func() { polys.PolygonN(-1) })
+	ExpectGeomEq(t, polys.PolygonN(0).AsGeometry(), poly0)
+	ExpectGeomEq(t, polys.PolygonN(1).AsGeometry(), poly1)
+	ExpectPanics(t, func() { polys.PolygonN(2) })
 }
 
 func TestGeometryCollectionAccessors(t *testing.T) {
-	geoms := geomFromWKT(t, "GEOMETRYCOLLECTION(POLYGON((0 0,0 1,1 0,0 0)),POLYGON((2 0,2 1,3 0,2 0)))").AsGeometryCollection()
-	geom0 := geomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))")
-	geom1 := geomFromWKT(t, "POLYGON((2 0,2 1,3 0,2 0))")
+	geoms := GeomFromWKT(t, "GEOMETRYCOLLECTION(POLYGON((0 0,0 1,1 0,0 0)),POLYGON((2 0,2 1,3 0,2 0)))").AsGeometryCollection()
+	geom0 := GeomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))")
+	geom1 := GeomFromWKT(t, "POLYGON((2 0,2 1,3 0,2 0))")
 
-	expectIntEq(t, geoms.NumGeometries(), 2)
-	expectPanics(t, func() { geoms.GeometryN(-1) })
-	expectGeomEq(t, geoms.GeometryN(0), geom0)
-	expectGeomEq(t, geoms.GeometryN(1), geom1)
-	expectPanics(t, func() { geoms.GeometryN(2) })
+	ExpectIntEq(t, geoms.NumGeometries(), 2)
+	ExpectPanics(t, func() { geoms.GeometryN(-1) })
+	ExpectGeomEq(t, geoms.GeometryN(0), geom0)
+	ExpectGeomEq(t, geoms.GeometryN(1), geom1)
+	ExpectPanics(t, func() { geoms.GeometryN(2) })
 }

--- a/geom/alg_convex_hull_test.go
+++ b/geom/alg_convex_hull_test.go
@@ -3,6 +3,8 @@ package geom_test
 import (
 	"strconv"
 	"testing"
+
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestConvexHull(t *testing.T) {
@@ -191,8 +193,8 @@ func TestConvexHull(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Logf("input: %s", tt.input)
-			got := geomFromWKT(t, tt.input).ConvexHull()
-			expectGeomEq(t, got, geomFromWKT(t, tt.output))
+			got := GeomFromWKT(t, tt.input).ConvexHull()
+			ExpectGeomEq(t, got, GeomFromWKT(t, tt.output))
 		})
 	}
 }

--- a/geom/alg_equals_exact_test.go
+++ b/geom/alg_equals_exact_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestEqualsExact(t *testing.T) {
@@ -196,7 +197,7 @@ func TestEqualsExact(t *testing.T) {
 	t.Run("reflexive", func(t *testing.T) {
 		for key, wkt := range wkts {
 			t.Run(key, func(t *testing.T) {
-				g := geomFromWKT(t, wkt)
+				g := GeomFromWKT(t, wkt)
 				t.Run("no options", func(t *testing.T) {
 					if !g.EqualsExact(g) {
 						t.Logf("WKT: %v", wkt)
@@ -220,8 +221,8 @@ func TestEqualsExact(t *testing.T) {
 							break
 						}
 					}
-					gA := geomFromWKT(t, wkts[keyA])
-					gB := geomFromWKT(t, wkts[keyB])
+					gA := GeomFromWKT(t, wkts[keyA])
+					gB := GeomFromWKT(t, wkts[keyB])
 					got := gA.EqualsExact(gB, geom.Tolerance(0.125))
 					if got != want {
 						t.Logf("WKT A: %v", wkts[keyA])
@@ -246,8 +247,8 @@ func TestEqualsExact(t *testing.T) {
 							break
 						}
 					}
-					gA := geomFromWKT(t, wkts[keyA])
-					gB := geomFromWKT(t, wkts[keyB])
+					gA := GeomFromWKT(t, wkts[keyA])
+					gB := GeomFromWKT(t, wkts[keyB])
 					got := gA.EqualsExact(gB, geom.IgnoreOrder)
 					if got != want {
 						t.Logf("WKT A: %v", wkts[keyA])

--- a/geom/alg_intersection_test.go
+++ b/geom/alg_intersection_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestIntersection(t *testing.T) {
@@ -192,7 +193,7 @@ func TestIntersection(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
+				if !got.EqualsExact(GeomFromWKT(t, tt.out), IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in1, tt.in2, tt.out, got.AsText())
 				}
 
@@ -219,7 +220,7 @@ func TestIntersection(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
+				if !got.EqualsExact(GeomFromWKT(t, tt.out), IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in2, tt.in1, tt.out, got.AsText())
 				}
 

--- a/geom/alg_intersects_test.go
+++ b/geom/alg_intersects_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestIntersects(t *testing.T) {
@@ -382,8 +383,8 @@ func TestIntersects(t *testing.T) {
 					}
 				}
 			}
-			g1 := geomFromWKT(t, tt.in1)
-			g2 := geomFromWKT(t, tt.in2)
+			g1 := GeomFromWKT(t, tt.in1)
+			g2 := GeomFromWKT(t, tt.in2)
 			t.Run("fwd", runTest(g1, g2))
 			t.Run("rev", runTest(g2, g1))
 		})

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestIsEmptyDimension(t *testing.T) {
@@ -94,7 +95,7 @@ func TestEnvelope(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log("wkt:", tt.wkt)
-			g := geomFromWKT(t, tt.wkt)
+			g := GeomFromWKT(t, tt.wkt)
 			env, have := g.Envelope()
 			if !have {
 				t.Fatalf("expected to have envelope but didn't")
@@ -127,7 +128,7 @@ func TestNoEnvelope(t *testing.T) {
 		"GEOMETRYCOLLECTION(POINT EMPTY)",
 	} {
 		t.Run(wkt, func(t *testing.T) {
-			g := geomFromWKT(t, wkt)
+			g := GeomFromWKT(t, wkt)
 			if _, have := g.Envelope(); have {
 				t.Errorf("have envelope but expected not to")
 			}
@@ -193,7 +194,7 @@ func TestIsSimple(t *testing.T) {
 		{"MULTIPOLYGON(((0 0,1 0,0 1,0 0)))", true},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got, defined := geomFromWKT(t, tt.wkt).IsSimple()
+			got, defined := GeomFromWKT(t, tt.wkt).IsSimple()
 			if !defined {
 				t.Fatal("not defined")
 			}
@@ -206,8 +207,8 @@ func TestIsSimple(t *testing.T) {
 }
 
 func TestIsSimpleGeometryCollection(t *testing.T) {
-	_, defined := geomFromWKT(t, "GEOMETRYCOLLECTION(POINT(1 2))").IsSimple()
-	expectBoolEq(t, defined, false)
+	_, defined := GeomFromWKT(t, "GEOMETRYCOLLECTION(POINT(1 2))").IsSimple()
+	ExpectBoolEq(t, defined, false)
 }
 
 func TestBoundary(t *testing.T) {
@@ -305,9 +306,9 @@ func TestBoundary(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Logf("WKT: %v", tt.wkt)
-			want := geomFromWKT(t, tt.boundary)
-			got := geomFromWKT(t, tt.wkt).Boundary()
-			expectGeomEq(t, got, want)
+			want := GeomFromWKT(t, tt.boundary)
+			got := GeomFromWKT(t, tt.wkt).Boundary()
+			ExpectGeomEq(t, got, want)
 		})
 	}
 }
@@ -372,42 +373,42 @@ func TestCoordinates(t *testing.T) {
 	}
 	t.Run("Point", func(t *testing.T) {
 		cmp0dOpt(t,
-			geomFromWKT(t, "POINT(1 2)").AsPoint().Coordinates(),
+			GeomFromWKT(t, "POINT(1 2)").AsPoint().Coordinates(),
 			[]float64{1, 2},
 		)
 		cmp0dOpt(t,
-			geomFromWKT(t, "POINT EMPTY").AsPoint().Coordinates(),
+			GeomFromWKT(t, "POINT EMPTY").AsPoint().Coordinates(),
 			[]float64{},
 		)
 	})
 	t.Run("Line-LineString-MultiPoint", func(t *testing.T) {
 		cmp1d(t,
-			geomFromWKT(t, "LINESTRING(0 1,2 3)").AsLine().Coordinates(),
+			GeomFromWKT(t, "LINESTRING(0 1,2 3)").AsLine().Coordinates(),
 			[][2]float64{{0, 1}, {2, 3}},
 		)
 		cmp1d(t,
-			geomFromWKT(t, "LINESTRING(0 1,2 3,4 5)").AsLineString().Coordinates(),
+			GeomFromWKT(t, "LINESTRING(0 1,2 3,4 5)").AsLineString().Coordinates(),
 			[][2]float64{{0, 1}, {2, 3}, {4, 5}},
 		)
 		cmp1d(t,
-			geomFromWKT(t, "LINESTRING(1 5,5 2,5 2,4 9)").AsLineString().Coordinates(),
+			GeomFromWKT(t, "LINESTRING(1 5,5 2,5 2,4 9)").AsLineString().Coordinates(),
 			[][2]float64{{1, 5}, {5, 2}, {5, 2}, {4, 9}},
 		)
 		cmp1dOpt(t,
-			geomFromWKT(t, "MULTIPOINT(0 1,2 3,EMPTY,4 5)").AsMultiPoint().Coordinates(),
+			GeomFromWKT(t, "MULTIPOINT(0 1,2 3,EMPTY,4 5)").AsMultiPoint().Coordinates(),
 			[][]float64{{0, 1}, {2, 3}, {}, {4, 5}},
 		)
 	})
 	t.Run("Polygon-MultiLineString", func(t *testing.T) {
 		cmp2d(t,
-			geomFromWKT(t, "POLYGON((0 0,0 10,10 0,0 0),(2 2,2 7,7 2,2 2))").AsPolygon().Coordinates(),
+			GeomFromWKT(t, "POLYGON((0 0,0 10,10 0,0 0),(2 2,2 7,7 2,2 2))").AsPolygon().Coordinates(),
 			[][][2]float64{
 				{{0, 0}, {0, 10}, {10, 0}, {0, 0}},
 				{{2, 2}, {2, 7}, {7, 2}, {2, 2}},
 			},
 		)
 		cmp2d(t,
-			geomFromWKT(t, "MULTILINESTRING((0 0,0 10,10 0,0 0),(2 2,2 8,8 2,2 2))").AsMultiLineString().Coordinates(),
+			GeomFromWKT(t, "MULTILINESTRING((0 0,0 10,10 0,0 0),(2 2,2 8,8 2,2 2))").AsMultiLineString().Coordinates(),
 			[][][2]float64{
 				{{0, 0}, {0, 10}, {10, 0}, {0, 0}},
 				{{2, 2}, {2, 8}, {8, 2}, {2, 2}},
@@ -416,7 +417,7 @@ func TestCoordinates(t *testing.T) {
 	})
 	t.Run("MultiPolygon", func(t *testing.T) {
 		cmp3d(t,
-			geomFromWKT(t, `
+			GeomFromWKT(t, `
 				MULTIPOLYGON(
 					(
 						(0 0,0 10,10 0,0 0),
@@ -467,11 +468,11 @@ func TestTransformXY(t *testing.T) {
 		{"GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(1 2)))", "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(1.5 2)))"},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			g := geomFromWKT(t, tt.wktIn)
+			g := GeomFromWKT(t, tt.wktIn)
 			got, err := g.TransformXY(transform)
-			expectNoErr(t, err)
-			want := geomFromWKT(t, tt.wktOut)
-			expectGeomEq(t, got, want)
+			ExpectNoErr(t, err)
+			want := GeomFromWKT(t, tt.wktOut)
+			ExpectGeomEq(t, got, want)
 		})
 	}
 }
@@ -487,7 +488,7 @@ func TestIsRing(t *testing.T) {
 		{"LINESTRING(0 0,1 0,1 1,0 1)", false},     // not closed
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, tt.wkt).AsLineString().IsRing()
+			got := GeomFromWKT(t, tt.wkt).AsLineString().IsRing()
 			if got != tt.want {
 				t.Logf("WKT: %v", tt.wkt)
 				t.Errorf("got=%v want=%v", got, tt.want)
@@ -506,7 +507,7 @@ func TestIsClosed(t *testing.T) {
 		{"LINESTRING(0 0,1 0,1 1,0 1)", false},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, tt.wkt).AsLineString().IsClosed()
+			got := GeomFromWKT(t, tt.wkt).AsLineString().IsClosed()
 			if got != tt.want {
 				t.Logf("WKT: %v", tt.wkt)
 				t.Errorf("got=%v want=%v", got, tt.want)
@@ -542,7 +543,7 @@ func TestLength(t *testing.T) {
 		)`, 1 + math.Sqrt(5) + math.Sqrt(2) + math.Sqrt(5)},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, tt.wkt).Length()
+			got := GeomFromWKT(t, tt.wkt).Length()
 			if math.Abs(tt.want-got) > 1e-6 {
 				t.Errorf("got=%v want=%v", got, tt.want)
 			}
@@ -583,7 +584,7 @@ func TestArea(t *testing.T) {
 		))`, 8.0},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, tt.wkt).Area()
+			got := GeomFromWKT(t, tt.wkt).Area()
 			if got != tt.want {
 				t.Errorf("got=%v want=%v", got, tt.want)
 			}
@@ -631,7 +632,7 @@ func TestSignedArea(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("input: %s", tc.input)
-			geom := geomFromWKT(t, tc.input)
+			geom := GeomFromWKT(t, tc.input)
 			var got float64
 			switch {
 			case geom.IsPolygon():
@@ -696,8 +697,8 @@ func TestCentroid(t *testing.T) {
 		{"GEOMETRYCOLLECTION(POINT EMPTY,POINT(5 5))", "POINT(5 5)"},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, tt.input).Centroid()
-			want := geomFromWKT(t, tt.output)
+			got := GeomFromWKT(t, tt.input).Centroid()
+			want := GeomFromWKT(t, tt.output)
 			if !want.EqualsExact(got.AsGeometry(), Tolerance(0.00000001)) {
 				t.Log(tt.input)
 				t.Errorf("got=%v want=%v", got.AsText(), tt.output)
@@ -707,24 +708,24 @@ func TestCentroid(t *testing.T) {
 }
 
 func TestLineStringToMultiLineString(t *testing.T) {
-	ls := geomFromWKT(t, "LINESTRING(1 2,3 4,5 6)").AsLineString()
+	ls := GeomFromWKT(t, "LINESTRING(1 2,3 4,5 6)").AsLineString()
 	got := ls.AsMultiLineString()
-	want := geomFromWKT(t, "MULTILINESTRING((1 2,3 4,5 6))")
+	want := GeomFromWKT(t, "MULTILINESTRING((1 2,3 4,5 6))")
 	if !got.EqualsExact(want) {
 		t.Errorf("want=%v got=%v", want, got)
 	}
 }
 
 func TestLineToLineString(t *testing.T) {
-	ln := geomFromWKT(t, "LINESTRING(1 2,3 4)").AsLine()
+	ln := GeomFromWKT(t, "LINESTRING(1 2,3 4)").AsLine()
 	got := ln.AsLineString()
-	expectIntEq(t, got.NumPoints(), 2)
-	expectGeomEq(t, got.StartPoint().AsGeometry(), geomFromWKT(t, "POINT(1 2)"))
-	expectGeomEq(t, got.EndPoint().AsGeometry(), geomFromWKT(t, "POINT(3 4)"))
+	ExpectIntEq(t, got.NumPoints(), 2)
+	ExpectGeomEq(t, got.StartPoint().AsGeometry(), GeomFromWKT(t, "POINT(1 2)"))
+	ExpectGeomEq(t, got.EndPoint().AsGeometry(), GeomFromWKT(t, "POINT(3 4)"))
 }
 
 func TestPolygonToMultiPolygon(t *testing.T) {
-	p := geomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))").AsPolygon()
+	p := GeomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))").AsPolygon()
 	mp := p.AsMultiPolygon()
 	if mp.AsText() != "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))" {
 		t.Errorf("got %v", mp.AsText())
@@ -848,9 +849,9 @@ func TestReverse(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			want := geomFromWKT(t, tt.boundary)
-			got := geomFromWKT(t, tt.wkt).Reverse()
-			expectGeomEq(t, got, want)
+			want := GeomFromWKT(t, tt.boundary)
+			got := GeomFromWKT(t, tt.wkt).Reverse()
+			ExpectGeomEq(t, got, want)
 		})
 	}
 }

--- a/geom/geojson_feature_collection_test.go
+++ b/geom/geojson_feature_collection_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestGeoJSONFeatureCollectionValidUnmarshal(t *testing.T) {
@@ -57,19 +58,19 @@ func TestGeoJSONFeatureCollectionValidUnmarshal(t *testing.T) {
 
 	var fc GeoJSONFeatureCollection
 	err := json.NewDecoder(strings.NewReader(input)).Decode(&fc)
-	expectNoErr(t, err)
+	ExpectNoErr(t, err)
 
-	expectIntEq(t, len(fc), 2)
+	ExpectIntEq(t, len(fc), 2)
 	f0 := fc[0]
 	f1 := fc[1]
 
-	expectStringEq(t, f0.ID.(string), "id0")
-	expectBoolEq(t, reflect.DeepEqual(f0.Properties, map[string]interface{}{"prop0": "value0", "prop1": "value1"}), true)
-	expectGeomEq(t, f0.Geometry, geomFromWKT(t, "LINESTRING(102 0,103 1,104 0,105 1)"))
+	ExpectStringEq(t, f0.ID.(string), "id0")
+	ExpectBoolEq(t, reflect.DeepEqual(f0.Properties, map[string]interface{}{"prop0": "value0", "prop1": "value1"}), true)
+	ExpectGeomEq(t, f0.Geometry, GeomFromWKT(t, "LINESTRING(102 0,103 1,104 0,105 1)"))
 
-	expectStringEq(t, f1.ID.(string), "id1")
-	expectBoolEq(t, reflect.DeepEqual(f1.Properties, map[string]interface{}{"prop0": "value2", "prop1": "value3"}), true)
-	expectGeomEq(t, f1.Geometry, geomFromWKT(t, "POLYGON((100 0,101 0,101 1,100 1,100 0))"))
+	ExpectStringEq(t, f1.ID.(string), "id1")
+	ExpectBoolEq(t, reflect.DeepEqual(f1.Properties, map[string]interface{}{"prop0": "value2", "prop1": "value3"}), true)
+	ExpectGeomEq(t, f1.Geometry, GeomFromWKT(t, "POLYGON((100 0,101 0,101 1,100 1,100 0))"))
 }
 
 func TestGeoJSONFeatureCollectionInvalidUnmarshal(t *testing.T) {
@@ -114,7 +115,7 @@ func TestGeoJSONFeatureCollectionInvalidUnmarshal(t *testing.T) {
 			// what the other test cases are based on.
 			var fc GeoJSONFeatureCollection
 			r := strings.NewReader(tt.input)
-			expectNoErr(t, json.NewDecoder(r).Decode(&fc))
+			ExpectNoErr(t, json.NewDecoder(r).Decode(&fc))
 			continue
 		}
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -133,30 +134,30 @@ func TestGeoJSONFeatureCollectionInvalidUnmarshal(t *testing.T) {
 
 func TestGeoJSONFeatureCollectionEmpty(t *testing.T) {
 	out, err := json.Marshal(GeoJSONFeatureCollection{})
-	expectNoErr(t, err)
-	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
+	ExpectNoErr(t, err)
+	ExpectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
 }
 
 func TestGeoJSONFeatureCollectionNil(t *testing.T) {
 	out, err := json.Marshal(GeoJSONFeatureCollection(nil))
-	expectNoErr(t, err)
-	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
+	ExpectNoErr(t, err)
+	ExpectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
 }
 
 func TestGeoJSONFeatureCollectionAndPropertiesNil(t *testing.T) {
-	out, err := json.Marshal(GeoJSONFeatureCollection{{Geometry: geomFromWKT(t, "POINT(1 2)")}})
-	expectNoErr(t, err)
-	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{}}]}`)
+	out, err := json.Marshal(GeoJSONFeatureCollection{{Geometry: GeomFromWKT(t, "POINT(1 2)")}})
+	ExpectNoErr(t, err)
+	ExpectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{}}]}`)
 }
 
 func TestGeoJSONFeatureCollectionAndPropertiesSet(t *testing.T) {
 	out, err := json.Marshal(GeoJSONFeatureCollection{{
-		Geometry: geomFromWKT(t, "POINT(1 2)"),
+		Geometry: GeomFromWKT(t, "POINT(1 2)"),
 		ID:       "myid",
 		Properties: map[string]interface{}{
 			"foo": "bar",
 		},
 	}})
-	expectNoErr(t, err)
-	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"id":"myid","properties":{"foo":"bar"}}]}`)
+	ExpectNoErr(t, err)
+	ExpectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"id":"myid","properties":{"foo":"bar"}}]}`)
 }

--- a/geom/geojson_geometry_test.go
+++ b/geom/geojson_geometry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestGeoJSONUnmarshalValid(t *testing.T) {
@@ -434,9 +435,9 @@ func TestGeoJSONUnmarshalValid(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got, err := UnmarshalGeoJSON([]byte(tt.geojson))
-			expectNoErr(t, err)
-			want := geomFromWKT(t, tt.wkt)
-			expectGeomEq(t, got, want)
+			ExpectNoErr(t, err)
+			want := GeomFromWKT(t, tt.wkt)
+			ExpectGeomEq(t, got, want)
 		})
 	}
 }
@@ -548,9 +549,9 @@ func TestGeoJSONMarshal(t *testing.T) {
 		},
 	} {
 		t.Run(tt.wkt, func(t *testing.T) {
-			geom := geomFromWKT(t, tt.wkt)
+			geom := GeomFromWKT(t, tt.wkt)
 			gotJSON, err := json.Marshal(geom)
-			expectNoErr(t, err)
+			ExpectNoErr(t, err)
 			if string(gotJSON) != tt.want {
 				t.Error("json doesn't match")
 				t.Logf("got:  %v", string(gotJSON))
@@ -561,9 +562,9 @@ func TestGeoJSONMarshal(t *testing.T) {
 }
 
 func TestGeoJSONMarshalAnyGeometryPopulated(t *testing.T) {
-	g := geomFromWKT(t, "POINT(1 2)")
+	g := GeomFromWKT(t, "POINT(1 2)")
 	got, err := json.Marshal(g)
-	expectNoErr(t, err)
+	ExpectNoErr(t, err)
 	const want = `{"type":"Point","coordinates":[1,2]}`
-	expectStringEq(t, string(got), want)
+	ExpectStringEq(t, string(got), want)
 }

--- a/geom/sql_integration_test.go
+++ b/geom/sql_integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/lib/pq"
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func newDB(t *testing.T) *sql.DB {
@@ -25,19 +26,19 @@ func TestIntegrationValuerScanner(t *testing.T) {
 	db := newDB(t)
 	defer db.Close()
 
-	input := geomFromWKT(t, "POINT(4 2)")
+	input := GeomFromWKT(t, "POINT(4 2)")
 	t.Run("input is AnyGeometry struct", func(t *testing.T) {
 		var output Geometry
 		if err := db.QueryRow("SELECT ST_AsBinary(ST_GeomFromWKB($1))", input).Scan(&output); err != nil {
 			t.Fatal(err)
 		}
-		expectGeomEq(t, output, input)
+		ExpectGeomEq(t, output, input)
 	})
 	t.Run("input is AnyGeometry pointer to struct", func(t *testing.T) {
 		var output Geometry
 		if err := db.QueryRow("SELECT ST_AsBinary(ST_GeomFromWKB($1))", &input).Scan(&output); err != nil {
 			t.Fatal(err)
 		}
-		expectGeomEq(t, output, input)
+		ExpectGeomEq(t, output, input)
 	})
 }

--- a/geom/sql_test.go
+++ b/geom/sql_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestValuerAny(t *testing.T) {
-	g := geomFromWKT(t, "POINT(1 2)")
+	g := GeomFromWKT(t, "POINT(1 2)")
 	val, err := g.Value()
 	if err != nil {
 		t.Fatal(err)
@@ -18,19 +19,19 @@ func TestValuerAny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectGeomEq(t, g, geom)
+	ExpectGeomEq(t, g, geom)
 }
 
 func TestScanner(t *testing.T) {
 	const wkt = "POINT(2 3)"
 	var wkb bytes.Buffer
-	expectNoErr(t, geomFromWKT(t, wkt).AsBinary(&wkb))
+	ExpectNoErr(t, GeomFromWKT(t, wkt).AsBinary(&wkb))
 	var g Geometry
 	check := func(t *testing.T, err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		expectGeomEq(t, g, geomFromWKT(t, wkt))
+		ExpectGeomEq(t, g, GeomFromWKT(t, wkt))
 	}
 	t.Run("string", func(t *testing.T) {
 		g = Geometry{}
@@ -57,12 +58,12 @@ func TestValuerConcrete(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log(wkt)
-			geom := geomFromWKT(t, wkt)
+			geom := GeomFromWKT(t, wkt)
 			val, err := geom.Value()
-			expectNoErr(t, err)
+			ExpectNoErr(t, err)
 			g, err := UnmarshalWKB(bytes.NewReader(val.([]byte)))
-			expectNoErr(t, err)
-			expectGeomEq(t, g, geom)
+			ExpectNoErr(t, err)
+			ExpectGeomEq(t, g, geom)
 		})
 	}
 }

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestEnvelopeContains(t *testing.T) {
@@ -39,7 +40,7 @@ func TestEnvelopeAsGeometry(t *testing.T) {
 		{NewEnvelope(XY{3, 4}, XY{8, 0}), "POLYGON((3 0,3 4,8 4,8 0,3 0))"},
 	} {
 		got := tt.env.AsGeometry()
-		expectGeomEq(t, got, geomFromWKT(t, tt.wantWKT))
+		ExpectGeomEq(t, got, GeomFromWKT(t, tt.wantWKT))
 	}
 }
 

--- a/geom/type_sum_test.go
+++ b/geom/type_sum_test.go
@@ -9,34 +9,35 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestZeroGeometry(t *testing.T) {
 	var z Geometry
-	expectBoolEq(t, z.IsGeometryCollection(), true)
+	ExpectBoolEq(t, z.IsGeometryCollection(), true)
 	z.AsGeometryCollection() // Doesn't crash.
-	expectStringEq(t, z.AsText(), "GEOMETRYCOLLECTION EMPTY")
+	ExpectStringEq(t, z.AsText(), "GEOMETRYCOLLECTION EMPTY")
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(z)
-	expectNoErr(t, err)
-	expectStringEq(t, strings.TrimSpace(buf.String()), `{"type":"GeometryCollection","geometries":[]}`)
+	ExpectNoErr(t, err)
+	ExpectStringEq(t, strings.TrimSpace(buf.String()), `{"type":"GeometryCollection","geometries":[]}`)
 
 	z = NewPointF(1, 2).AsGeometry() // Set away from zero value
-	expectBoolEq(t, z.IsPoint(), true)
+	ExpectBoolEq(t, z.IsPoint(), true)
 	err = json.NewDecoder(&buf).Decode(&z)
-	expectNoErr(t, err)
-	expectBoolEq(t, z.IsPoint(), false)
-	expectBoolEq(t, z.IsGeometryCollection(), true)
-	expectBoolEq(t, z.IsEmpty(), true)
+	ExpectNoErr(t, err)
+	ExpectBoolEq(t, z.IsPoint(), false)
+	ExpectBoolEq(t, z.IsGeometryCollection(), true)
+	ExpectBoolEq(t, z.IsEmpty(), true)
 	z = Geometry{}
 
 	z.AsBinary(ioutil.Discard) // Doesn't crash
 
 	_, err = z.Value()
-	expectNoErr(t, err)
+	ExpectNoErr(t, err)
 
-	expectIntEq(t, z.Dimension(), 0)
+	ExpectIntEq(t, z.Dimension(), 0)
 }
 
 func TestGeometryType(t *testing.T) {
@@ -63,7 +64,7 @@ func TestGeometryType(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log("wkt:", tt.wkt)
-			g := geomFromWKT(t, tt.wkt)
+			g := GeomFromWKT(t, tt.wkt)
 			if tt.geoType != g.Type() {
 				t.Errorf("expect: %s, got %s", tt.geoType, g.Type())
 			}

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func xy(x, y float64) Coordinates {
@@ -153,7 +154,7 @@ func TestMultiPolygonValidation(t *testing.T) {
 		`MULTIPOLYGON(EMPTY,((0 0,0 1,1 0,0 0)))`,
 	} {
 		t.Run(fmt.Sprintf("valid_%d", i), func(t *testing.T) {
-			geomFromWKT(t, wkt)
+			GeomFromWKT(t, wkt)
 		})
 	}
 	for i, wkt := range []string{

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func hexStringToBytes(t *testing.T, s string) []byte {
@@ -452,8 +453,8 @@ func TestWKBParseValid(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			geom, err := UnmarshalWKB(bytes.NewReader(hexStringToBytes(t, tt.wkb)))
-			expectNoErr(t, err)
-			expectGeomEq(t, geom, geomFromWKT(t, tt.wkt))
+			ExpectNoErr(t, err)
+			ExpectGeomEq(t, geom, GeomFromWKT(t, tt.wkt))
 		})
 	}
 }
@@ -495,22 +496,22 @@ func TestWKBMarshalValid(t *testing.T) {
 		"GEOMETRYCOLLECTION(POINT(1 2),LINESTRING(1 2,3 4))",
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			geom := geomFromWKT(t, wkt)
+			geom := GeomFromWKT(t, wkt)
 			var buf bytes.Buffer
 			err := geom.AsBinary(&buf)
-			expectNoErr(t, err)
+			ExpectNoErr(t, err)
 			readBackGeom, err := UnmarshalWKB(&buf)
-			expectNoErr(t, err)
-			expectGeomEq(t, readBackGeom, geom)
+			ExpectNoErr(t, err)
+			ExpectGeomEq(t, readBackGeom, geom)
 		})
 	}
 }
 
 func TestWKBMarshalEmptyPoint(t *testing.T) {
-	g := geomFromWKT(t, "POINT EMPTY")
+	g := GeomFromWKT(t, "POINT EMPTY")
 	var buf bytes.Buffer
 	err := g.AsBinary(&buf)
-	expectNoErr(t, err)
+	ExpectNoErr(t, err)
 	want := hexStringToBytes(t, "0101000000010000000000f87f010000000000f87f")
 	if !bytes.Equal(want, buf.Bytes()) {
 		t.Logf("want:\n%v", hex.Dump(want))

--- a/geom/wkt_test.go
+++ b/geom/wkt_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestUnmarshalWKTValidGrammar(t *testing.T) {
@@ -98,34 +99,34 @@ func TestMarshalUnmarshalWKT(t *testing.T) {
 		"GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))",
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, wkt).AsText()
-			expectStringEq(t, got, wkt)
+			got := GeomFromWKT(t, wkt).AsText()
+			ExpectStringEq(t, got, wkt)
 		})
 	}
 }
 
 func TestUnmarshalWKT(t *testing.T) {
 	t.Run("multi line string containing an empty line string", func(t *testing.T) {
-		g := geomFromWKT(t, "MULTILINESTRING((1 2,3 4),EMPTY,(5 6,7 8))")
+		g := GeomFromWKT(t, "MULTILINESTRING((1 2,3 4),EMPTY,(5 6,7 8))")
 		mls := g.AsMultiLineString()
-		expectIntEq(t, mls.NumLineStrings(), 3)
-		expectGeomEq(t,
+		ExpectIntEq(t, mls.NumLineStrings(), 3)
+		ExpectGeomEq(t,
 			mls.LineStringN(0).AsGeometry(),
-			geomFromWKT(t, "LINESTRING(1 2,3 4)"),
+			GeomFromWKT(t, "LINESTRING(1 2,3 4)"),
 		)
-		expectGeomEq(t,
+		ExpectGeomEq(t,
 			mls.LineStringN(1).AsGeometry(),
-			geomFromWKT(t, "LINESTRING EMPTY"),
+			GeomFromWKT(t, "LINESTRING EMPTY"),
 		)
-		expectGeomEq(t,
+		ExpectGeomEq(t,
 			mls.LineStringN(2).AsGeometry(),
-			geomFromWKT(t, "LINESTRING(5 6,7 8)"),
+			GeomFromWKT(t, "LINESTRING(5 6,7 8)"),
 		)
 	})
 	t.Run("multipoints with and without parenthesised points", func(t *testing.T) {
-		g1 := geomFromWKT(t, "MULTIPOINT((10 40),(40 30),(20 20),(30 10))")
-		g2 := geomFromWKT(t, "MULTIPOINT(10 40,40 30,20 20,30 10)")
-		expectGeomEq(t, g1, g2)
+		g1 := GeomFromWKT(t, "MULTIPOINT((10 40),(40 30),(20 20),(30 10))")
+		g2 := GeomFromWKT(t, "MULTIPOINT(10 40,40 30,20 20,30 10)")
+		ExpectGeomEq(t, g1, g2)
 	})
 }
 
@@ -161,7 +162,7 @@ func TestAsTextEmpty(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := tt.g.AsText()
-			expectStringEq(t, got, tt.want)
+			ExpectStringEq(t, got, tt.want)
 		})
 	}
 }

--- a/geom/xy_ctor_test.go
+++ b/geom/xy_ctor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	. "github.com/peterstace/simplefeatures/internal/geomtest"
 )
 
 func TestXYConstructors(t *testing.T) {
@@ -74,8 +75,8 @@ func TestXYConstructors(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			want := geomFromWKT(t, tt.WKT)
-			expectGeomEq(t, tt.Geom.AsGeometry(), want)
+			want := GeomFromWKT(t, tt.WKT)
+			ExpectGeomEq(t, tt.Geom.AsGeometry(), want)
 		})
 	}
 }

--- a/internal/geomtest/helper.go
+++ b/internal/geomtest/helper.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/peterstace/simplefeatures/geom"
 )
 
-func geomFromWKT(t *testing.T, wkt string) Geometry {
+func GeomFromWKT(t *testing.T, wkt string) Geometry {
 	t.Helper()
 	geom, err := UnmarshalWKT(strings.NewReader(wkt))
 	if err != nil {
@@ -16,7 +16,7 @@ func geomFromWKT(t *testing.T, wkt string) Geometry {
 	return geom
 }
 
-func expectPanics(t *testing.T, fn func()) {
+func ExpectPanics(t *testing.T, fn func()) {
 	t.Helper()
 	defer func() {
 		if r := recover(); r != nil {
@@ -27,49 +27,49 @@ func expectPanics(t *testing.T, fn func()) {
 	fn()
 }
 
-func expectNoErr(t *testing.T, err error) {
+func ExpectNoErr(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func expectGeomEq(t *testing.T, got, want Geometry, opts ...EqualsExactOption) {
+func ExpectGeomEq(t *testing.T, got, want Geometry, opts ...EqualsExactOption) {
 	t.Helper()
 	if !got.EqualsExact(want, opts...) {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got.AsText(), want.AsText())
 	}
 }
 
-func expectCoordsEq(t *testing.T, got, want Coordinates) {
+func ExpectCoordsEq(t *testing.T, got, want Coordinates) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectStringEq(t *testing.T, got, want string) {
+func ExpectStringEq(t *testing.T, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %q\nwant: %q\n", got, want)
 	}
 }
 
-func expectIntEq(t *testing.T, got, want int) {
+func ExpectIntEq(t *testing.T, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %d\nwant: %d\n", got, want)
 	}
 }
 
-func expectBoolEq(t *testing.T, got, want bool) {
+func ExpectBoolEq(t *testing.T, got, want bool) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %t\nwant: %t\n", got, want)
 	}
 }
 
-func expectXYEq(t *testing.T, got, want XY) {
+func ExpectXYEq(t *testing.T, got, want XY) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)


### PR DESCRIPTION
This is so that the test helpers can be used both in tests for the
`geom` package, and tests for the `geom_test` package. They may also be
useful for testing packages other than `geom` (although they're not used
for that right now).