### PR TITLE
TransformXY modified to return concrete geometry types (Issue #102)

### DIFF
--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -170,16 +170,16 @@ func (c GeometryCollection) MarshalJSON() ([]byte, error) {
 }
 
 // TransformXY transforms this GeometryCollection into another GeometryCollection according to fn.
-func (c GeometryCollection) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (c GeometryCollection) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (GeometryCollection, error) {
 	transformed := make([]Geometry, len(c.geoms))
 	for i := range c.geoms {
 		var err error
 		transformed[i], err = c.geoms[i].TransformXY(fn, opts...)
 		if err != nil {
-			return Geometry{}, err
+			return GeometryCollection{}, err
 		}
 	}
-	return NewGeometryCollection(transformed).AsGeometry(), nil
+	return NewGeometryCollection(transformed), nil
 }
 
 // EqualsExact checks if this GeometryCollection is exactly equal to another GeometryCollection.

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -141,11 +141,11 @@ func (n Line) Coordinates() []Coordinates {
 }
 
 // TransformXY transforms this Line into another Line according to fn.
-func (n Line) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (n Line) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Line, error) {
 	coords := n.Coordinates()
 	transform1dCoords(coords, fn)
 	ln, err := NewLineC(coords[0], coords[1], opts...)
-	return ln.AsGeometry(), err
+	return ln, err
 }
 
 // EqualsExact checks if this Line is exactly equal to another curve.

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -283,11 +283,11 @@ func (s LineString) Coordinates() []Coordinates {
 }
 
 // TransformXY transforms this LineString into another LineString according to fn.
-func (s LineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (s LineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (LineString, error) {
 	coords := s.Coordinates()
 	transform1dCoords(coords, fn)
 	ls, err := NewLineStringC(coords, opts...)
-	return ls.AsGeometry(), err
+	return ls, err
 }
 
 // EqualsExact checks if this LineString is exactly equal to another curve.

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -232,11 +232,11 @@ func (m MultiLineString) Coordinates() [][]Coordinates {
 }
 
 // TransformXY transforms this MultiLineString into another MultiLineString according to fn.
-func (m MultiLineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (m MultiLineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (MultiLineString, error) {
 	coords := m.Coordinates()
 	transform2dCoords(coords, fn)
 	mls, err := NewMultiLineStringC(coords, opts...)
-	return mls.AsGeometry(), err
+	return mls, err
 }
 
 // EqualsExact checks if this MultiLineString is exactly equal to another MultiLineString.

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -190,10 +190,10 @@ func (m MultiPoint) Coordinates() []OptionalCoordinates {
 }
 
 // TransformXY transforms this MultiPoint into another MultiPoint according to fn.
-func (m MultiPoint) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (m MultiPoint) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (MultiPoint, error) {
 	coords := m.Coordinates()
 	transformOptional1dCoords(coords, fn)
-	return NewMultiPointOC(coords, opts...).AsGeometry(), nil
+	return NewMultiPointOC(coords, opts...), nil
 }
 
 // EqualsExact checks if this MultiPoint is exactly equal to another MultiPoint.

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -327,11 +327,11 @@ func (m MultiPolygon) Coordinates() [][][]Coordinates {
 }
 
 // TransformXY transforms this MultiPolygon into another MultiPolygon according to fn.
-func (m MultiPolygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (m MultiPolygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (MultiPolygon, error) {
 	coords := m.Coordinates()
 	transform3dCoords(coords, fn)
 	mp, err := NewMultiPolygonC(coords, opts...)
-	return mp.AsGeometry(), err
+	return mp, err
 }
 
 // EqualsExact checks if this MultiPolygon is exactly equal to another MultiPolygon.

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -141,12 +141,12 @@ func (p Point) MarshalJSON() ([]byte, error) {
 }
 
 // TransformXY transforms this Point into another Point according to fn.
-func (p Point) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (p Point) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Point, error) {
 	coords := p.Coordinates()
 	if !coords.Empty {
 		coords.Value.XY = fn(coords.Value.XY)
 	}
-	return NewPointOC(coords, opts...).AsGeometry(), nil
+	return NewPointOC(coords, opts...), nil
 }
 
 // EqualsExact checks if this Point is exactly equal to another Point.

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -333,11 +333,11 @@ func (p Polygon) Coordinates() [][]Coordinates {
 }
 
 // TransformXY transforms this Polygon into another Polygon according to fn.
-func (p Polygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+func (p Polygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Polygon, error) {
 	coords := p.Coordinates()
 	transform2dCoords(coords, fn)
 	poly, err := NewPolygonC(coords, opts...)
-	return poly.AsGeometry(), err
+	return poly, err
 }
 
 // EqualsExact checks if this Polygon is exactly equal to another Polygon.

--- a/geom/type_sum.go
+++ b/geom/type_sum.go
@@ -516,21 +516,29 @@ func (g Geometry) Intersection(other Geometry) (Geometry, error) {
 func (g Geometry) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
 	switch g.tag {
 	case geometryCollectionTag:
-		return g.AsGeometryCollection().TransformXY(fn, opts...)
+		gt, err := g.AsGeometryCollection().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case pointTag:
-		return g.AsPoint().TransformXY(fn, opts...)
+		gt, err := g.AsPoint().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case lineTag:
-		return g.AsLine().TransformXY(fn, opts...)
+		gt, err := g.AsLine().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case lineStringTag:
-		return g.AsLineString().TransformXY(fn, opts...)
+		gt, err := g.AsLineString().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case polygonTag:
-		return g.AsPolygon().TransformXY(fn, opts...)
+		gt, err := g.AsPolygon().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case multiPointTag:
-		return g.AsMultiPoint().TransformXY(fn, opts...)
+		gt, err := g.AsMultiPoint().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case multiLineStringTag:
-		return g.AsMultiLineString().TransformXY(fn, opts...)
+		gt, err := g.AsMultiLineString().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	case multiPolygonTag:
-		return g.AsMultiPolygon().TransformXY(fn, opts...)
+		gt, err := g.AsMultiPolygon().TransformXY(fn, opts...)
+		return gt.AsGeometry(), err
 	default:
 		panic("unknown geometry: " + g.tag.String())
 	}


### PR DESCRIPTION
Modified all TransformXY functions to return their own type.

The largest change was to TransformXY in type_sum.go; it still returns a Geometry object. That seemed to be the way to go, but I'm not entirely sure if what I've done matches the original intent?