### PR TITLE
Remove IsValid

### DIFF
--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -332,18 +332,6 @@ func CheckConvexHull(t *testing.T, want UnaryResult, g geom.Geometry) {
 	})
 }
 
-func CheckIsValid(t *testing.T, want UnaryResult, g geom.Geometry) {
-	t.Run("CheckIsValid", func(t *testing.T) {
-		got := g.IsValid()
-		want := want.IsValid
-		if got != want {
-			t.Logf("got:  %t", got)
-			t.Logf("want: %t", want)
-			t.Error("mismatch")
-		}
-	})
-}
-
 func CheckIsRing(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckIsRing", func(t *testing.T) {
 		isDefined := g.IsLine() || g.IsLineString()

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -46,7 +46,6 @@ func TestFuzz(t *testing.T) {
 			CheckIsSimple(t, want, g)
 			CheckBoundary(t, want, g)
 			CheckConvexHull(t, want, g)
-			CheckIsValid(t, want, g)
 			CheckIsRing(t, want, g)
 			CheckLength(t, want, g)
 			CheckArea(t, want, g)

--- a/fuzztests/pg.go
+++ b/fuzztests/pg.go
@@ -21,7 +21,6 @@ type UnaryResult struct {
 	IsSimple   sql.NullBool
 	Boundary   geom.NullGeometry
 	ConvexHull geom.Geometry
-	IsValid    bool
 	IsRing     sql.NullBool
 	Length     float64
 	Area       float64
@@ -89,7 +88,6 @@ func (p BatchPostGIS) Unary(g geom.Geometry) (UnaryResult, error) {
 		END,
 
 		ST_AsText(ST_ConvexHull(ST_GeomFromText($3))),
-		ST_IsValid(ST_GeomFromWKB($1)),
 
 		-- IsRing only defined for LineStrings.
 		CASE
@@ -120,7 +118,6 @@ func (p BatchPostGIS) Unary(g geom.Geometry) (UnaryResult, error) {
 		&result.IsSimple,
 		&boundaryWKT,
 		&convexHullWKT,
-		&result.IsValid,
 		&result.IsRing,
 		&result.Length,
 		&result.Area,

--- a/fuzztests/postgis.go
+++ b/fuzztests/postgis.go
@@ -211,10 +211,6 @@ func (p PostGIS) ConvexHull(t *testing.T, g geom.Geometry) geom.Geometry {
 	return p.geomFunc(t, g, "ST_ConvexHull")
 }
 
-func (p PostGIS) IsValid(t *testing.T, g geom.Geometry) bool {
-	return p.boolFunc(t, g, "ST_IsValid")
-}
-
 func (p PostGIS) IsRing(t *testing.T, g geom.Geometry) bool {
 	// ST_IsRing returns an error whenever it gets anything other than an ST_LineString.
 	return p.stringFunc(t, g, "ST_GeometryType") == "ST_LineString" &&

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -471,31 +471,6 @@ func (g Geometry) ConvexHull() Geometry {
 	return convexHull(g)
 }
 
-// IsValid returns if the current geometry is valid. It is useful to use when
-// validation is disabled at constructing, for example, json.Unmarshal
-func (g Geometry) IsValid() bool {
-	switch g.tag {
-	case geometryCollectionTag:
-		return g.AsGeometryCollection().IsValid()
-	case pointTag:
-		return g.AsPoint().IsValid()
-	case lineTag:
-		return g.AsLine().IsValid()
-	case lineStringTag:
-		return g.AsLineString().IsValid()
-	case polygonTag:
-		return g.AsPolygon().IsValid()
-	case multiPointTag:
-		return g.AsMultiPoint().IsValid()
-	case multiLineStringTag:
-		return g.AsMultiLineString().IsValid()
-	case multiPolygonTag:
-		return g.AsMultiPolygon().IsValid()
-	default:
-		panic("unknown geometry: " + g.tag.String())
-	}
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (g Geometry) Intersects(other Geometry) bool {

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -220,18 +220,6 @@ func (c GeometryCollection) EqualsExact(other Geometry, opts ...EqualsExactOptio
 		geometryCollectionExactEqual(c, other.AsGeometryCollection(), opts)
 }
 
-// IsValid checks if this GeometryCollection is valid. However, there is no
-// constraints on it, so this function always returns true
-func (c GeometryCollection) IsValid() bool {
-	all := true
-	c.walk(func(g Geometry) {
-		if !g.IsValid() {
-			all = false
-		}
-	})
-	return all
-}
-
 // Reverse in the case of GeometryCollection reverses each component and also
 // returns them in the original order.
 func (c GeometryCollection) Reverse() GeometryCollection {

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -210,12 +210,6 @@ func (n Line) EqualsExact(other Geometry, opts ...EqualsExactOption) bool {
 	return curvesExactEqual(n.Coordinates(), otherSeq, opts)
 }
 
-// IsValid checks if this Line is valid
-func (n Line) IsValid() bool {
-	_, err := NewLine(n.a, n.b)
-	return err == nil
-}
-
 // Length gives the length of the line.
 func (n Line) Length() float64 {
 	delta := n.a.XY.Sub(n.b.XY)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -284,12 +284,6 @@ func (s LineString) EqualsExact(other Geometry, opts ...EqualsExactOption) bool 
 	return curvesExactEqual(s.Coordinates(), otherSeq, opts)
 }
 
-// IsValid checks if this LineString is valid
-func (s LineString) IsValid() bool {
-	_, err := NewLineString(s.Coordinates())
-	return err == nil
-}
-
 // IsRing returns true iff this LineString is both simple and closed (i.e. is a
 // linear ring).
 func (s LineString) IsRing() bool {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -277,16 +277,6 @@ func (m MultiLineString) EqualsExact(other Geometry, opts ...EqualsExactOption) 
 		multiLineStringExactEqual(m, other.AsMultiLineString(), opts)
 }
 
-// IsValid checks if this MultiLineString is valid
-func (m MultiLineString) IsValid() bool {
-	for _, ls := range m.lines {
-		if !ls.IsValid() {
-			return false
-		}
-	}
-	return true
-}
-
 // Length gives the sum of the lengths of the constituent members of the multi
 // line string.
 func (m MultiLineString) Length() float64 {

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -229,12 +229,6 @@ func (m MultiPoint) EqualsExact(other Geometry, opts ...EqualsExactOption) bool 
 		multiPointExactEqual(m, other.AsMultiPoint(), opts)
 }
 
-// IsValid checks if this MultiPoint is valid. However, there is no way to indicate
-// whether or not MultiPoint is valid, so this function always returns true
-func (m MultiPoint) IsValid() bool {
-	return true
-}
-
 // Centroid gives the centroid of the coordinates of the MultiPoint.
 func (m MultiPoint) Centroid() Point {
 	var sum XY

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -376,17 +376,6 @@ func (m MultiPolygon) EqualsExact(other Geometry, opts ...EqualsExactOption) boo
 		multiPolygonExactEqual(m, other.AsMultiPolygon(), opts)
 }
 
-// IsValid checks if this MultiPolygon is valid
-func (m MultiPolygon) IsValid() bool {
-	for _, p := range m.polys {
-		if !p.IsValid() {
-			return false
-		}
-	}
-	_, err := NewMultiPolygonFromPolygons(m.polys)
-	return err == nil
-}
-
 // Area in the case of a MultiPolygon is the sum of the areas of its polygons.
 func (m MultiPolygon) Area() float64 {
 	var area float64

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -184,12 +184,6 @@ func (p Point) EqualsExact(other Geometry, opts ...EqualsExactOption) bool {
 	return newEqualsExactOptionSet(opts).eq(p.coords, other.AsPoint().coords)
 }
 
-// IsValid checks if this Point is valid, but there is not way to indicate if
-// Point is valid, so this function always returns true
-func (p Point) IsValid() bool {
-	return true
-}
-
 // Centroid of a point is that point.
 func (p Point) Centroid() Point {
 	return p.Force2D()

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -346,17 +346,6 @@ func (p Polygon) EqualsExact(other Geometry, opts ...EqualsExactOption) bool {
 		polygonExactEqual(p, other.AsPolygon(), opts)
 }
 
-// IsValid checks if this Polygon is valid
-func (p Polygon) IsValid() bool {
-	for _, r := range p.rings {
-		if !r.IsValid() {
-			return false
-		}
-	}
-	_, err := NewPolygonFromRings(p.rings)
-	return err == nil
-}
-
 // Area of a Polygon is the outer ring's area minus the areas of all inner rings.
 func (p Polygon) Area() float64 {
 	area := math.Abs(signedAreaOfLinearRing(p.ExteriorRing()))


### PR DESCRIPTION
Having an IsValid method implies the existence of geometry objects that
were created in an invalid state. This is problematic, because all of
the methods on geometries assume that the geometry is valid.

Users will need alternate ways to determine if their WKB, WKT, or
GeoJSON are valid or not. This can be done by checking the error that
gets returned when the geometry is created.

Fixes #88 and fixes #58 