### PR TITLE
Remove redundant binary operator checks from fuzzchecks

### DIFF
--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -379,35 +379,6 @@ func CheckLength(t *testing.T, want UnaryResult, g geom.Geometry) {
 	})
 }
 
-func CheckEqualsExact(t *testing.T, pg PostGIS, g1, g2 geom.Geometry) {
-	t.Run("CheckEqualsExact", func(t *testing.T) {
-		got := g1.EqualsExact(g2)
-		want := pg.OrderingEquals(t, g1, g2)
-		if got != want {
-			t.Logf("got:  %t", got)
-			t.Logf("want: %t", want)
-			t.Error("mismatch")
-		}
-	})
-}
-
-func CheckIntersects(t *testing.T, pg PostGIS, g1, g2 geom.Geometry) {
-	t.Run("CheckIntersects", func(t *testing.T) {
-		if containsMultiPointContainingEmptyPoint(g1) || containsMultiPointContainingEmptyPoint(g2) {
-			// PostGIS gives the incorrect result for these geometries (it says
-			// that they always intersect).
-			return
-		}
-		got := g1.Intersects(g2)
-		want := pg.Intersects(t, g1, g2)
-		if got != want {
-			t.Logf("got:  %t", got)
-			t.Logf("want: %t", want)
-			t.Error("mismatch")
-		}
-	})
-}
-
 func containsMultiPointContainingEmptyPoint(g geom.Geometry) bool {
 	switch {
 	case g.IsMultiPoint():
@@ -426,38 +397,6 @@ func containsMultiPointContainingEmptyPoint(g geom.Geometry) bool {
 		}
 	}
 	return false
-}
-
-func CheckIntersection(t *testing.T, pg PostGIS, g1, g2 geom.Geometry) {
-	t.Run("CheckIntersection", func(t *testing.T) {
-		got, err := g1.Intersection(g2)
-		if err != nil {
-			return // operation not implemented
-		}
-		want := pg.Intersection(t, g1, g2)
-
-		if got.IsEmpty() && want.IsEmpty() {
-			return // Both empty, so they match.
-		}
-
-		if got.IsGeometryCollection() || want.IsGeometryCollection() {
-			// GeometryCollections are not supported by ST_Equals. So there's
-			// not much that we can do here.
-			return
-		}
-
-		// PostGIS TolerantEquals (a chain of ST_SnapToGrid and ST_Equals) is
-		// used rather than in memory ExactEquals because simplefeatures does
-		// not implement intersect in exactly the same way as PostGIS.
-
-		if !pg.TolerantEquals(t, got, want) {
-			t.Logf("g1:   %s", g1.AsText())
-			t.Logf("g2:   %s", g2.AsText())
-			t.Logf("got:  %s", got.AsText())
-			t.Logf("want: %s", want.AsText())
-			t.Error("mismatch")
-		}
-	})
 }
 
 func CheckArea(t *testing.T, want UnaryResult, g geom.Geometry) {

--- a/fuzztests/fuzz_test.go
+++ b/fuzztests/fuzz_test.go
@@ -55,15 +55,6 @@ func TestFuzz(t *testing.T) {
 			CheckType(t, want, g)
 		})
 	}
-	for i, g1 := range geoms {
-		for j, g2 := range geoms {
-			t.Run(fmt.Sprintf("geom_%d_%d_", i, j), func(t *testing.T) {
-				CheckEqualsExact(t, pg, g1, g2)
-				CheckIntersects(t, pg, g1, g2)
-				CheckIntersection(t, pg, g1, g2)
-			})
-		}
-	}
 }
 
 func setupDB(t *testing.T) PostGIS {

--- a/fuzztests/postgis.go
+++ b/fuzztests/postgis.go
@@ -221,22 +221,6 @@ func (p PostGIS) IsRing(t *testing.T, g geom.Geometry) bool {
 		p.boolFunc(t, g, "ST_IsRing")
 }
 
-func (p PostGIS) OrderingEquals(t *testing.T, g1, g2 geom.Geometry) bool {
-	return p.boolBinary(t, g1, g2, "ST_OrderingEquals")
-}
-
-func (p PostGIS) Intersects(t *testing.T, g1, g2 geom.Geometry) bool {
-	return p.boolBinary(t, g1, g2, "ST_Intersects")
-}
-
-func (p PostGIS) Intersection(t *testing.T, g1, g2 geom.Geometry) geom.Geometry {
-	// PostGIS returns an error if geometries with differing coordinate type
-	// are passed in (hence force to 2D).
-	g1 = g1.Force2D()
-	g2 = g2.Force2D()
-	return p.geomBinary(t, g1, g2, "ST_Intersection")
-}
-
 func (p PostGIS) Length(t *testing.T, g geom.Geometry) float64 {
 	return p.float64Func(t, g, "ST_Length")
 }


### PR DESCRIPTION
These checks were already covered by the cmprefimpl checks. In addition
to this, the tests were starting to take a very long time to run, e.g.
over 15 minutes. This was causing some significant pain around waiting
for CI to pass, and testing changes before pushing new code.

Fixes #134 