### PR TITLE
Refine WKB interface

### DIFF
--- a/fuzztests/checks.go
+++ b/fuzztests/checks.go
@@ -131,10 +131,7 @@ func CheckWKB(t *testing.T, want UnaryResult, g geom.Geometry) {
 			// cases are skipped.
 			return
 		}
-		var got bytes.Buffer
-		if err := g.AsBinary(&got); err != nil {
-			t.Fatalf("writing wkb: %v", err)
-		}
+		got := g.AsBinary()
 
 		// PostGIS and SimpleFeatures use slightly different (but compatible)
 		// representations of NaN. Account for this by converting the PostGIS
@@ -144,9 +141,9 @@ func CheckWKB(t *testing.T, want UnaryResult, g geom.Geometry) {
 			[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x7f},
 		)
 
-		if !bytes.Equal(got.Bytes(), want) {
+		if !bytes.Equal(got, want) {
 			t.Logf("wkt: %v", g.AsText())
-			t.Logf("got:\n%s", hex.Dump(got.Bytes()))
+			t.Logf("got:\n%s", hex.Dump(got))
 			t.Logf("want:\n%s", hex.Dump(want))
 			t.Error("mismatch")
 		}

--- a/geom/marshal_unmarshal_test.go
+++ b/geom/marshal_unmarshal_test.go
@@ -193,9 +193,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 		for i, wkt := range wkts {
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
 				original := geomFromWKT(t, wkt)
-				var wkb bytes.Buffer
-				expectNoErr(t, original.AsBinary(&wkb))
-				reconstructed, err := geom.UnmarshalWKB(&wkb)
+				wkb := original.AsBinary()
+				reconstructed, err := geom.UnmarshalWKB(bytes.NewReader(wkb))
 				expectNoErr(t, err)
 				reconstructedWKT := reconstructed.AsText()
 				expectStringEq(t, wkt, reconstructedWKT)

--- a/geom/sql_test.go
+++ b/geom/sql_test.go
@@ -23,8 +23,7 @@ func TestValuerAny(t *testing.T) {
 
 func TestScanner(t *testing.T) {
 	const wkt = "POINT(2 3)"
-	var wkb bytes.Buffer
-	expectNoErr(t, geomFromWKT(t, wkt).AsBinary(&wkb))
+	wkb := geomFromWKT(t, wkt).AsBinary()
 	var g Geometry
 	check := func(t *testing.T, err error) {
 		if err != nil {
@@ -34,11 +33,11 @@ func TestScanner(t *testing.T) {
 	}
 	t.Run("string", func(t *testing.T) {
 		g = Geometry{}
-		check(t, g.Scan(string(wkb.Bytes())))
+		check(t, g.Scan(string(wkb)))
 	})
 	t.Run("byte", func(t *testing.T) {
 		g = Geometry{}
-		check(t, g.Scan([]byte(wkb.Bytes())))
+		check(t, g.Scan(wkb))
 	})
 }
 

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -261,26 +261,31 @@ func (g Geometry) AppendWKT(dst []byte) []byte {
 	}
 }
 
-// AsBinary writes the WKB (Well Known Binary) representation of the geometry
-// to the writer.
-func (g Geometry) AsBinary(w io.Writer) error {
+// AsBinary returns the WKB (Well Known Text) representation of the geometry.
+func (g Geometry) AsBinary() []byte {
+	return g.AppendWKB(nil)
+}
+
+// AppendWKB appends the WKB (Well Known Text) representation of the geometry
+// to the input slice.
+func (g Geometry) AppendWKB(dst []byte) []byte {
 	switch g.tag {
 	case geometryCollectionTag:
-		return g.AsGeometryCollection().AsBinary(w)
+		return g.AsGeometryCollection().AppendWKB(dst)
 	case pointTag:
-		return g.AsPoint().AsBinary(w)
+		return g.AsPoint().AppendWKB(dst)
 	case lineTag:
-		return g.AsLine().AsBinary(w)
+		return g.AsLine().AppendWKB(dst)
 	case lineStringTag:
-		return g.AsLineString().AsBinary(w)
+		return g.AsLineString().AppendWKB(dst)
 	case polygonTag:
-		return g.AsPolygon().AsBinary(w)
+		return g.AsPolygon().AppendWKB(dst)
 	case multiPointTag:
-		return g.AsMultiPoint().AsBinary(w)
+		return g.AsMultiPoint().AppendWKB(dst)
 	case multiLineStringTag:
-		return g.AsMultiLineString().AsBinary(w)
+		return g.AsMultiLineString().AppendWKB(dst)
 	case multiPolygonTag:
-		return g.AsMultiPolygon().AsBinary(w)
+		return g.AsMultiPolygon().AppendWKB(dst)
 	default:
 		panic("unknown geometry: " + g.tag.String())
 	}
@@ -289,9 +294,7 @@ func (g Geometry) AsBinary(w io.Writer) error {
 // Value implements the database/sql/driver.Valuer interface by returning the
 // WKB (Well Known Binary) representation of this Geometry.
 func (g Geometry) Value() (driver.Value, error) {
-	var buf bytes.Buffer
-	err := g.AsBinary(&buf)
-	return buf.Bytes(), err
+	return g.AsBinary(), nil
 }
 
 // Scan implements the database/sql.Scanner interface by parsing the src value

--- a/geom/type_geometry_test.go
+++ b/geom/type_geometry_test.go
@@ -3,7 +3,6 @@ package geom_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"strconv"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func TestZeroGeometry(t *testing.T) {
 	expectBoolEq(t, z.IsEmpty(), true)
 	z = Geometry{}
 
-	z.AsBinary(ioutil.Discard) // Doesn't crash
+	_ = z.AsBinary() // Doesn't crash
 
 	_, err = z.Value()
 	expectNoErr(t, err)

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -1,10 +1,8 @@
 package geom
 
 import (
-	"bytes"
 	"database/sql/driver"
 	"fmt"
-	"io"
 	"math"
 	"unsafe"
 )
@@ -136,21 +134,24 @@ func (n Line) Boundary() MultiPoint {
 // Value implements the database/sql/driver.Valuer interface by returning the
 // WKB (Well Known Binary) representation of this Geometry.
 func (n Line) Value() (driver.Value, error) {
-	var buf bytes.Buffer
-	err := n.AsBinary(&buf)
-	return buf.Bytes(), err
+	return n.AsBinary(), nil
 }
 
-// AsBinary writes the WKB (Well Known Binary) representation of the geometry
-// to the writer.
-func (n Line) AsBinary(w io.Writer) error {
-	marsh := newWKBMarshaller(w)
+// AsBinary returns the WKB (Well Known Text) representation of the geometry.
+func (n Line) AsBinary() []byte {
+	return n.AppendWKB(nil)
+}
+
+// AppendWKB appends the WKB (Well Known Text) representation of the geometry
+// to the input slice.
+func (n Line) AppendWKB(dst []byte) []byte {
+	marsh := newWKBMarshaller(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(wkbGeomTypeLineString, n.a.Type)
 	marsh.writeCount(2)
 	marsh.writeCoordinates(n.a)
 	marsh.writeCoordinates(n.b)
-	return marsh.err
+	return marsh.buf
 }
 
 // ConvexHull returns the geometry representing the smallest convex geometry

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -1,10 +1,8 @@
 package geom
 
 import (
-	"bytes"
 	"database/sql/driver"
 	"errors"
-	"io"
 	"math"
 	"sort"
 	"unsafe"
@@ -228,19 +226,22 @@ func (s LineString) Boundary() MultiPoint {
 // Value implements the database/sql/driver.Valuer interface by returning the
 // WKB (Well Known Binary) representation of this Geometry.
 func (s LineString) Value() (driver.Value, error) {
-	var buf bytes.Buffer
-	err := s.AsBinary(&buf)
-	return buf.Bytes(), err
+	return s.AsBinary(), nil
 }
 
-// AsBinary writes the WKB (Well Known Binary) representation of the geometry
-// to the writer.
-func (s LineString) AsBinary(w io.Writer) error {
-	marsh := newWKBMarshaller(w)
+// AsBinary returns the WKB (Well Known Text) representation of the geometry.
+func (s LineString) AsBinary() []byte {
+	return s.AppendWKB(nil)
+}
+
+// AppendWKB appends the WKB (Well Known Text) representation of the geometry
+// to the input slice.
+func (s LineString) AppendWKB(dst []byte) []byte {
+	marsh := newWKBMarshaller(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(wkbGeomTypeLineString, s.CoordinatesType())
 	marsh.writeSequence(s.seq)
-	return marsh.err
+	return marsh.buf
 }
 
 // ConvexHull returns the geometry representing the smallest convex geometry

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -428,10 +428,8 @@ func TestWKBMarshalValid(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			geom := geomFromWKT(t, wkt)
-			var buf bytes.Buffer
-			err := geom.AsBinary(&buf)
-			expectNoErr(t, err)
-			readBackGeom, err := UnmarshalWKB(&buf)
+			buf := geom.AsBinary()
+			readBackGeom, err := UnmarshalWKB(bytes.NewReader(buf))
 			expectNoErr(t, err)
 			expectGeomEq(t, readBackGeom, geom)
 		})
@@ -522,14 +520,12 @@ func TestWKBMarshalEmptyPoint(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g := geomFromWKT(t, tt.wkt)
-			var buf bytes.Buffer
-			err := g.AsBinary(&buf)
-			expectNoErr(t, err)
+			buf := g.AsBinary()
 			want := hexStringToBytes(t, tt.hex)
-			if !bytes.Equal(want, buf.Bytes()) {
+			if !bytes.Equal(want, buf) {
 				t.Logf("wkt: %v", tt.wkt)
 				t.Logf("want:\n%v", hex.Dump(want))
-				t.Logf("got:\n%v", hex.Dump(buf.Bytes()))
+				t.Logf("got:\n%v", hex.Dump(buf))
 				t.Errorf("mismatch")
 			}
 		})

--- a/geos/libgeos_handle.go
+++ b/geos/libgeos_handle.go
@@ -99,15 +99,12 @@ func (h *Handle) Release() {
 
 // createGeometryHandle converts a Geometry object into a GEOS geometry handle.
 func (h *Handle) createGeometryHandle(g geom.Geometry) (*C.GEOSGeometry, error) {
-	wkb := new(bytes.Buffer)
-	if err := g.AsBinary(wkb); err != nil {
-		return nil, err
-	}
+	wkb := g.AsBinary()
 	gh := C.GEOSWKBReader_read_r(
 		h.context,
 		h.reader,
-		(*C.uchar)(&wkb.Bytes()[0]),
-		C.ulong(wkb.Len()),
+		(*C.uchar)(&wkb[0]),
+		C.ulong(len(wkb)),
 	)
 	if gh == nil {
 		return nil, h.err()

--- a/internal/libgeos/handle.go
+++ b/internal/libgeos/handle.go
@@ -234,16 +234,12 @@ func (h *Handle) createGeomHandleForGeometryCollection(gc geom.GeometryCollectio
 }
 
 func (h *Handle) createGeomHandleUsingWKB(g geom.Geometry) (*C.GEOSGeometry, error) {
-	wkb := bytes.NewBuffer(h.wkbBuf)
-	if err := g.AsBinary(wkb); err != nil {
-		return nil, err
-	}
-	h.wkbBuf = wkb.Bytes()
+	h.wkbBuf = g.AppendWKB(h.wkbBuf)
 	gh := C.GEOSWKBReader_read_r(
 		h.context,
 		h.wkbReader,
 		(*C.uchar)(&h.wkbBuf[0]),
-		C.ulong(wkb.Len()),
+		C.ulong(len(h.wkbBuf)),
 	)
 	h.wkbBuf = h.wkbBuf[:0]
 	if gh == nil {


### PR DESCRIPTION
AsBinary now returns a []byte (and no error). This is a bit simpler
to use.

Adds a new AppendWKB method, which operates on a byte slice.

Fixes #109 