### PR TITLE
Unexport Intersection functionality

### DIFF
--- a/geom/alg_intersection_test.go
+++ b/geom/alg_intersection_test.go
@@ -1,11 +1,9 @@
-package geom_test
+package geom
 
 import (
 	"strconv"
 	"strings"
 	"testing"
-
-	. "github.com/peterstace/simplefeatures/geom"
 )
 
 func TestIntersection(t *testing.T) {
@@ -188,11 +186,15 @@ func TestIntersection(t *testing.T) {
 			}
 
 			t.Run("forward", func(t *testing.T) {
-				got, err := in1g.Intersection(in2g)
+				got, err := intersection(in1g, in2g)
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
+				want, err := UnmarshalWKT(strings.NewReader(tt.out))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !got.EqualsExact(want, IgnoreOrder) {
 					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in1, tt.in2, tt.out, got.AsText())
 				}
 
@@ -215,12 +217,16 @@ func TestIntersection(t *testing.T) {
 				return
 			}
 			t.Run("reversed", func(t *testing.T) {
-				got, err := in2g.Intersection(in1g)
+				got, err := intersection(in1g, in2g)
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !got.EqualsExact(geomFromWKT(t, tt.out), IgnoreOrder) {
-					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in2, tt.in1, tt.out, got.AsText())
+				want, err := UnmarshalWKT(strings.NewReader(tt.out))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !got.EqualsExact(want, IgnoreOrder) {
+					t.Errorf("\ninput1: %s\ninput2: %s\nwant:   %v\ngot:    %v", tt.in1, tt.in2, tt.out, got.AsText())
 				}
 
 				// We can infer the desired result for Intersects, which gives

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -480,17 +480,6 @@ func (g Geometry) Intersects(other Geometry) bool {
 	return hasIntersection(g, other)
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (g Geometry) Intersection(other Geometry) (Geometry, error) {
-	result, err := intersection(g, other)
-	if err != nil {
-		return Geometry{}, err
-	}
-	return result, nil
-}
-
 // TransformXY transforms this Geometry into another geometry according the
 // mapping provided by the XY function. Some classes of mappings (such as
 // affine transformations) will preserve the validity this Geometry in the

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -75,13 +75,6 @@ func (c GeometryCollection) AppendWKT(dst []byte) []byte {
 	return append(dst, ')')
 }
 
-// Intersection calculates the intersection between this geometry and another
-// (i.e. the overlap between the two geometries). It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (c GeometryCollection) Intersection(g Geometry) (Geometry, error) {
-	return intersection(c.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (c GeometryCollection) Intersects(g Geometry) bool {

--- a/geom/type_line.go
+++ b/geom/type_line.go
@@ -102,13 +102,6 @@ func (n Line) IsSimple() bool {
 	return true
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (n Line) Intersection(g Geometry) (Geometry, error) {
-	return intersection(n.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (n Line) Intersects(g Geometry) bool {

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -173,13 +173,6 @@ func (s LineString) IsClosed() bool {
 	return !s.IsEmpty() && s.seq.GetXY(0) == s.seq.GetXY(s.seq.Length()-1)
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (s LineString) Intersection(g Geometry) (Geometry, error) {
-	return intersection(s.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (s LineString) Intersects(g Geometry) bool {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -122,13 +122,6 @@ func (m MultiLineString) IsSimple() bool {
 	return true
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (m MultiLineString) Intersection(g Geometry) (Geometry, error) {
-	return intersection(m.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (m MultiLineString) Intersects(g Geometry) bool {

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -118,13 +118,6 @@ func (m MultiPoint) IsSimple() bool {
 	return true
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (m MultiPoint) Intersection(g Geometry) (Geometry, error) {
-	return intersection(m.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (m MultiPoint) Intersects(g Geometry) bool {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -250,13 +250,6 @@ func (m MultiPolygon) Intersects(g Geometry) bool {
 	return hasIntersection(m.AsGeometry(), g)
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (m MultiPolygon) Intersection(g Geometry) (Geometry, error) {
-	return intersection(m.AsGeometry(), g)
-}
-
 // IsEmpty return true if and only if this MultiPolygon doesn't contain any
 // Polygons, or only contains empty Polygons.
 func (m MultiPolygon) IsEmpty() bool {

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -81,13 +81,6 @@ func (p Point) IsSimple() bool {
 	return true
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (p Point) Intersection(g Geometry) (Geometry, error) {
-	return intersection(p.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (p Point) Intersects(g Geometry) bool {

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -238,13 +238,6 @@ func (p Polygon) IsSimple() bool {
 	return true
 }
 
-// Intersection calculates the of this geometry and another, i.e. the portion
-// of the two geometries that are shared. It is not implemented for all
-// geometry pairs, and returns an error for those cases.
-func (p Polygon) Intersection(g Geometry) (Geometry, error) {
-	return intersection(p.AsGeometry(), g)
-}
-
 // Intersects return true if and only if this geometry intersects with the
 // other, i.e. they shared at least one common point.
 func (p Polygon) Intersects(g Geometry) bool {


### PR DESCRIPTION
This is because it is only partially complete. We can add it back in
once it works for all geometry pairs.

Fixes #155 