### PR TITLE
Use r-tree for LineString's IsSimple

### DIFF
--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -205,6 +205,29 @@ func TestIsSimple(t *testing.T) {
 	}
 }
 
+func BenchmarkLineStringIsSimpleZigZag(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(strconv.Itoa(sz), func(b *testing.B) {
+			floats := make([]float64, 2*sz)
+			for i := 0; i < sz; i++ {
+				floats[2*i+0] = float64(i%2) * 0.01
+				floats[2*i+1] = float64(i) * 0.01
+			}
+			ls, err := NewLineString(NewSequence(floats, DimXY))
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if !ls.IsSimple() {
+					b.Fatal("not simple")
+				}
+			}
+		})
+	}
+}
+
 func TestIsSimpleGeometryCollection(t *testing.T) {
 	_, defined := geomFromWKT(t, "GEOMETRYCOLLECTION(POINT(1 2))").IsSimple()
 	expectBoolEq(t, defined, false)

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -160,6 +160,7 @@ func TestIsSimple(t *testing.T) {
 		{"LINESTRING(0 0,1 1,2 2)", true},
 		{"LINESTRING(0 0,0 0,0 1,1 0,0 0)", true},
 		{"LINESTRING(0 0,0 1,1 0,0 0,0 0)", true},
+		{"LINESTRING(1 2,1 2,3 4,3 4,3 4,5 6,5 6)", true},
 
 		{"POLYGON((0 0,0 1,1 0,0 0))", true},
 

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -158,6 +158,8 @@ func TestIsSimple(t *testing.T) {
 		{"LINESTRING(1 1,2 2,0 0)", false},
 		{"LINESTRING(1 1,2 2,3 2,3 3,0 0)", false},
 		{"LINESTRING(0 0,1 1,2 2)", true},
+		{"LINESTRING(0 0,0 0,0 1,1 0,0 0)", true},
+		{"LINESTRING(0 0,0 1,1 0,0 0,0 0)", true},
 
 		{"POLYGON((0 0,0 1,1 0,0 0))", true},
 

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -96,6 +96,12 @@ func (s LineString) IsSimple() bool {
 		return true
 	}
 
+	// We need to track the index of the previous line segments, so that we can
+	// ignore the case where adjacent line segments intersect at a point (due
+	// to their construction). We can just subtract 1 from the current index,
+	// since there could be duplicated vertices in the middle of the sequence.
+	prev := -1
+
 	var tree rtree.RTree
 	n := s.seq.Length()
 	for i := 0; i < n; i++ {
@@ -127,7 +133,7 @@ func (s LineString) IsSimple() bool {
 			// The dimension must be 1. Since the intersection is between two
 			// lines, the intersection must be a *single* point.
 
-			if abs(i-j) == 1 {
+			if j == prev {
 				// Adjacent lines will intersect at a point due to
 				// construction, so this case is okay.
 				return nil
@@ -155,6 +161,7 @@ func (s LineString) IsSimple() bool {
 			return false
 		}
 		tree.Insert(box, i)
+		prev = i
 	}
 	return true
 }

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -142,8 +142,7 @@ func (s LineString) IsSimple() bool {
 			// The first and last segment are allowed to intersect at a point,
 			// so long as that point is the start of the first segment and the
 			// end of the last segment (i.e. the line string is closed).
-			atLoop := (i == first && j == last) || (i == last && j == first)
-			if atLoop && s.IsClosed() {
+			if i == last && j == first && s.IsClosed() {
 				return nil
 			}
 

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -142,13 +142,9 @@ func (s LineString) IsSimple() bool {
 			// The first and last segment are allowed to intersect at a point,
 			// so long as that point is the start of the first segment and the
 			// end of the last segment (i.e. the line string is closed).
-			if (i == first && j == last) || (i == last && j == first) {
-				if s.IsClosed() {
-					return nil
-				} else {
-					simple = false
-					return rtree.Stop
-				}
+			atLoop := (i == first && j == last) || (i == last && j == first)
+			if atLoop && s.IsClosed() {
+				return nil
 			}
 
 			// Any other point intersection (e.g. looping back on

--- a/geom/type_sequence.go
+++ b/geom/type_sequence.go
@@ -132,8 +132,7 @@ func (s Sequence) Force2D() Sequence {
 // getLine extracts a 2D line segment from a sequence by joining together
 // adjacent locations in the sequence. It is designed to be called with i equal
 // to each index in the sequence (from 0 to n-1, both inclusive). The flag
-// indicates if the returned line is valid. Calling getLine with 0 will never
-// return a valid line, calling getLine with 1 will return the first line etc.
+// indicates if the returned line is valid.
 func getLine(seq Sequence, i int) (line, bool) {
 	if i == 0 {
 		return line{}, false
@@ -143,4 +142,24 @@ func getLine(seq Sequence, i int) (line, bool) {
 		b: seq.GetXY(i),
 	}
 	return ln, ln.a != ln.b
+}
+
+// firstAndLastLines returns the index of the first and last line segments (if
+// they exist) in the sequence.
+func firstAndLastLines(seq Sequence) (int, int, bool) {
+	n := seq.Length()
+	first, last := -1, -1
+	for i := 1; i < n; i++ {
+		if seq.GetXY(i) != seq.GetXY(i-1) {
+			first = i
+			break
+		}
+	}
+	for i := n - 1; i >= 1; i-- {
+		if seq.GetXY(i) != seq.GetXY(i-1) {
+			last = i
+			break
+		}
+	}
+	return first, last, first != -1 && last != -1
 }

--- a/geom/type_sequence.go
+++ b/geom/type_sequence.go
@@ -132,7 +132,8 @@ func (s Sequence) Force2D() Sequence {
 // getLine extracts a 2D line segment from a sequence by joining together
 // adjacent locations in the sequence. It is designed to be called with i equal
 // to each index in the sequence (from 0 to n-1, both inclusive). The flag
-// indicates if the returned line is valid.
+// indicates if the returned line is valid. Calling getLine with 0 will never
+// return a valid line, calling getLine with 1 will return the first line etc.
 func getLine(seq Sequence, i int) (line, bool) {
 	if i == 0 {
 		return line{}, false


### PR DESCRIPTION
This fixes the "worst case scenario" for this algorithm, which occurs
when the line segments in the LineString are stacked on top of each
other vertically (vertical zig zag).

Performance change:

```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkLineStringIsSimpleZigZag/10-4        1499          3683          +145.70%
BenchmarkLineStringIsSimpleZigZag/100-4       72693         93119         +28.10%
BenchmarkLineStringIsSimpleZigZag/1000-4      5991268       1265259       -78.88%
BenchmarkLineStringIsSimpleZigZag/10000-4     585784268     16355471      -97.21%
```

Worse for smaller inputs, but quickly catches up for inputs > 100. Significantly better complexity class (quadratic vs linearithmic). I suspect there are some "large" constants for the new solution related to memory management in the rtree.