### PR TITLE
Use r-tree for MLS/MLS intersection in MultiPolygon validation

### DIFF
--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -15,6 +15,8 @@ func intersectionOfMultiLineStringAndMultiLineString(
 }
 
 func intersectionOfLines(lines1, lines2 []line) (MultiPoint, MultiLineString) {
+	// TODO: Should we swap lines1 and lines2 depending on length?
+
 	bulk := make([]rtree.BulkItem, len(lines1))
 	for i, ln := range lines1 {
 		bulk[i] = rtree.BulkItem{

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -1,69 +1,52 @@
 package geom
 
-func intersectionOfLineStringAndLineString(ls1, ls2 LineString) (MultiPoint, MultiLineString) {
-	// TODO: This is quadratic in the length of the input. Should use an
-	// acceleration structure.
-	var points []XY
-	var lines []line
-	seq1 := ls1.Coordinates()
-	for i := 0; i < seq1.Length(); i++ {
-		ln1, ok := getLine(seq1, i)
-		if !ok {
-			continue
-		}
-		seq2 := ls2.Coordinates()
-		for j := 0; j < seq2.Length(); j++ {
-			ln2, ok := getLine(seq2, j)
-			if !ok {
-				continue
-			}
-			inter := ln1.intersectLine(ln2)
-			if inter.empty {
-				continue
-			}
-			if inter.ptA == inter.ptB {
-				points = append(points, inter.ptA)
-			} else {
-				lines = append(lines, line{inter.ptA, inter.ptB})
-			}
-		}
-	}
+import "github.com/peterstace/simplefeatures/rtree"
 
-	mpFloats := make([]float64, 0, 2*len(points))
-	for _, xy := range points {
-		mpFloats = append(mpFloats, xy.X, xy.Y)
-	}
-
-	lss := make([]LineString, 0, len(lines))
-	for _, ln := range lines {
-		lss = append(lss, ln.asLineString())
-	}
-
-	return NewMultiPoint(NewSequence(mpFloats, DimXY)), NewMultiLineStringFromLineStrings(lss)
+func intersectionOfLineStringAndLineString(
+	ls1, ls2 LineString,
+) (MultiPoint, MultiLineString) {
+	return intersectionOfLines(ls1.asLines(), ls2.asLines())
 }
 
 func intersectionOfMultiLineStringAndMultiLineString(
 	mls1, mls2 MultiLineString,
-) (
-	MultiPoint, MultiLineString,
-) {
-	// TODO: This has horrible time complexity. Should use acceleration structure.
-	var pts []Point
-	var lss []LineString
-	for i := 0; i < mls1.NumLineStrings(); i++ {
-		ls1 := mls1.LineStringN(i)
-		for j := 0; j < mls2.NumLineStrings(); j++ {
-			ls2 := mls2.LineStringN(j)
-			interMP, interMLS := intersectionOfLineStringAndLineString(ls1, ls2)
-			for k := 0; k < interMP.NumPoints(); k++ {
-				pts = append(pts, interMP.PointN(k))
-			}
-			for k := 0; k < interMLS.NumLineStrings(); k++ {
-				lss = append(lss, interMLS.LineStringN(k))
-			}
+) (MultiPoint, MultiLineString) {
+	return intersectionOfLines(mls1.asLines(), mls2.asLines())
+}
+
+func intersectionOfLines(lines1, lines2 []line) (MultiPoint, MultiLineString) {
+	bulk := make([]rtree.BulkItem, len(lines1))
+	for i, ln := range lines1 {
+		bulk[i] = rtree.BulkItem{
+			Box:       toBox(ln.envelope()),
+			DataIndex: i,
 		}
 	}
-	return NewMultiPointFromPoints(pts), NewMultiLineStringFromLineStrings(lss)
+	tree := rtree.BulkLoad(bulk)
+
+	var lines []LineString
+	var ptFloats []float64
+	seen := make(map[XY]bool)
+
+	for j := range lines2 {
+		tree.Search(toBox(lines2[j].envelope()), func(i int) error {
+			inter := lines2[j].intersectLine(lines1[i])
+			if inter.empty {
+				return nil
+			}
+			if inter.ptA == inter.ptB {
+				if pt := inter.ptA; !seen[pt] {
+					ptFloats = append(ptFloats, pt.X, pt.Y)
+					seen[pt] = true
+				}
+			} else {
+				lines = append(lines, line{inter.ptA, inter.ptB}.asLineString())
+			}
+			return nil
+		})
+	}
+	return NewMultiPoint(NewSequence(ptFloats, DimXY)),
+		NewMultiLineStringFromLineStrings(lines)
 }
 
 func intersectionOfMultiPointAndMultiPoint(mp1, mp2 MultiPoint) MultiPoint {

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -328,3 +328,46 @@ func BenchmarkMultipolygonValidation(b *testing.B) {
 		})
 	}
 }
+
+// regularPolygon computes a regular polygon circumscribed by a circle with the
+// given center and radius. Sides must be at least 3 or it will panic.
+func regularPolygon(center XY, radius float64, sides int) Polygon {
+	if sides <= 2 {
+		panic(sides)
+	}
+	coords := make([]float64, 2*(sides+1))
+	for i := 0; i < sides; i++ {
+		angle := math.Pi/2 + float64(i)/float64(sides)*2*math.Pi
+		coords[2*i+0] = center.X + math.Cos(angle)*radius
+		coords[2*i+1] = center.Y + math.Sin(angle)*radius
+	}
+	coords[2*sides+0] = coords[0]
+	coords[2*sides+1] = coords[1]
+	ring, err := NewLineString(NewSequence(coords, DimXY))
+	if err != nil {
+		panic(err)
+	}
+	poly, err := NewPolygonFromRings([]LineString{ring})
+	if err != nil {
+		panic(err)
+	}
+	return poly
+}
+
+func BenchmarkMultiPolygonTwoCircles(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+			const eps = 0.1
+			polys := []Polygon{
+				regularPolygon(XY{X: -eps, Y: -eps}, 1.0, sz),
+				regularPolygon(XY{X: math.Sqrt2, Y: math.Sqrt2}, 1.0, sz),
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := NewMultiPolygonFromPolygons(polys); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -169,6 +169,14 @@ func TestMultiPolygonValidation(t *testing.T) {
 			((0 0,0 1,1 0,0 0)),
 			((0 0,0 1,1 0,0 0))
 		)`,
+		`MULTIPOLYGON(
+			((0 0,3 0,3 3,0 3,0 0)),
+			((1 1,2 1,2 2,1 2,1 1))
+		)`,
+		`MULTIPOLYGON(
+			((1 1,2 1,2 2,1 2,1 1)),
+			((0 0,3 0,3 3,0 3,0 0))
+		)`,
 	} {
 		t.Run(fmt.Sprintf("invalid_%d", i), func(t *testing.T) {
 			_, err := UnmarshalWKT(strings.NewReader(wkt))


### PR DESCRIPTION
```
name                                          old time/op  new time/op  delta
IntersectsLineStringWithLineString/n=10-4     3.61µs ± 5%  3.63µs ± 8%     ~     (p=0.675 n=14+15)
IntersectsLineStringWithLineString/n=100-4    53.8µs ±18%  52.6µs ± 8%     ~     (p=0.775 n=15+15)
IntersectsLineStringWithLineString/n=1000-4    706µs ± 6%   694µs ± 7%     ~     (p=0.310 n=15+14)
IntersectsLineStringWithLineString/n=10000-4  11.2ms ± 9%  10.9ms ± 8%     ~     (p=0.345 n=15+15)
LineStringIsSimpleZigZag/10-4                 3.72µs ± 6%  3.80µs ± 8%     ~     (p=0.683 n=14+15)
LineStringIsSimpleZigZag/100-4                97.1µs ± 6%  96.1µs ± 7%     ~     (p=0.477 n=15+14)
LineStringIsSimpleZigZag/1000-4               1.34ms ± 5%  1.33ms ± 9%     ~     (p=0.252 n=14+15)
LineStringIsSimpleZigZag/10000-4              17.6ms ± 6%  17.6ms ± 8%     ~     (p=0.769 n=14+14)
PolygonSingleRingValidation/n=10-4            4.39µs ± 5%  4.36µs ± 2%     ~     (p=0.296 n=14+13)
PolygonSingleRingValidation/n=100-4            100µs ±11%    98µs ± 6%     ~     (p=0.653 n=15+15)
PolygonSingleRingValidation/n=1000-4          1.43ms ± 7%  1.42ms ± 6%     ~     (p=0.830 n=14+13)
PolygonSingleRingValidation/n=10000-4         21.7ms ± 4%  21.8ms ± 5%     ~     (p=0.533 n=14+15)
PolygonMultipleRingsValidation/n=4-4          15.3µs ± 9%  15.2µs ± 6%     ~     (p=0.982 n=14+14)
PolygonMultipleRingsValidation/n=36-4          140µs ± 5%   139µs ± 6%     ~     (p=0.621 n=15+14)
PolygonMultipleRingsValidation/n=400-4        1.78ms ± 8%  1.80ms ± 8%     ~     (p=0.316 n=13+15)
PolygonMultipleRingsValidation/n=4096-4       20.9ms ± 5%  20.5ms ± 9%     ~     (p=0.123 n=12+13)
PolygonZigZagRingsValidation/n=10-4           35.7µs ± 5%  34.5µs ± 5%   -3.46%  (p=0.011 n=14+14)
PolygonZigZagRingsValidation/n=100-4           450µs ± 7%   448µs ± 7%     ~     (p=0.822 n=14+15)
PolygonZigZagRingsValidation/n=1000-4         5.86ms ± 8%  5.80ms ± 9%     ~     (p=0.354 n=15+14)
PolygonZigZagRingsValidation/n=10000-4        77.8ms ± 6%  75.9ms ± 3%   -2.48%  (p=0.016 n=14+14)
MultipolygonValidation/n=1-4                   318ns ± 4%   320ns ± 8%     ~     (p=0.711 n=13+14)
MultipolygonValidation/n=4-4                   944ns ± 5%   939ns ± 5%     ~     (p=0.676 n=14+13)
MultipolygonValidation/n=16-4                 9.26µs ± 9%  9.09µs ±17%     ~     (p=0.325 n=14+13)
MultipolygonValidation/n=64-4                 58.4µs ± 7%  59.6µs ± 6%     ~     (p=0.112 n=14+15)
MultipolygonValidation/n=256-4                 312µs ± 4%   313µs ± 5%     ~     (p=0.713 n=15+15)
MultipolygonValidation/n=1024-4               1.61ms ± 8%  1.57ms ± 4%     ~     (p=0.290 n=15+14)
MultiPolygonTwoCircles/n=10-4                 26.3µs ± 7%   6.7µs ± 5%  -74.61%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                1.54ms ± 4%  0.08ms ±10%  -94.69%  (p=0.000 n=14+15)
MultiPolygonTwoCircles/n=1000-4                140ms ± 3%     1ms ±13%  -99.28%  (p=0.000 n=13+15)
MultiPolygonTwoCircles/n=10000-4               13.6s ± 0%    0.0s ±12%  -99.90%  (p=0.000 n=12+15)
```