### PR TITLE
Use uint64 rather than int for r-tree record ID

### DIFF
--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -21,7 +21,7 @@ func intersectionOfLines(lines1, lines2 []line) (MultiPoint, MultiLineString) {
 	for i, ln := range lines1 {
 		bulk[i] = rtree.BulkItem{
 			Box:      toBox(ln.envelope()),
-			RecordID: i,
+			RecordID: uint64(i),
 		}
 	}
 	tree := rtree.BulkLoad(bulk)
@@ -31,7 +31,7 @@ func intersectionOfLines(lines1, lines2 []line) (MultiPoint, MultiLineString) {
 	seen := make(map[XY]bool)
 
 	for j := range lines2 {
-		tree.Search(toBox(lines2[j].envelope()), func(i int) error {
+		tree.Search(toBox(lines2[j].envelope()), func(i uint64) error {
 			inter := lines2[j].intersectLine(lines1[i])
 			if inter.empty {
 				return nil

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -201,7 +201,7 @@ func hasIntersectionBetweenLines(
 	for i, ln := range lines1 {
 		bulk[i] = rtree.BulkItem{
 			Box:      toBox(ln.envelope()),
-			RecordID: i,
+			RecordID: uint64(i),
 		}
 	}
 	tree := rtree.BulkLoad(bulk)
@@ -212,7 +212,7 @@ func hasIntersectionBetweenLines(
 	var envPopulated bool
 
 	for _, lnA := range lines2 {
-		tree.Search(toBox(lnA.envelope()), func(i int) error {
+		tree.Search(toBox(lnA.envelope()), func(i uint64) error {
 			lnB := lines1[i]
 			inter := lnA.intersectLine(lnB)
 			if inter.empty {

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -100,7 +100,7 @@ func (s LineString) IsSimple() bool {
 	// ignore the case where adjacent line segments intersect at a point (due
 	// to their construction). We can just subtract 1 from the current index,
 	// since there could be duplicated vertices in the middle of the sequence.
-	prev := -1
+	var prev uint64 = math.MaxUint64
 
 	var tree rtree.RTree
 	n := s.seq.Length()
@@ -111,8 +111,8 @@ func (s LineString) IsSimple() bool {
 		}
 		simple := true // assume simple until proven otherwise
 		box := toBox(ln.envelope())
-		tree.Search(box, func(j int) error {
-			other, ok := getLine(s.seq, j)
+		tree.Search(box, func(j uint64) error {
+			other, ok := getLine(s.seq, int(j))
 			if !ok {
 				// We previously were able to access line j (otherwise we
 				// wouldn't have been able to put it into the tree). So if we
@@ -142,7 +142,7 @@ func (s LineString) IsSimple() bool {
 			// The first and last segment are allowed to intersect at a point,
 			// so long as that point is the start of the first segment and the
 			// end of the last segment (i.e. the line string is closed).
-			if i == last && j == first && s.IsClosed() {
+			if i == last && int(j) == first && s.IsClosed() {
 				return nil
 			}
 
@@ -155,8 +155,8 @@ func (s LineString) IsSimple() bool {
 		if !simple {
 			return false
 		}
-		tree.Insert(box, i)
-		prev = i
+		tree.Insert(box, uint64(i))
+		prev = uint64(i)
 	}
 	return true
 }

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -62,7 +62,7 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 		}
 		box := toBox(env)
 
-		err := tree.Search(box, func(j int) error {
+		err := tree.Search(box, func(j uint64) error {
 			interMP, interMLS := intersectionOfMultiLineStringAndMultiLineString(
 				polys[i].Boundary(),
 				polys[j].Boundary(),
@@ -98,7 +98,7 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 			return err
 		}
 
-		tree.Insert(box, i)
+		tree.Insert(box, uint64(i))
 	}
 	return nil
 }

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -81,7 +81,7 @@ func validatePolygon(rings []LineString, opts ...ConstructorOption) error {
 			return errors.New("polygon rings must not be empty")
 		}
 		box := toBox(env)
-		if err := tree.Search(box, func(j int) error {
+		if err := tree.Search(box, func(j uint64) error {
 			otherRing := rings[j]
 			if i > 0 && j > 0 { // Check is skipped if the outer ring is involved.
 				// It's ok to access the first coord (index 0), since we've
@@ -112,13 +112,13 @@ func validatePolygon(rings []LineString, opts ...ConstructorOption) error {
 				interVerts[ext.singlePoint] = interVert
 			}
 			graph.addEdge(interVert, i)
-			graph.addEdge(interVert, j)
+			graph.addEdge(interVert, int(j))
 			return nil
 		}); err != nil {
 			return err
 		}
 
-		tree.Insert(box, i)
+		tree.Insert(box, uint64(i))
 	}
 
 	// All inner rings must be inside the outer ring.

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -5,7 +5,7 @@ import "sort"
 // BulkItem is an item that can be inserted for bulk loading.
 type BulkItem struct {
 	Box      Box
-	RecordID int
+	RecordID uint64
 }
 
 // BulkLoad bulk loads multiple items into a new R-Tree. The bulk load
@@ -23,8 +23,8 @@ func (t *RTree) bulkInsert(items []BulkItem) int {
 		node := node{isLeaf: true, parent: -1}
 		for _, item := range items {
 			node.entries = append(node.entries, entry{
-				box:   item.Box,
-				index: item.RecordID,
+				box:      item.Box,
+				recordID: item.RecordID,
 			})
 		}
 		t.nodes = append(t.nodes, node)
@@ -52,8 +52,8 @@ func (t *RTree) bulkInsert(items []BulkItem) int {
 	n2 := t.bulkInsert(items[split:])
 
 	parent := node{isLeaf: false, parent: -1, entries: []entry{
-		entry{box: t.calculateBound(n1), index: n1},
-		entry{box: t.calculateBound(n2), index: n2},
+		entry{box: t.calculateBound(n1), child: n1},
+		entry{box: t.calculateBound(n2), child: n2},
 	}}
 	t.nodes = append(t.nodes, parent)
 	t.nodes[n1].parent = len(t.nodes) - 1


### PR DESCRIPTION
By using a uint64, we open up the possibility do do things other than
just storing an index to an array with the record id. E.g. we could
treat the uint64 as two uint32s, and store two different indexes. This
would be less clean with an int, because we can't be 100% guarenteed
that we have 64 bits to play with.