### PR TITLE
Pass constructor options to any GEOS operations that produce Geometries

### DIFF
--- a/geos/libgeos_test.go
+++ b/geos/libgeos_test.go
@@ -561,7 +561,7 @@ type BinaryOperationTestCase struct {
 	Out      string
 }
 
-func RunBinaryOperationTest(t *testing.T, fn func(a, b geom.Geometry) (geom.Geometry, error), cases []BinaryOperationTestCase) {
+func RunBinaryOperationTest(t *testing.T, fn func(a, b geom.Geometry, opts ...geom.ConstructorOption) (geom.Geometry, error), cases []BinaryOperationTestCase) {
 	for i, c := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			run := func(rev bool) func(t *testing.T) {


### PR DESCRIPTION
This will allow users to disable validation for the results of GEOS
operations. This could be useful for two reasons (right now):

1. It will give a performance boost. Technically, GEOS operations
   _shouln't_ produce invalid geometries. So users may want to skip
   validation for that reason.

2. GEOS may _not_ give valid geometries in all cases. E.g. a bug in
   GEOS. Users may wish to disable validations so that they get _some_
   sort of geometry back.

Fixes #177 