### PR TITLE
GEOS benchmarks

### DIFF
--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -26,7 +26,7 @@ func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	if err != nil {
 		panic(err)
 	}
-	poly, err := geom.NewPolygonFromRings([]geom.LineString{ring})
+	poly, err := geom.NewPolygonFromRings([]geom.LineString{ring}, geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}

--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -1,0 +1,52 @@
+package geos_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geos"
+)
+
+// regularPolygon computes a regular polygon circumscribed by a circle with the
+// given center and radius. Sides must be at least 3 or it will panic.
+func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
+	if sides <= 2 {
+		panic(sides)
+	}
+	coords := make([]float64, 2*(sides+1))
+	for i := 0; i < sides; i++ {
+		angle := math.Pi/2 + float64(i)/float64(sides)*2*math.Pi
+		coords[2*i+0] = center.X + math.Cos(angle)*radius
+		coords[2*i+1] = center.Y + math.Sin(angle)*radius
+	}
+	coords[2*sides+0] = coords[0]
+	coords[2*sides+1] = coords[1]
+	ring, err := geom.NewLineString(geom.NewSequence(coords, geom.DimXY))
+	if err != nil {
+		panic(err)
+	}
+	poly, err := geom.NewPolygonFromRings([]geom.LineString{ring})
+	if err != nil {
+		panic(err)
+	}
+	return poly
+}
+
+func BenchmarkIntersection(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+			inputA := regularPolygon(geom.XY{X: 0, Y: 0}, 1.0, sz).AsGeometry()
+			inputB := regularPolygon(geom.XY{X: 1, Y: 0}, 1.0, sz).AsGeometry()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := geos.Intersection(inputA, inputB)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -22,7 +22,7 @@ func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	}
 	coords[2*sides+0] = coords[0]
 	coords[2*sides+1] = coords[1]
-	ring, err := geom.NewLineString(geom.NewSequence(coords, geom.DimXY))
+	ring, err := geom.NewLineString(geom.NewSequence(coords, geom.DimXY), geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}

--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -49,3 +49,19 @@ func BenchmarkIntersection(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkNoOp(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+			input := regularPolygon(geom.XY{X: 0, Y: 0}, 1.0, sz).AsGeometry()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, err := noop(input, geom.DisableAllValidations)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -1,4 +1,4 @@
-package geos_test
+package geos
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
-	"github.com/peterstace/simplefeatures/geos"
 )
 
 // regularPolygon computes a regular polygon circumscribed by a circle with the
@@ -39,10 +38,10 @@ func BenchmarkIntersection(b *testing.B) {
 		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
 			inputA := regularPolygon(geom.XY{X: 0, Y: 0}, 1.0, sz).AsGeometry()
 			inputB := regularPolygon(geom.XY{X: 1, Y: 0}, 1.0, sz).AsGeometry()
-
 			b.ResetTimer()
+
 			for i := 0; i < b.N; i++ {
-				_, err := geos.Intersection(inputA, inputB)
+				_, err := Intersection(inputA, inputB, geom.DisableAllValidations)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -14,6 +14,8 @@ old="$(mktemp)"
 new="$(mktemp)"
 trap "rm -f $new $old" EXIT
 
+package="./..."
+
 for (( i = 0; i < 15; i++ )); do
 	echo
 	echo "RUN $i"
@@ -22,13 +24,13 @@ for (( i = 0; i < 15; i++ )); do
 	echo "OLD"
 	git checkout "$old_git_sha1"
 	echo
-	go test ./... -test.run='^$' -benchtime=0.1s -benchmem -bench=. | tee -a "$old"
+	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench=. | tee -a "$old"
 
 	echo
 	echo "NEW"
 	git checkout "$new_git_sha1"
 	echo
-	go test ./... -test.run='^$' -benchtime=0.1s -benchmem -bench=. | tee -a "$new"
+	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench=. | tee -a "$new"
 done
 
 echo


### PR DESCRIPTION
## Description

Adds two new benchmark tests.

1. No-op GEOS test. This creates a polygon, sends it to GEOS, does a NOP, and sends it back to simplefeatures. This benchmark essentially does 4 operations: 1) Converts from simplefeatures representation to WKB 2) Unmarshals that WKB using GEOS 3) Marshals to a new WKB in GEOS, 4) Unmarshals the WKB to a Go representation.

2. Intersection test. This benchmarks the intersection (using GEOS) of two circular polygons that partially overlap.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

#188 

## Benchmark Results

As expected, no change:

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.61µs ±15%    3.69µs ± 9%    ~     (p=0.086 n=13+15)
IntersectsLineStringWithLineString/n=100-4      53.1µs ±16%    52.4µs ±12%    ~     (p=0.734 n=14+14)
IntersectsLineStringWithLineString/n=1000-4      688µs ± 6%     691µs ± 6%    ~     (p=0.802 n=14+13)
IntersectsLineStringWithLineString/n=10000-4    11.1ms ± 6%    11.4ms ± 8%    ~     (p=0.128 n=12+12)
LineStringIsSimpleZigZag/10-4                   3.70µs ± 7%    3.74µs ±11%    ~     (p=0.919 n=14+14)
LineStringIsSimpleZigZag/100-4                  94.7µs ± 9%    96.7µs ± 8%    ~     (p=0.164 n=14+14)
LineStringIsSimpleZigZag/1000-4                 1.40ms ±23%    1.32ms ± 5%  -5.77%  (p=0.011 n=15+13)
LineStringIsSimpleZigZag/10000-4                17.2ms ± 7%    18.1ms ± 8%  +5.47%  (p=0.000 n=13+15)
PolygonSingleRingValidation/n=10-4              4.35µs ±10%    4.39µs ± 8%    ~     (p=0.376 n=14+14)
PolygonSingleRingValidation/n=100-4             96.7µs ± 4%    98.8µs ±12%    ~     (p=0.496 n=13+15)
PolygonSingleRingValidation/n=1000-4            1.41ms ± 6%    1.45ms ± 8%    ~     (p=0.081 n=15+15)
PolygonSingleRingValidation/n=10000-4           22.1ms ±19%    21.7ms ± 8%    ~     (p=0.839 n=14+14)
PolygonMultipleRingsValidation/n=4-4            15.7µs ± 7%    15.4µs ± 7%    ~     (p=0.720 n=13+14)
PolygonMultipleRingsValidation/n=36-4            142µs ± 9%     141µs ±10%    ~     (p=0.618 n=15+13)
PolygonMultipleRingsValidation/n=400-4          1.86ms ±11%    1.85ms ± 7%    ~     (p=0.806 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         20.7ms ± 7%    20.6ms ± 5%    ~     (p=0.667 n=14+14)
PolygonZigZagRingsValidation/n=10-4             35.8µs ±10%    35.8µs ±10%    ~     (p=0.880 n=14+15)
PolygonZigZagRingsValidation/n=100-4             457µs ±14%     449µs ± 8%    ~     (p=0.621 n=14+15)
PolygonZigZagRingsValidation/n=1000-4           5.75ms ±12%    5.77ms ±12%    ~     (p=0.983 n=15+14)
PolygonZigZagRingsValidation/n=10000-4          78.8ms ± 7%    77.9ms ± 8%    ~     (p=0.331 n=15+14)
MultipolygonValidation/n=1-4                     383ns ±14%     383ns ±22%    ~     (p=0.923 n=15+14)
MultipolygonValidation/n=4-4                    1.07µs ±12%    1.08µs ± 8%    ~     (p=0.710 n=14+14)
MultipolygonValidation/n=16-4                   9.46µs ±12%    9.76µs ±10%    ~     (p=0.339 n=13+15)
MultipolygonValidation/n=64-4                   59.7µs ±11%    58.0µs ± 3%    ~     (p=0.137 n=14+14)
MultipolygonValidation/n=256-4                   308µs ± 7%     308µs ± 5%    ~     (p=0.762 n=13+13)
MultipolygonValidation/n=1024-4                 1.62ms ±12%    1.66ms ±20%    ~     (p=0.561 n=15+14)
MultiPolygonTwoCircles/n=10-4                   10.5µs ± 4%    10.8µs ±11%    ~     (p=0.275 n=13+14)
MultiPolygonTwoCircles/n=100-4                   131µs ± 8%     132µs ± 4%    ~     (p=0.141 n=14+13)
MultiPolygonTwoCircles/n=1000-4                 1.78ms ±12%    1.76ms ± 3%    ~     (p=0.614 n=15+12)
MultiPolygonTwoCircles/n=10000-4                26.2ms ±12%    26.4ms ± 6%    ~     (p=0.454 n=14+14)
MultiPolygonMultipleTouchingPoints/n=1-4        7.54µs ± 4%    7.73µs ±12%    ~     (p=0.217 n=12+14)
MultiPolygonMultipleTouchingPoints/n=10-4       61.6µs ±10%    59.8µs ± 7%    ~     (p=0.202 n=14+13)
MultiPolygonMultipleTouchingPoints/n=100-4       724µs ± 9%     700µs ± 2%    ~     (p=0.160 n=14+12)
MultiPolygonMultipleTouchingPoints/n=1000-4     8.93ms ± 8%    8.98ms ± 6%    ~     (p=0.430 n=13+14)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.63kB ± 0%    3.63kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=100-4      40.1kB ± 0%    40.1kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      369kB ± 0%     369kB ± 0%    ~     (p=0.462 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    5.45MB ± 0%    5.45MB ± 0%    ~     (p=0.689 n=15+15)
LineStringIsSimpleZigZag/10-4                   3.34kB ± 0%    3.34kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/100-4                  64.4kB ± 0%    64.4kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  667kB ± 0%     667kB ± 0%    ~     (p=0.972 n=14+14)
LineStringIsSimpleZigZag/10000-4                7.33MB ± 0%    7.33MB ± 0%    ~     (p=0.904 n=15+14)
PolygonSingleRingValidation/n=10-4              3.47kB ± 0%    3.47kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=100-4             62.4kB ± 0%    62.4kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=1000-4             666kB ± 0%     666kB ± 0%    ~     (p=1.003 n=13+15)
PolygonSingleRingValidation/n=10000-4           7.34MB ± 0%    7.34MB ± 0%    ~     (p=0.242 n=14+12)
PolygonMultipleRingsValidation/n=4-4            7.90kB ± 0%    7.90kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           73.1kB ± 0%    73.1kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           847kB ± 0%     847kB ± 0%    ~     (p=1.003 n=15+14)
PolygonMultipleRingsValidation/n=4096-4         9.08MB ± 0%    9.08MB ± 0%    ~     (p=0.973 n=13+14)
PolygonZigZagRingsValidation/n=10-4             21.2kB ± 0%    21.2kB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             247kB ± 0%     247kB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4           2.38MB ± 0%    2.38MB ± 0%    ~     (p=0.100 n=14+15)
PolygonZigZagRingsValidation/n=10000-4          30.5MB ± 0%    30.5MB ± 0%    ~     (p=0.991 n=15+14)
MultipolygonValidation/n=1-4                      225B ± 0%      225B ± 0%    ~     (all equal)
MultipolygonValidation/n=4-4                      820B ± 0%      820B ± 0%    ~     (all equal)
MultipolygonValidation/n=16-4                   8.53kB ± 0%    8.53kB ± 0%    ~     (all equal)
MultipolygonValidation/n=64-4                   44.7kB ± 0%    44.7kB ± 0%    ~     (all equal)
MultipolygonValidation/n=256-4                   185kB ± 0%     185kB ± 0%    ~     (all equal)
MultipolygonValidation/n=1024-4                  783kB ± 0%     783kB ± 0%    ~     (p=0.156 n=12+15)
MultiPolygonTwoCircles/n=10-4                   7.81kB ± 0%    7.81kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=100-4                  74.4kB ± 0%    74.4kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  673kB ± 0%     673kB ± 0%    ~     (p=0.710 n=15+15)
MultiPolygonTwoCircles/n=10000-4                10.3MB ± 0%    10.3MB ± 0%    ~     (p=0.148 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1-4        4.79kB ± 0%    4.79kB ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       26.9kB ± 0%    26.9kB ± 0%    ~     (p=0.202 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       243kB ± 0%     243kB ± 0%    ~     (p=0.878 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.44MB ± 0%    2.44MB ± 0%    ~     (p=1.000 n=15+15)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         34.0 ± 0%      34.0 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=100-4         363 ± 0%       363 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      3.06k ± 0%     3.06k ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4     33.6k ± 0%     33.6k ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10-4                     27.0 ± 0%      27.0 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/100-4                     441 ± 0%       441 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  4.62k ± 0%     4.62k ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 46.4k ± 0%     46.4k ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10-4                30.0 ± 0%      30.0 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=100-4                427 ± 0%       427 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=1000-4             4.61k ± 0%     4.61k ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10000-4            46.5k ± 0%     46.5k ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              90.0 ± 0%      90.0 ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              778 ± 0%       778 ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           8.89k ± 0%     8.89k ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          92.1k ± 0%     92.1k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10-4                209 ± 0%       209 ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             2.00k ± 0%     2.00k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4            18.4k ± 0%     18.4k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4            194k ± 0%      194k ± 0%    ~     (p=0.867 n=15+14)
MultipolygonValidation/n=1-4                      6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MultipolygonValidation/n=4-4                      11.0 ± 0%      11.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=16-4                     68.0 ± 0%      68.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=64-4                      325 ± 0%       325 ± 0%    ~     (all equal)
MultipolygonValidation/n=256-4                   1.33k ± 0%     1.33k ± 0%    ~     (all equal)
MultipolygonValidation/n=1024-4                  5.57k ± 0%     5.57k ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     86.0 ± 0%      86.0 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=100-4                     736 ± 0%       736 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  6.13k ± 0%     6.13k ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                 67.3k ± 0%     67.3k ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4          75.0 ± 0%      75.0 ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          432 ± 0%       432 ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4       3.88k ± 0%     3.88k ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4      36.3k ± 0%     36.3k ± 0%    ~     (p=0.791 n=15+12)
```
