### PR TITLE
WKB reinterpret cast marshaling hack

### DIFF
--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/peterstace/simplefeatures/geom"
 	. "github.com/peterstace/simplefeatures/geom"
 )
 
@@ -355,11 +356,11 @@ func regularPolygon(center XY, radius float64, sides int) Polygon {
 	}
 	coords[2*sides+0] = coords[0]
 	coords[2*sides+1] = coords[1]
-	ring, err := NewLineString(NewSequence(coords, DimXY))
+	ring, err := NewLineString(NewSequence(coords, DimXY), geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}
-	poly, err := NewPolygonFromRings([]LineString{ring})
+	poly, err := NewPolygonFromRings([]LineString{ring}, geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}

--- a/geom/wkb_marshal.go
+++ b/geom/wkb_marshal.go
@@ -53,8 +53,13 @@ func (m *wkbMarshaller) writeCoordinates(c Coordinates) {
 func (m *wkbMarshaller) writeSequence(seq Sequence) {
 	n := seq.Length()
 	m.writeCount(n)
-	for i := 0; i < n; i++ {
-		c := seq.Get(i)
-		m.writeCoordinates(c)
+
+	// Iterating over the floats in the sequence and appending them directly
+	// rather than using the Get method on the sequence provides a significant
+	// performance improvement.
+	for _, f := range seq.floats {
+		var buf [8]byte
+		wkbBO.PutUint64(buf[:], math.Float64bits(f))
+		m.buf = append(m.buf, buf[:]...)
 	}
 }

--- a/geom/wkb_marshal.go
+++ b/geom/wkb_marshal.go
@@ -34,8 +34,11 @@ func newWKBMarshaller(buf []byte) *wkbMarshaller {
 }
 
 func (m *wkbMarshaller) writeByteOrder() {
-	const littleEndian byte = 1
-	m.buf = append(m.buf, littleEndian)
+	if nativeOrder == binary.LittleEndian {
+		m.buf = append(m.buf, 1)
+	} else {
+		m.buf = append(m.buf, 0)
+	}
 }
 
 func (m *wkbMarshaller) writeGeomType(geomType GeometryType, ctype CoordinatesType) {

--- a/geom/wkb_marshal.go
+++ b/geom/wkb_marshal.go
@@ -87,11 +87,10 @@ func (m *wkbMarshaller) writeSequence(seq Sequence) {
 // floatsAsBytes reinterprets the floats slice as a bytes slice in a similar
 // manner to reinterpret_cast in C++.
 func floatsAsBytes(floats []float64) []byte {
-	floatsHeader := (*reflect.SliceHeader)(unsafe.Pointer(&floats))
-	bytesHeader := reflect.SliceHeader{
-		Data: floatsHeader.Data,
-		Len:  8 * len(floats),
-		Cap:  8 * cap(floats),
-	}
-	return *(*[]byte)(unsafe.Pointer(&bytesHeader))
+	var byts []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&byts))
+	hdr.Data = (*reflect.SliceHeader)(unsafe.Pointer(&floats)).Data
+	hdr.Len = 8 * len(floats)
+	hdr.Cap = 8 * cap(floats)
+	return byts
 }

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -3,6 +3,7 @@ package geom_test
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -530,4 +531,18 @@ func TestWKBMarshalEmptyPoint(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkMarshalWKB(b *testing.B) {
+	b.Run("polygon", func(b *testing.B) {
+		for _, sz := range []int{10, 100, 1000, 10000} {
+			b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+				poly := regularPolygon(XY{}, 1.0, sz)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					poly.AsBinary()
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Description

This change gives significant performance improvements to WKB marshalling. It does this by using a "reinterpret_cast" style operation on sequences of coordinates, allowing us to `append` the WKB bytes for a sequence rather than having to build it up manually.

## Check List

Have you:

- Added unit tests? N/A, no behaviour change.

- Add cmprefimpl tests? (if appropriate?) N/A, no behaviour change.

## Related Issue

- N/A

## Benchmark Results

Significant (90%) performance increase to WKB marshalling. This is also reflected in some of the GEOS benchmarks, since these involve WKB transformations (up to 15% improvement).

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.83µs ±25%    3.64µs ± 9%     ~     (p=0.085 n=14+15)
IntersectsLineStringWithLineString/n=100-4      50.8µs ± 7%    51.4µs ± 8%     ~     (p=0.519 n=14+13)
IntersectsLineStringWithLineString/n=1000-4      691µs ± 9%     705µs ± 9%     ~     (p=0.387 n=15+13)
IntersectsLineStringWithLineString/n=10000-4    11.8ms ±14%    11.9ms ±15%     ~     (p=0.775 n=15+15)
LineStringIsSimpleZigZag/10-4                   3.83µs ± 9%    3.78µs ±11%     ~     (p=0.599 n=15+14)
LineStringIsSimpleZigZag/100-4                  97.7µs ±12%    97.3µs ±11%     ~     (p=0.621 n=15+14)
LineStringIsSimpleZigZag/1000-4                 1.34ms ± 8%    1.36ms ±11%     ~     (p=0.621 n=15+14)
LineStringIsSimpleZigZag/10000-4                17.5ms ± 4%    17.3ms ± 4%     ~     (p=0.139 n=13+13)
PolygonSingleRingValidation/n=10-4              4.30µs ± 5%    4.42µs ± 6%   +2.81%  (p=0.007 n=13+14)
PolygonSingleRingValidation/n=100-4              101µs ±11%      99µs ± 5%     ~     (p=0.667 n=14+14)
PolygonSingleRingValidation/n=1000-4            1.50ms ±11%    1.46ms ±12%     ~     (p=0.187 n=15+15)
PolygonSingleRingValidation/n=10000-4           22.5ms ±18%    21.4ms ± 6%     ~     (p=0.093 n=15+12)
PolygonMultipleRingsValidation/n=4-4            15.4µs ±12%    15.1µs ±10%     ~     (p=0.583 n=14+13)
PolygonMultipleRingsValidation/n=36-4            141µs ± 8%     140µs ± 4%     ~     (p=0.867 n=14+13)
PolygonMultipleRingsValidation/n=400-4          1.80ms ± 3%    1.81ms ± 6%     ~     (p=0.482 n=14+14)
PolygonMultipleRingsValidation/n=4096-4         20.5ms ± 4%    20.4ms ± 2%     ~     (p=0.683 n=15+13)
PolygonZigZagRingsValidation/n=10-4             36.3µs ± 8%    36.5µs ± 9%     ~     (p=0.967 n=15+15)
PolygonZigZagRingsValidation/n=100-4             449µs ± 6%     446µs ± 7%     ~     (p=0.603 n=14+14)
PolygonZigZagRingsValidation/n=1000-4           5.97ms ±16%    5.91ms ±19%     ~     (p=0.624 n=15+15)
PolygonZigZagRingsValidation/n=10000-4          77.8ms ± 7%    75.6ms ± 2%   -2.92%  (p=0.002 n=15+12)
MultipolygonValidation/n=1-4                     378ns ±14%     381ns ± 5%     ~     (p=0.134 n=14+14)
MultipolygonValidation/n=4-4                    1.07µs ± 6%    1.07µs ± 4%     ~     (p=0.532 n=15+13)
MultipolygonValidation/n=16-4                   10.2µs ±23%    10.1µs ±12%     ~     (p=1.000 n=15+15)
MultipolygonValidation/n=64-4                   62.0µs ± 9%    59.4µs ± 6%   -4.20%  (p=0.021 n=15+15)
MultipolygonValidation/n=256-4                   319µs ± 9%     308µs ± 4%   -3.43%  (p=0.021 n=14+14)
MultipolygonValidation/n=1024-4                 1.64ms ±10%    1.65ms ±13%     ~     (p=0.713 n=15+15)
MultiPolygonTwoCircles/n=10-4                   10.6µs ±13%    10.8µs ±11%     ~     (p=0.389 n=15+15)
MultiPolygonTwoCircles/n=100-4                   131µs ± 5%     134µs ±12%     ~     (p=0.454 n=14+14)
MultiPolygonTwoCircles/n=1000-4                 1.79ms ± 8%    1.73ms ± 6%   -2.96%  (p=0.006 n=14+14)
MultiPolygonTwoCircles/n=10000-4                25.8ms ± 6%    26.7ms ±10%     ~     (p=0.130 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1-4        7.84µs ± 7%    7.67µs ± 6%     ~     (p=0.220 n=13+14)
MultiPolygonMultipleTouchingPoints/n=10-4       59.1µs ± 3%    60.2µs ±10%     ~     (p=0.194 n=14+14)
MultiPolygonMultipleTouchingPoints/n=100-4       698µs ± 3%     720µs ± 8%   +3.11%  (p=0.037 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     9.00ms ± 6%    9.15ms ±10%     ~     (p=0.235 n=13+15)
MarshalWKB/polygon/n=10-4                        506ns ±12%     196ns ±17%  -61.19%  (p=0.000 n=15+14)
MarshalWKB/polygon/n=100-4                      3.19µs ± 4%    0.65µs ±36%  -79.65%  (p=0.000 n=13+14)
MarshalWKB/polygon/n=1000-4                     39.1µs ±13%     4.0µs ±18%  -89.74%  (p=0.000 n=15+13)
MarshalWKB/polygon/n=10000-4                     384µs ±10%      32µs ±39%  -91.70%  (p=0.000 n=13+13)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             52.8µs ± 5%    50.8µs ±12%   -3.71%  (p=0.029 n=13+15)
Intersection/n=100-4                             109µs ± 7%     104µs ±11%   -4.87%  (p=0.000 n=15+14)
Intersection/n=1000-4                            547µs ±11%     474µs ± 9%  -13.23%  (p=0.000 n=15+14)
Intersection/n=10000-4                          5.32ms ±14%    4.50ms ±16%  -15.26%  (p=0.000 n=15+15)
NoOp/n=10-4                                     5.70µs ±12%    5.43µs ± 9%   -4.68%  (p=0.016 n=15+15)
NoOp/n=100-4                                    26.9µs ± 8%    24.4µs ± 7%   -9.52%  (p=0.000 n=13+15)
NoOp/n=1000-4                                    231µs ± 7%     194µs ± 4%  -16.00%  (p=0.000 n=14+13)
NoOp/n=10000-4                                  2.58ms ±11%    2.12ms ±18%  -17.97%  (p=0.000 n=14+14)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.63kB ± 0%    3.63kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4      40.1kB ± 0%    40.1kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      369kB ± 0%     369kB ± 0%     ~     (p=0.132 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    5.45MB ± 0%    5.45MB ± 0%     ~     (p=0.060 n=14+15)
LineStringIsSimpleZigZag/10-4                   3.34kB ± 0%    3.34kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                  64.4kB ± 0%    64.4kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  667kB ± 0%     667kB ± 0%     ~     (p=0.529 n=15+14)
LineStringIsSimpleZigZag/10000-4                7.33MB ± 0%    7.33MB ± 0%     ~     (p=0.703 n=15+15)
PolygonSingleRingValidation/n=10-4              3.47kB ± 0%    3.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4             62.4kB ± 0%    62.4kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             666kB ± 0%     666kB ± 0%     ~     (p=0.492 n=13+15)
PolygonSingleRingValidation/n=10000-4           7.34MB ± 0%    7.34MB ± 0%     ~     (p=0.214 n=15+14)
PolygonMultipleRingsValidation/n=4-4            7.90kB ± 0%    7.90kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           73.1kB ± 0%    73.1kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           847kB ± 0%     847kB ± 0%     ~     (p=0.438 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         9.08MB ± 0%    9.08MB ± 0%     ~     (p=0.666 n=13+14)
PolygonZigZagRingsValidation/n=10-4             21.2kB ± 0%    21.2kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             247kB ± 0%     247kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4           2.38MB ± 0%    2.38MB ± 0%     ~     (p=0.063 n=15+15)
PolygonZigZagRingsValidation/n=10000-4          30.5MB ± 0%    30.5MB ± 0%     ~     (p=0.453 n=15+14)
MultipolygonValidation/n=1-4                      225B ± 0%      225B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      820B ± 0%      820B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   8.53kB ± 0%    8.53kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                   44.7kB ± 0%    44.7kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                   185kB ± 0%     185kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  783kB ± 0%     783kB ± 0%     ~     (p=0.462 n=15+13)
MultiPolygonTwoCircles/n=10-4                   7.81kB ± 0%    7.81kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                  74.4kB ± 0%    74.4kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  673kB ± 0%     673kB ± 0%   -0.00%  (p=0.027 n=15+12)
MultiPolygonTwoCircles/n=10000-4                10.3MB ± 0%    10.3MB ± 0%   -0.00%  (p=0.004 n=15+12)
MultiPolygonMultipleTouchingPoints/n=1-4        4.79kB ± 0%    4.79kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       26.9kB ± 0%    26.9kB ± 0%     ~     (p=0.415 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       243kB ± 0%     243kB ± 0%     ~     (p=0.690 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.44MB ± 0%    2.44MB ± 0%   +0.01%  (p=0.033 n=15+15)
MarshalWKB/polygon/n=10-4                         504B ± 0%      232B ± 0%  -53.97%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=100-4                      4.09kB ± 0%    1.83kB ± 0%  -55.19%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=1000-4                     71.7kB ± 0%    16.4kB ± 0%  -77.08%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10000-4                     874kB ± 0%     164kB ± 0%  -81.26%  (p=0.000 n=13+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             2.18kB ± 0%    1.62kB ± 0%  -25.37%  (p=0.000 n=15+15)
Intersection/n=100-4                            13.1kB ± 0%     8.6kB ± 0%  -34.41%  (p=0.000 n=13+12)
Intersection/n=1000-4                            187kB ± 0%      76kB ± 0%  -59.11%  (p=0.000 n=14+14)
Intersection/n=10000-4                          2.19MB ± 0%    0.77MB ± 0%  -64.83%  (p=0.000 n=12+12)
NoOp/n=10-4                                     1.58kB ± 0%    1.30kB ± 0%  -17.77%  (p=0.000 n=15+15)
NoOp/n=100-4                                    11.3kB ± 0%     9.0kB ± 0%  -20.11%  (p=0.000 n=15+15)
NoOp/n=1000-4                                    137kB ± 0%      82kB ± 0%  -40.38%  (p=0.000 n=15+14)
NoOp/n=10000-4                                  1.52MB ± 0%    0.81MB ± 0%  -46.67%  (p=0.000 n=14+15)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         34.0 ± 0%      34.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4         363 ± 0%       363 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      3.06k ± 0%     3.06k ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4     33.6k ± 0%     33.6k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                     441 ± 0%       441 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  4.62k ± 0%     4.62k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 46.4k ± 0%     46.4k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                30.0 ± 0%      30.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                427 ± 0%       427 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             4.61k ± 0%     4.61k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4            46.5k ± 0%     46.5k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              90.0 ± 0%      90.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              778 ± 0%       778 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           8.89k ± 0%     8.89k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          92.1k ± 0%     92.1k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4                209 ± 0%       209 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             2.00k ± 0%     2.00k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4            18.4k ± 0%     18.4k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4            194k ± 0%      194k ± 0%     ~     (p=1.000 n=15+15)
MultipolygonValidation/n=1-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      11.0 ± 0%      11.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     68.0 ± 0%      68.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                      325 ± 0%       325 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                   1.33k ± 0%     1.33k ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  5.57k ± 0%     5.57k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     86.0 ± 0%      86.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                     736 ± 0%       736 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  6.13k ± 0%     6.13k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                 67.3k ± 0%     67.3k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4          75.0 ± 0%      75.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          432 ± 0%       432 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4       3.88k ± 0%     3.88k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4      36.3k ± 0%     36.3k ± 0%     ~     (p=0.055 n=12+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        9.00 ± 0%      6.00 ± 0%  -33.33%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=1000-4                       17.0 ± 0%       6.0 ± 0%  -64.71%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10000-4                      26.0 ± 0%       6.0 ± 0%  -76.92%  (p=0.000 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               83.0 ± 0%      83.0 ± 0%     ~     (all equal)
Intersection/n=100-4                               321 ± 0%       315 ± 0%   -1.87%  (p=0.000 n=15+15)
Intersection/n=1000-4                            2.74k ± 0%     2.71k ± 0%   -0.80%  (p=0.000 n=15+15)
Intersection/n=10000-4                           26.8k ± 0%     26.7k ± 0%   -0.15%  (p=0.000 n=15+15)
NoOp/n=10-4                                       73.0 ± 0%      73.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                       436 ± 0%       433 ± 0%   -0.69%  (p=0.000 n=15+15)
NoOp/n=1000-4                                    4.04k ± 0%     4.03k ± 0%   -0.27%  (p=0.000 n=15+15)
NoOp/n=10000-4                                   40.1k ± 0%     40.0k ± 0%   -0.05%  (p=0.000 n=15+15)
```
