### PR TITLE
Performance improvements to WKB unmarshalling

### DIFF
--- a/geom/marshal_unmarshal_test.go
+++ b/geom/marshal_unmarshal_test.go
@@ -1,7 +1,6 @@
 package geom_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"strconv"
 	"testing"
@@ -194,7 +193,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
 				original := geomFromWKT(t, wkt)
 				wkb := original.AsBinary()
-				reconstructed, err := geom.UnmarshalWKB(bytes.NewReader(wkb))
+				reconstructed, err := geom.UnmarshalWKB(wkb)
 				expectNoErr(t, err)
 				reconstructedWKT := reconstructed.AsText()
 				expectStringEq(t, wkt, reconstructedWKT)

--- a/geom/sql_test.go
+++ b/geom/sql_test.go
@@ -1,7 +1,6 @@
 package geom_test
 
 import (
-	"bytes"
 	"strconv"
 	"testing"
 
@@ -14,7 +13,7 @@ func TestValuerAny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	geom, err := UnmarshalWKB(bytes.NewReader(val.([]byte)))
+	geom, err := UnmarshalWKB(val.([]byte))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +58,7 @@ func TestValuerConcrete(t *testing.T) {
 			geom := geomFromWKT(t, wkt)
 			val, err := geom.Value()
 			expectNoErr(t, err)
-			g, err := UnmarshalWKB(bytes.NewReader(val.([]byte)))
+			g, err := UnmarshalWKB(val.([]byte))
 			expectNoErr(t, err)
 			expectGeomEq(t, g, geom)
 		})

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -1,11 +1,8 @@
 package geom
 
 import (
-	"bytes"
 	"database/sql/driver"
 	"fmt"
-	"io"
-	"strings"
 	"unsafe"
 )
 
@@ -281,12 +278,12 @@ func (g Geometry) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (g *Geometry) Scan(src interface{}) error {
-	var r io.Reader
+	var wkb []byte
 	switch src := src.(type) {
 	case []byte:
-		r = bytes.NewReader(src)
+		wkb = src
 	case string:
-		r = strings.NewReader(src)
+		wkb = []byte(src)
 	default:
 		// nil is specifically not supported. It _could_ map to an empty
 		// geometry, however then the caller wouldn't be able to differentiate
@@ -295,7 +292,7 @@ func (g *Geometry) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported src type in Scan: %T", src)
 	}
 
-	unmarshalled, err := UnmarshalWKB(r)
+	unmarshalled, err := UnmarshalWKB(wkb)
 	if err != nil {
 		return err
 	}

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -169,7 +169,7 @@ func (p *wkbParser) parsePoint(ctype CoordinatesType) Point {
 
 	if math.IsNaN(c.X) && math.IsNaN(c.Y) {
 		// Empty points are represented as NaN,NaN is WKB.
-		return Point{}
+		return Point{}.ForceCoordinatesType(ctype)
 	}
 	if math.IsNaN(c.X) || math.IsNaN(c.Y) {
 		p.setErr(errors.New("point contains mixed NaN values"))

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -219,7 +219,7 @@ func bytesAsFloats(byts []byte) []float64 {
 // flipEndianessStride8 flips the endianess of the input bytes, assuming that
 // they represent data items that are 8 bytes long.
 func flipEndianessStride8(p []byte) {
-	for i := 0; i < len(p)/8; i += 8 {
+	for i := 0; i < len(p); i += 8 {
 		p[i+0], p[i+7] = p[i+7], p[i+0]
 		p[i+1], p[i+6] = p[i+6], p[i+1]
 		p[i+2], p[i+5] = p[i+5], p[i+2]

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -68,7 +68,7 @@ func (p *wkbParser) readByte() byte {
 }
 
 func (p *wkbParser) parseUint32() uint32 {
-	if len(p.body) < 4 {
+	if p.err != nil || len(p.body) < 4 {
 		p.setErr(io.ErrUnexpectedEOF)
 		return 0
 	}
@@ -139,7 +139,7 @@ func (p *wkbParser) parseGeomRoot(gtype GeometryType, ctype CoordinatesType) Geo
 }
 
 func (p *wkbParser) parseFloat64() float64 {
-	if len(p.body) < 8 {
+	if p.err != nil || len(p.body) < 8 {
 		p.setErr(io.ErrUnexpectedEOF)
 		return 0
 	}

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -207,13 +207,12 @@ func (p *wkbParser) parseLineString(ctype CoordinatesType) LineString {
 // bytesAsFloats reinterprets the bytes slice as a float64 slice in a similar
 // manner to reinterpret_cast in C++.
 func bytesAsFloats(byts []byte) []float64 {
-	bytsHeader := (*reflect.SliceHeader)(unsafe.Pointer(&byts))
-	floatsHeader := reflect.SliceHeader{
-		Data: bytsHeader.Data,
-		Len:  len(byts) / 8,
-		Cap:  cap(byts) / 8,
-	}
-	return *(*[]float64)(unsafe.Pointer(&floatsHeader))
+	var floats []float64
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&floats))
+	hdr.Data = (*reflect.SliceHeader)(unsafe.Pointer(&byts)).Data
+	hdr.Len = len(byts) / 8
+	hdr.Cap = cap(byts) / 8
+	return floats
 }
 
 // flipEndianessStride8 flips the endianess of the input bytes, assuming that

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -546,3 +546,20 @@ func BenchmarkMarshalWKB(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkUnmarshalWKB(b *testing.B) {
+	b.Run("polygon", func(b *testing.B) {
+		for _, sz := range []int{10, 100, 1000, 10000} {
+			b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+				wkb := regularPolygon(XY{}, 1.0, sz).AsBinary()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, err := UnmarshalWKB(bytes.NewReader(wkb), DisableAllValidations)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+}

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -384,7 +384,7 @@ func TestWKBParseValid(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			geom, err := UnmarshalWKB(bytes.NewReader(hexStringToBytes(t, tt.wkb)))
+			geom, err := UnmarshalWKB(hexStringToBytes(t, tt.wkb))
 			expectNoErr(t, err)
 			expectGeomEq(t, geom, geomFromWKT(t, tt.wkt))
 		})
@@ -394,7 +394,7 @@ func TestWKBParseValid(t *testing.T) {
 func TestWKBParserInvalidGeometryType(t *testing.T) {
 	// Same as POINT(1 2), but with the geometry type byte set to 0xff.
 	const wkb = "01ff000000000000000000f03f0000000000000040"
-	_, err := UnmarshalWKB(bytes.NewReader(hexStringToBytes(t, wkb)))
+	_, err := UnmarshalWKB(hexStringToBytes(t, wkb))
 	if err == nil {
 		t.Errorf("expected an error but got nil")
 	}
@@ -430,7 +430,7 @@ func TestWKBMarshalValid(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			geom := geomFromWKT(t, wkt)
 			buf := geom.AsBinary()
-			readBackGeom, err := UnmarshalWKB(bytes.NewReader(buf))
+			readBackGeom, err := UnmarshalWKB(buf)
 			expectNoErr(t, err)
 			expectGeomEq(t, readBackGeom, geom)
 		})
@@ -554,7 +554,7 @@ func BenchmarkUnmarshalWKB(b *testing.B) {
 				wkb := regularPolygon(XY{}, 1.0, sz).AsBinary()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					_, err := UnmarshalWKB(bytes.NewReader(wkb), DisableAllValidations)
+					_, err := UnmarshalWKB(wkb, DisableAllValidations)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/geos/libgeos.go
+++ b/geos/libgeos.go
@@ -507,10 +507,10 @@ func (h *handle) decode(gh *C.GEOSGeometry, opts []geom.ConstructorOption) (geom
 		return geom.Geometry{}, h.err()
 	}
 	defer C.GEOSFree_r(h.context, unsafe.Pointer(serialised))
-	r := bytes.NewReader(C.GoBytes(unsafe.Pointer(serialised), C.int(size)))
+	byts := C.GoBytes(unsafe.Pointer(serialised), C.int(size))
 
 	if isWKT != 0 {
-		return geom.UnmarshalWKT(r, opts...)
+		return geom.UnmarshalWKT(bytes.NewReader(byts), opts...)
 	}
-	return geom.UnmarshalWKB(r, opts...)
+	return geom.UnmarshalWKB(byts, opts...)
 }

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -92,7 +92,7 @@ var mismatchErr = errors.New("mismatch")
 func checkIsValid(h *Handle, g geom.Geometry, log *log.Logger) (bool, error) {
 	wkb := g.AsBinary()
 	var validAsPerSimpleFeatures bool
-	if _, err := geom.UnmarshalWKB(bytes.NewReader(wkb)); err == nil {
+	if _, err := geom.UnmarshalWKB(wkb); err == nil {
 		validAsPerSimpleFeatures = true
 	}
 	log.Printf("Valid as per simplefeatures: %v", validAsPerSimpleFeatures)
@@ -267,7 +267,7 @@ func checkFromBinary(h *Handle, g geom.Geometry, log *log.Logger) error {
 		return err
 	}
 
-	got, err := geom.UnmarshalWKB(bytes.NewReader(wkb))
+	got, err := geom.UnmarshalWKB(wkb)
 	if err != nil {
 		return err
 	}

--- a/internal/cmprefimpl/cmpgeos/extract_source.go
+++ b/internal/cmprefimpl/cmpgeos/extract_source.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -79,7 +78,7 @@ func convertToGeometries(candidates []string) ([]geom.Geometry, error) {
 		if err != nil {
 			continue
 		}
-		g, err := geom.UnmarshalWKB(bytes.NewReader(buf), geom.DisableAllValidations)
+		g, err := geom.UnmarshalWKB(buf, geom.DisableAllValidations)
 		if err == nil {
 			geoms = append(geoms, g)
 		}

--- a/internal/cmprefimpl/cmpgeos/handle.go
+++ b/internal/cmprefimpl/cmpgeos/handle.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -350,8 +349,8 @@ func (h *Handle) decodeGeomHandleUsingWKB(gh *C.GEOSGeometry) (geom.Geometry, er
 		return geom.Geometry{}, fmt.Errorf("writing wkb: %v", h.err())
 	}
 	defer C.GEOSFree_r(h.context, unsafe.Pointer(wkb))
-	reader := bytes.NewReader(C.GoBytes(unsafe.Pointer(wkb), C.int(size)))
-	return geom.UnmarshalWKB(reader)
+	byts := C.GoBytes(unsafe.Pointer(wkb), C.int(size))
+	return geom.UnmarshalWKB(byts)
 }
 
 func (h *Handle) AsText(g geom.Geometry) (string, error) {

--- a/internal/cmprefimpl/cmppg/checks.go
+++ b/internal/cmprefimpl/cmppg/checks.go
@@ -53,7 +53,7 @@ func CheckWKBParse(t *testing.T, pg PostGIS, candidates []string) {
 		}
 		any = true
 		t.Run(fmt.Sprintf("CheckWKBParse_%d", i), func(t *testing.T) {
-			_, sfErr := geom.UnmarshalWKB(bytes.NewReader(buf))
+			_, sfErr := geom.UnmarshalWKB(buf)
 			isValid, reason := pg.WKBIsValidWithReason(t, wkb)
 			if (sfErr == nil) != isValid {
 				t.Logf("WKB: %v", wkb)

--- a/internal/cmprefimpl/cmppg/fuzz_test.go
+++ b/internal/cmprefimpl/cmppg/fuzz_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"database/sql"
 	"fmt"
 	"go/ast"
@@ -130,7 +129,7 @@ func convertToGeometries(t *testing.T, candidates []string) []geom.Geometry {
 		if err != nil {
 			continue
 		}
-		g, err := geom.UnmarshalWKB(bytes.NewReader(buf))
+		g, err := geom.UnmarshalWKB(buf)
 		if err == nil {
 			geoms = append(geoms, g)
 		}


### PR DESCRIPTION
## Description

When performing WKB unmarshalling, unmarshals sequences in the WKB directly into memory (since they are byte for byte identical).

## Check List

Have you:

- Added unit tests? Yes. The existing tests for WKB have good coverage, and I added a test for little vs big endian unmarashalling.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- Tangentially related to #190 

## Benchmark Results

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.87µs ± 7%    3.83µs ± 8%     ~     (p=0.713 n=15+15)
IntersectsLineStringWithLineString/n=100-4      56.9µs ±11%    55.5µs ±13%     ~     (p=0.412 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      733µs ± 6%     757µs ±14%     ~     (p=0.201 n=15+14)
IntersectsLineStringWithLineString/n=10000-4    12.2ms ±14%    12.7ms ±10%     ~     (p=0.108 n=15+13)
LineStringIsSimpleZigZag/10-4                   3.91µs ±12%    3.98µs ±10%     ~     (p=0.591 n=15+14)
LineStringIsSimpleZigZag/100-4                   101µs ±10%     101µs ±15%     ~     (p=0.839 n=14+14)
LineStringIsSimpleZigZag/1000-4                 1.41ms ±11%    1.42ms ± 8%     ~     (p=0.621 n=15+14)
LineStringIsSimpleZigZag/10000-4                18.9ms ± 8%    18.5ms ±10%     ~     (p=0.158 n=14+15)
PolygonSingleRingValidation/n=10-4              4.64µs ±14%    4.57µs ±11%     ~     (p=0.949 n=15+14)
PolygonSingleRingValidation/n=100-4              105µs ±12%     104µs ±11%     ~     (p=0.744 n=15+15)
PolygonSingleRingValidation/n=1000-4            1.51ms ± 8%    1.49ms ± 8%     ~     (p=0.539 n=15+15)
PolygonSingleRingValidation/n=10000-4           22.5ms ±14%    23.1ms ±18%     ~     (p=0.482 n=14+14)
PolygonMultipleRingsValidation/n=4-4            16.1µs ± 6%    15.9µs ± 8%     ~     (p=0.451 n=15+14)
PolygonMultipleRingsValidation/n=36-4            149µs ± 7%     149µs ± 8%     ~     (p=0.880 n=14+15)
PolygonMultipleRingsValidation/n=400-4          1.91ms ± 8%    1.95ms ± 8%     ~     (p=0.267 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         23.1ms ±35%    21.3ms ± 5%     ~     (p=0.112 n=15+14)
PolygonZigZagRingsValidation/n=10-4             38.4µs ±17%    38.2µs ±15%     ~     (p=0.747 n=15+14)
PolygonZigZagRingsValidation/n=100-4             459µs ± 8%     477µs ±15%     ~     (p=0.161 n=15+15)
PolygonZigZagRingsValidation/n=1000-4           5.90ms ± 7%    6.20ms ±13%     ~     (p=0.123 n=14+15)
PolygonZigZagRingsValidation/n=10000-4          84.0ms ±14%    81.8ms ± 7%     ~     (p=0.839 n=14+14)
MultipolygonValidation/n=1-4                     395ns ±11%     408ns ±10%     ~     (p=0.173 n=15+13)
MultipolygonValidation/n=4-4                    1.12µs ±15%    1.09µs ± 7%     ~     (p=0.728 n=15+12)
MultipolygonValidation/n=16-4                   10.2µs ±11%    10.0µs ±11%     ~     (p=0.539 n=15+15)
MultipolygonValidation/n=64-4                   62.5µs ± 8%    64.4µs ±18%     ~     (p=0.512 n=15+15)
MultipolygonValidation/n=256-4                   318µs ± 6%     337µs ±11%   +5.96%  (p=0.008 n=13+15)
MultipolygonValidation/n=1024-4                 1.69ms ±10%    1.70ms ±10%     ~     (p=0.949 n=15+14)
MultiPolygonTwoCircles/n=10-4                   10.9µs ± 7%    11.0µs ±10%     ~     (p=0.943 n=13+14)
MultiPolygonTwoCircles/n=100-4                   140µs ±11%     143µs ±10%     ~     (p=0.561 n=15+14)
MultiPolygonTwoCircles/n=1000-4                 1.79ms ± 8%    1.87ms ± 6%   +4.49%  (p=0.002 n=14+13)
MultiPolygonTwoCircles/n=10000-4                26.7ms ± 8%    27.2ms ±11%     ~     (p=0.430 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1-4        8.06µs ± 8%    8.02µs ±14%     ~     (p=0.510 n=14+13)
MultiPolygonMultipleTouchingPoints/n=10-4       62.9µs ±17%    65.8µs ± 5%   +4.48%  (p=0.006 n=14+15)
MultiPolygonMultipleTouchingPoints/n=100-4       751µs ± 7%     739µs ± 3%     ~     (p=0.507 n=15+11)
MultiPolygonMultipleTouchingPoints/n=1000-4     9.34ms ± 7%    9.39ms ±13%     ~     (p=0.806 n=15+15)
MarshalWKB/polygon/n=10-4                        203ns ±15%     205ns ±12%     ~     (p=0.598 n=14+15)
MarshalWKB/polygon/n=100-4                       623ns ±17%     581ns ±26%   -6.70%  (p=0.044 n=15+15)
MarshalWKB/polygon/n=1000-4                     3.99µs ±16%    4.25µs ±30%     ~     (p=0.683 n=14+15)
MarshalWKB/polygon/n=10000-4                    32.6µs ±29%    32.4µs ±24%     ~     (p=0.867 n=13+14)
UnmarshalWKB/polygon/n=10-4                     1.77µs ±14%    0.35µs ± 7%  -80.46%  (p=0.000 n=14+15)
UnmarshalWKB/polygon/n=100-4                    12.3µs ±12%     0.8µs ±32%  -93.70%  (p=0.000 n=15+13)
UnmarshalWKB/polygon/n=1000-4                    114µs ±13%       4µs ±49%  -96.26%  (p=0.000 n=15+13)
UnmarshalWKB/polygon/n=10000-4                  1.18ms ±13%    0.04ms ±11%  -96.95%  (p=0.000 n=14+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             56.1µs ±16%    54.7µs ±23%     ~     (p=0.354 n=14+15)
Intersection/n=100-4                             110µs ±13%     103µs ±14%   -7.07%  (p=0.009 n=15+15)
Intersection/n=1000-4                            496µs ±13%     420µs ±13%  -15.44%  (p=0.000 n=15+15)
Intersection/n=10000-4                          4.63ms ±13%    3.86ms ±12%  -16.56%  (p=0.000 n=15+15)
NoOp/n=10-4                                     5.48µs ± 5%    3.97µs ±15%  -27.65%  (p=0.000 n=13+14)
NoOp/n=100-4                                    25.2µs ± 9%    13.2µs ± 9%  -47.67%  (p=0.000 n=14+15)
NoOp/n=1000-4                                    215µs ±10%      97µs ±11%  -54.89%  (p=0.000 n=15+14)
NoOp/n=10000-4                                  2.28ms ±14%    1.06ms ±19%  -53.50%  (p=0.000 n=15+15)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.63kB ± 0%    3.63kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4      40.1kB ± 0%    40.1kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      369kB ± 0%     369kB ± 0%     ~     (p=0.957 n=14+15)
IntersectsLineStringWithLineString/n=10000-4    5.45MB ± 0%    5.45MB ± 0%     ~     (p=0.919 n=13+15)
LineStringIsSimpleZigZag/10-4                   3.34kB ± 0%    3.34kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                  64.4kB ± 0%    64.4kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  667kB ± 0%     667kB ± 0%     ~     (p=0.336 n=13+15)
LineStringIsSimpleZigZag/10000-4                7.33MB ± 0%    7.33MB ± 0%     ~     (p=0.595 n=15+14)
PolygonSingleRingValidation/n=10-4              3.47kB ± 0%    3.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4             62.4kB ± 0%    62.4kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             666kB ± 0%     666kB ± 0%     ~     (p=0.376 n=15+14)
PolygonSingleRingValidation/n=10000-4           7.34MB ± 0%    7.34MB ± 0%     ~     (p=0.998 n=14+14)
PolygonMultipleRingsValidation/n=4-4            7.90kB ± 0%    7.90kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           73.1kB ± 0%    73.1kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           847kB ± 0%     847kB ± 0%     ~     (p=0.220 n=15+12)
PolygonMultipleRingsValidation/n=4096-4         9.08MB ± 0%    9.08MB ± 0%     ~     (p=0.381 n=15+12)
PolygonZigZagRingsValidation/n=10-4             21.2kB ± 0%    21.2kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             247kB ± 0%     247kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4           2.38MB ± 0%    2.38MB ± 0%     ~     (p=0.071 n=14+14)
PolygonZigZagRingsValidation/n=10000-4          30.5MB ± 0%    30.5MB ± 0%     ~     (p=0.888 n=15+14)
MultipolygonValidation/n=1-4                      225B ± 0%      225B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      820B ± 0%      820B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   8.53kB ± 0%    8.53kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                   44.7kB ± 0%    44.7kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                   185kB ± 0%     185kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  783kB ± 0%     783kB ± 0%     ~     (p=0.250 n=15+15)
MultiPolygonTwoCircles/n=10-4                   7.81kB ± 0%    7.81kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                  74.4kB ± 0%    74.4kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  673kB ± 0%     673kB ± 0%   +0.00%  (p=0.037 n=12+15)
MultiPolygonTwoCircles/n=10000-4                10.3MB ± 0%    10.3MB ± 0%     ~     (p=0.795 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4        4.79kB ± 0%    4.79kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       26.9kB ± 0%    26.9kB ± 0%     ~     (p=0.669 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       243kB ± 0%     243kB ± 0%     ~     (p=0.569 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.44MB ± 0%    2.44MB ± 0%     ~     (p=0.146 n=14+15)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       712B ± 0%      282B ± 0%  -60.39%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=100-4                    5.21kB ± 0%    1.90kB ± 0%  -63.56%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=1000-4                   48.6kB ± 0%    16.5kB ± 0%  -66.07%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=10000-4                   484kB ± 0%     164kB ± 0%  -66.13%  (p=0.000 n=14+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.62kB ± 0%    1.19kB ± 0%  -26.60%  (p=0.000 n=15+15)
Intersection/n=100-4                            8.62kB ± 0%    6.33kB ± 0%  -26.56%  (p=0.000 n=12+12)
Intersection/n=1000-4                           76.5kB ± 0%    55.0kB ± 0%  -28.10%  (p=0.000 n=12+15)
Intersection/n=10000-4                           771kB ± 0%     557kB ± 0%  -27.69%  (p=0.000 n=12+13)
NoOp/n=10-4                                     1.30kB ± 0%    0.86kB ± 0%  -33.33%  (p=0.000 n=15+15)
NoOp/n=100-4                                    8.99kB ± 0%    5.68kB ± 0%  -36.83%  (p=0.000 n=15+15)
NoOp/n=1000-4                                   81.6kB ± 0%    49.5kB ± 0%  -39.37%  (p=0.000 n=15+15)
NoOp/n=10000-4                                   812kB ± 0%     492kB ± 0%  -39.43%  (p=0.000 n=15+15)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         34.0 ± 0%      34.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4         363 ± 0%       363 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      3.06k ± 0%     3.06k ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4     33.6k ± 0%     33.6k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                     441 ± 0%       441 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  4.62k ± 0%     4.62k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 46.4k ± 0%     46.4k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                30.0 ± 0%      30.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                427 ± 0%       427 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             4.61k ± 0%     4.61k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4            46.5k ± 0%     46.5k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              90.0 ± 0%      90.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              778 ± 0%       778 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           8.89k ± 0%     8.89k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          92.1k ± 0%     92.1k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4                209 ± 0%       209 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             2.00k ± 0%     2.00k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4            18.4k ± 0%     18.4k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4            194k ± 0%      194k ± 0%     ~     (p=0.338 n=15+14)
MultipolygonValidation/n=1-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      11.0 ± 0%      11.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     68.0 ± 0%      68.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                      325 ± 0%       325 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                   1.33k ± 0%     1.33k ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  5.57k ± 0%     5.57k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     86.0 ± 0%      86.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                     736 ± 0%       736 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  6.13k ± 0%     6.13k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                 67.3k ± 0%     67.3k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4          75.0 ± 0%      75.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          432 ± 0%       432 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4       3.88k ± 0%     3.88k ± 0%     ~     (p=0.133 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-4      36.3k ± 0%     36.3k ± 0%     ~     (p=0.324 n=15+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       59.0 ± 0%       7.0 ± 0%  -88.14%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=100-4                       419 ± 0%         7 ± 0%  -98.33%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=1000-4                    4.02k ± 0%     0.01k ± 0%  -99.83%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=10000-4                   40.0k ± 0%      0.0k ± 0%  -99.98%  (p=0.000 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               83.0 ± 0%      31.0 ± 0%  -62.65%  (p=0.000 n=15+15)
Intersection/n=100-4                               315 ± 0%        31 ± 0%  -90.16%  (p=0.000 n=15+15)
Intersection/n=1000-4                            2.71k ± 0%     0.03k ± 0%  -98.86%  (p=0.000 n=15+15)
Intersection/n=10000-4                           26.7k ± 0%      0.0k ± 0%  -99.88%  (p=0.000 n=15+15)
NoOp/n=10-4                                       73.0 ± 0%      21.0 ± 0%  -71.23%  (p=0.000 n=15+15)
NoOp/n=100-4                                       433 ± 0%        21 ± 0%  -95.15%  (p=0.000 n=15+15)
NoOp/n=1000-4                                    4.03k ± 0%     0.02k ± 0%  -99.48%  (p=0.000 n=15+15)
NoOp/n=10000-4                                   40.0k ± 0%      0.0k ± 0%  -99.95%  (p=0.000 n=15+15)
```
