### PR TITLE
Make UnmarshalWKT accept a string instead of an io.Reader

### DIFF
--- a/geom/alg_point_in_ring_test.go
+++ b/geom/alg_point_in_ring_test.go
@@ -3,7 +3,6 @@ package geom
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 )
 
@@ -130,7 +129,7 @@ func TestPointInRing(t *testing.T) {
 			},
 		},
 	} {
-		g, err := UnmarshalWKT(strings.NewReader(tc.wkt))
+		g, err := UnmarshalWKT(tc.wkt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -142,7 +141,7 @@ func TestPointInRing(t *testing.T) {
 		ring := poly.ExteriorRing()
 
 		for j, st := range tc.subTests {
-			pt, err := UnmarshalWKT(strings.NewReader(st.pointWKT))
+			pt, err := UnmarshalWKT(st.pointWKT)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -170,10 +169,10 @@ func TestPointInRing(t *testing.T) {
 }
 
 func TestPointInPolygon(t *testing.T) {
-	g, err := UnmarshalWKT(strings.NewReader(`POLYGON(
+	g, err := UnmarshalWKT(`POLYGON(
 		(0 0,1 0,1 1,2 1,2 0,3 0,3 -1,4 -1,4 0,5 0,5 1,6 1,6 -1,7 -1,7 0,8 0,8 -1,9 -1,10 0,11 -1,11 1,12 0,13 1,13 -1,14 -1,14 -2,30 -2,30 3,14 3,14 2,0 2,0 0),
 		(15 0,16 0,16 1,17 1,17 0,18 0,18 -1,19 -1,19 0,20 0,20 1,21 1,21 -1,22 -1,22 0,23 0,23 -1,24 -1,25 0,26 -1,26 1,27 0,28 1,28 -1,29 -1,29 2,15 2,15 0)
-	)`))
+	)`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -3,7 +3,6 @@ package geom_test
 import (
 	"math"
 	"strconv"
-	"strings"
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
@@ -47,7 +46,7 @@ func TestIsEmptyDimension(t *testing.T) {
 		{"GEOMETRYCOLLECTION(POLYGON((0 0,1 1,1 0,0 0)),POINT(1 1),LINESTRING(0 0,1 1))", false, 2},
 	} {
 		t.Run(tt.wkt, func(t *testing.T) {
-			geom, err := UnmarshalWKT(strings.NewReader(tt.wkt))
+			geom, err := UnmarshalWKT(tt.wkt)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -2,7 +2,6 @@ package geom_test
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -31,11 +30,11 @@ func TestDisableValidation(t *testing.T) {
 		"GEOMETRYCOLLECTION(LINESTRING(0 1,0 1))",
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			_, err := geom.UnmarshalWKT(strings.NewReader(wkt))
+			_, err := geom.UnmarshalWKT(wkt)
 			if err == nil {
 				t.Fatal("expected validation error unmarshalling wkt")
 			}
-			_, err = geom.UnmarshalWKT(strings.NewReader(wkt), geom.DisableAllValidations)
+			_, err = geom.UnmarshalWKT(wkt, geom.DisableAllValidations)
 			if err != nil {
 				t.Errorf("disabling validations still gave an error: %v", err)
 			}

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -1,7 +1,6 @@
 package geom_test
 
 import (
-	"strings"
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
@@ -9,7 +8,7 @@ import (
 
 func geomFromWKT(t *testing.T, wkt string) Geometry {
 	t.Helper()
-	geom, err := UnmarshalWKT(strings.NewReader(wkt))
+	geom, err := UnmarshalWKT(wkt)
 	if err != nil {
 		t.Fatalf("could not unmarshal WKT:\n  wkt: %s\n  err: %v", wkt, err)
 	}

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"math/rand"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -53,7 +52,7 @@ func TestPolygonValidation(t *testing.T) {
 		)`,
 	} {
 		t.Run("valid_"+strconv.Itoa(i), func(t *testing.T) {
-			_, err := UnmarshalWKT(strings.NewReader(wkt))
+			_, err := UnmarshalWKT(wkt)
 			if err != nil {
 				t.Error(err)
 			}
@@ -106,7 +105,7 @@ func TestPolygonValidation(t *testing.T) {
 		`POLYGON((0 0,0 1,1 0,0 0),EMPTY)`,
 	} {
 		t.Run("invalid_"+strconv.Itoa(i), func(t *testing.T) {
-			_, err := UnmarshalWKT(strings.NewReader(wkt))
+			_, err := UnmarshalWKT(wkt)
 			if err == nil {
 				t.Log("WKT", wkt)
 				t.Error("expected error")
@@ -192,7 +191,7 @@ func TestMultiPolygonValidation(t *testing.T) {
 		)`,
 	} {
 		t.Run(fmt.Sprintf("invalid_%d", i), func(t *testing.T) {
-			_, err := UnmarshalWKT(strings.NewReader(wkt))
+			_, err := UnmarshalWKT(wkt)
 			if err == nil {
 				t.Log(wkt)
 				t.Error("expected error")

--- a/geom/wkt_parser.go
+++ b/geom/wkt_parser.go
@@ -16,7 +16,14 @@ import (
 
 // UnmarshalWKT parses a Well Known Text (WKT), and returns the corresponding
 // Geometry.
-func UnmarshalWKT(r io.Reader, opts ...ConstructorOption) (Geometry, error) {
+func UnmarshalWKT(wkt string, opts ...ConstructorOption) (Geometry, error) {
+	return UnmarshalWKTFromReader(strings.NewReader(wkt), opts...)
+}
+
+// UnmarshalWKTFromReader parses a Well Known Text (WKT), and returns the
+// corresponding Geometry. It the same as UnmarshalWKT, but allows an io.Reader
+// to be used instead of a string.
+func UnmarshalWKTFromReader(r io.Reader, opts ...ConstructorOption) (Geometry, error) {
 	p := newParser(r, opts)
 	geom := p.nextGeometryTaggedText()
 	p.checkEOF()

--- a/geom/wkt_test.go
+++ b/geom/wkt_test.go
@@ -2,7 +2,6 @@ package geom_test
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
@@ -20,7 +19,7 @@ func TestUnmarshalWKTValidGrammar(t *testing.T) {
 		{"exponent", "point (1e3 1.5e2)"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := UnmarshalWKT(strings.NewReader(tt.wkt))
+			_, err := UnmarshalWKT(tt.wkt)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -51,7 +50,7 @@ func TestUnmarshalWKTInvalidGrammar(t *testing.T) {
 		{"geometry collection no coords", "GEOMETRYCOLLECTION()"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := UnmarshalWKT(strings.NewReader(tt.wkt))
+			_, err := UnmarshalWKT(tt.wkt)
 			if err == nil {
 				t.Fatalf("expected error but got nil")
 			} else {

--- a/geos/libgeos.go
+++ b/geos/libgeos.go
@@ -510,7 +510,7 @@ func (h *handle) decode(gh *C.GEOSGeometry, opts []geom.ConstructorOption) (geom
 	r := bytes.NewReader(C.GoBytes(unsafe.Pointer(serialised), C.int(size)))
 
 	if isWKT != 0 {
-		return geom.UnmarshalWKT(r, opts...)
+		return geom.UnmarshalWKTFromReader(r, opts...)
 	}
 	return geom.UnmarshalWKB(r, opts...)
 }

--- a/geos/libgeos_test.go
+++ b/geos/libgeos_test.go
@@ -2,7 +2,6 @@ package geos
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -10,7 +9,7 @@ import (
 
 func geomFromWKT(t *testing.T, wkt string) geom.Geometry {
 	t.Helper()
-	geom, err := geom.UnmarshalWKT(strings.NewReader(wkt))
+	geom, err := geom.UnmarshalWKT(wkt)
 	if err != nil {
 		t.Fatalf("could not unmarshal WKT:\n  wkt: %s\n  err: %v", wkt, err)
 	}

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -200,7 +200,7 @@ func checkFromText(h *Handle, g geom.Geometry, log *log.Logger) error {
 		return err
 	}
 
-	got, err := geom.UnmarshalWKT(strings.NewReader(wkt))
+	got, err := geom.UnmarshalWKT(wkt)
 	if err != nil {
 		return err
 	}

--- a/internal/cmprefimpl/cmpgeos/extract_source.go
+++ b/internal/cmprefimpl/cmpgeos/extract_source.go
@@ -64,7 +64,7 @@ func extractStringsFromSource(dir string) ([]string, error) {
 func convertToGeometries(candidates []string) ([]geom.Geometry, error) {
 	var geoms []geom.Geometry
 	for _, c := range candidates {
-		g, err := geom.UnmarshalWKT(strings.NewReader(c), geom.DisableAllValidations)
+		g, err := geom.UnmarshalWKT(c, geom.DisableAllValidations)
 		if err == nil {
 			geoms = append(geoms, g)
 		}

--- a/internal/cmprefimpl/cmppg/checks.go
+++ b/internal/cmprefimpl/cmppg/checks.go
@@ -27,7 +27,7 @@ func CheckWKTParse(t *testing.T, pg PostGIS, candidates []string) {
 			// isn't closed (and thus won't be accepted by simple features).
 			wkt := strings.ReplaceAll(wkt, "LINEARRING", "LINESTRING")
 
-			_, sfErr := geom.UnmarshalWKT(strings.NewReader(wkt))
+			_, sfErr := geom.UnmarshalWKT(wkt)
 			isValid, reason := pg.WKTIsValidWithReason(wkt)
 			if (sfErr == nil) != isValid {
 				t.Logf("SimpleFeatures err: %v", sfErr)

--- a/internal/cmprefimpl/cmppg/fuzz_test.go
+++ b/internal/cmprefimpl/cmppg/fuzz_test.go
@@ -115,7 +115,7 @@ func extractStringsFromSource(t *testing.T) []string {
 func convertToGeometries(t *testing.T, candidates []string) []geom.Geometry {
 	var geoms []geom.Geometry
 	for _, c := range candidates {
-		g, err := geom.UnmarshalWKT(strings.NewReader(c))
+		g, err := geom.UnmarshalWKT(c)
 		if err == nil {
 			geoms = append(geoms, g)
 		}

--- a/internal/cmprefimpl/cmppg/pg.go
+++ b/internal/cmprefimpl/cmppg/pg.go
@@ -135,24 +135,18 @@ func (p BatchPostGIS) Unary(g geom.Geometry) (UnaryResult, error) {
 
 	if boundaryWKT.Valid {
 		result.Boundary.Valid = true
-		result.Boundary.Geometry, err = geom.UnmarshalWKT(
-			strings.NewReader(boundaryWKT.String),
-		)
+		result.Boundary.Geometry, err = geom.UnmarshalWKT(boundaryWKT.String)
 		if err != nil {
 			return result, err
 		}
 	}
 
-	result.ConvexHull, err = geom.UnmarshalWKT(
-		strings.NewReader(convexHullWKT),
-	)
+	result.ConvexHull, err = geom.UnmarshalWKT(convexHullWKT)
 	if err != nil {
 		return result, err
 	}
 
-	result.Reverse, err = geom.UnmarshalWKT(
-		strings.NewReader(reverseWKT),
-	)
+	result.Reverse, err = geom.UnmarshalWKT(reverseWKT)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION


## Description
This is because unmarshalling a WKT from a string seems to be the most
common operation. There is rarely a need to unmarshal from an io.Reader.
This also brings the UnmarshalWKT and UnmarshalWKB function signatures
in alignment with each other.

There is a new UnmarshalWKTFromReader function, which has the old
signature of UnmarshalWKT. This is only needed in those rare cases where
you have an io.Reader.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A
