### PR TITLE
Use traditional pointer approach for RTree

### DIFF
--- a/rtree/box.go
+++ b/rtree/box.go
@@ -7,11 +7,11 @@ type Box struct {
 	MinX, MinY, MaxX, MaxY float64
 }
 
-// calculate bound calculates the smallest bounding box that fits a node.
-func (t *RTree) calculateBound(n int) Box {
-	box := t.nodes[n].entries[0].box
-	for _, entry := range t.nodes[n].entries[1:] {
-		box = combine(box, entry.box)
+// calculateBound calculates the smallest bounding box that fits a node.
+func calculateBound(n *node) Box {
+	box := n.entries[0].box
+	for i := 1; i < n.numEntries; i++ {
+		box = combine(box, n.entries[i].box)
 	}
 	return box
 }

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -19,7 +19,7 @@ func BulkLoad(items []BulkItem) RTree {
 }
 
 func (t *RTree) bulkInsert(items []BulkItem) *node {
-	if len(items) <= 2 {
+	if len(items) <= maxChildren {
 		root := &node{isLeaf: true, numEntries: len(items)}
 		for i, item := range items {
 			root.entries[i] = entry{

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -19,9 +19,6 @@ func BulkLoad(items []BulkItem) RTree {
 }
 
 func (t *RTree) bulkInsert(items []BulkItem) *node {
-	if len(items) == 0 {
-		return nil
-	}
 	if len(items) <= 2 {
 		root := &node{isLeaf: true, numEntries: len(items)}
 		for i, item := range items {

--- a/rtree/insert.go
+++ b/rtree/insert.go
@@ -106,7 +106,7 @@ func (t *RTree) splitNode(n *node) *node {
 	bestArea := math.Inf(+1)
 	var bestSplit uint64
 	for split := minSplit; split <= maxSplit; split++ {
-		if bits.OnesCount64(split) < minChildren {
+		if ones := bits.OnesCount64(split); ones < minChildren || (n.numEntries-ones) < minChildren {
 			continue
 		}
 		var boxA, boxB Box

--- a/rtree/insert.go
+++ b/rtree/insert.go
@@ -134,27 +134,25 @@ func (t *RTree) splitNode(n *node) *node {
 		}
 	}
 
-	var entriesA, entriesB []entry
-	for i := 0; i < n.numEntries; i++ {
+	// Use the existing node for the 0 bits in the split, and a new node for
+	// the 1 bits in the split.
+	//n.entries = [maxChildren + 1]entry{}
+	newNode := &node{isLeaf: n.isLeaf}
+	totalEntries := n.numEntries
+	n.numEntries = 0
+	for i := 0; i < totalEntries; i++ {
 		entry := n.entries[i]
 		if bestSplit&(1<<i) == 0 {
-			entriesA = append(entriesA, entry)
+			n.entries[n.numEntries] = entry
+			n.numEntries++
 		} else {
-			entriesB = append(entriesB, entry)
+			newNode.entries[newNode.numEntries] = entry
+			newNode.numEntries++
 		}
 	}
-
-	// Use the existing node for A...
-	copy(n.entries[:], entriesA)
-	n.numEntries = len(entriesA)
-
-	// And create a new node for B.
-	newNode := &node{
-		numEntries: len(entriesB),
-		parent:     nil,
-		isLeaf:     n.isLeaf,
+	for i := n.numEntries; i < len(n.entries); i++ {
+		n.entries[i] = entry{}
 	}
-	copy(newNode.entries[:], entriesB)
 	if !n.isLeaf {
 		for i := 0; i < newNode.numEntries; i++ {
 			newNode.entries[i].child.parent = newNode

--- a/rtree/insert.go
+++ b/rtree/insert.go
@@ -12,84 +12,72 @@ const (
 
 // Insert adds a new record to the RTree.
 func (t *RTree) Insert(box Box, recordID int) {
-	if len(t.nodes) == 0 {
-		t.nodes = append(t.nodes, node{isLeaf: true, entries: nil, parent: -1})
-		t.rootIndex = 0
+	if t.root == nil {
+		t.root = &node{isLeaf: true}
 	}
 
 	leaf := t.chooseLeafNode(box)
-	t.nodes[leaf].entries = append(t.nodes[leaf].entries, entry{box: box, index: recordID})
+	leaf.appendRecord(box, recordID)
 
 	current := leaf
-	for current != t.rootIndex {
-		parent := t.nodes[current].parent
-		for i := range t.nodes[parent].entries {
-			e := &t.nodes[parent].entries[i]
-			if e.index == current {
+	for current != t.root {
+		parent := current.parent
+		for i := 0; i < parent.numEntries; i++ {
+			e := &parent.entries[i]
+			if e.child == current {
 				e.box = combine(e.box, box)
-				break
 			}
 		}
 		current = parent
 	}
 
-	if len(t.nodes[leaf].entries) <= maxChildren {
+	if leaf.numEntries <= maxChildren {
 		return
 	}
 
 	newNode := t.splitNode(leaf)
 	root1, root2 := t.adjustTree(leaf, newNode)
 
-	if root2 != -1 {
+	if root2 != nil {
 		t.joinRoots(root1, root2)
 	}
 }
 
-func (t *RTree) joinRoots(r1, r2 int) {
-	t.nodes = append(t.nodes, node{
-		isLeaf: false,
-		entries: []entry{
-			entry{
-				box:   t.calculateBound(r1),
-				index: r1,
-			},
-			entry{
-				box:   t.calculateBound(r2),
-				index: r2,
-			},
+func (t *RTree) joinRoots(r1, r2 *node) {
+	newRoot := &node{
+		entries: [1 + maxChildren]entry{
+			entry{box: calculateBound(r1), child: r1},
+			entry{box: calculateBound(r2), child: r2},
 		},
-		parent: -1,
-	})
-	t.rootIndex = len(t.nodes) - 1
-	t.nodes[r1].parent = len(t.nodes) - 1
-	t.nodes[r2].parent = len(t.nodes) - 1
+		numEntries: 2,
+		parent:     nil,
+		isLeaf:     false,
+	}
+	r1.parent = newRoot
+	r2.parent = newRoot
+	t.root = newRoot
 }
 
-func (t *RTree) adjustTree(n, nn int) (int, int) {
+// TODO: rename n and nn to leaf and newNode
+func (t *RTree) adjustTree(n, nn *node) (*node, *node) {
 	for {
-		if n == t.rootIndex {
+		if n == t.root {
 			return n, nn
 		}
-		parent := t.nodes[n].parent
-		parentEntry := -1
-		for i, entry := range t.nodes[parent].entries {
-			if entry.index == n {
-				parentEntry = i
+		parent := n.parent
+		for i := 0; i < parent.numEntries; i++ {
+			if parent.entries[i].child == n {
+				parent.entries[i].box = calculateBound(n)
 				break
 			}
 		}
-		t.nodes[parent].entries[parentEntry].box = t.calculateBound(n)
 
 		// AT4
-		pp := -1
-		if nn != -1 {
-			newEntry := entry{
-				box:   t.calculateBound(nn),
-				index: nn,
-			}
-			t.nodes[parent].entries = append(t.nodes[parent].entries, newEntry)
-			t.nodes[nn].parent = parent
-			if len(t.nodes[parent].entries) > maxChildren {
+		var pp *node
+		if nn != nil {
+			parent.appendChild(calculateBound(nn), nn)
+			nn.parent = parent
+			if parent.numEntries > maxChildren {
 				pp = t.splitNode(parent)
 			}
 		}
@@ -101,7 +89,7 @@ func (t *RTree) adjustTree(n, nn int) (int, int) {
 // splitNode splits node with index n into two nodes. The first node replaces
 // n, and the second node is newly created. The return value is the index of
 // the new node.
-func (t *RTree) splitNode(n int) int {
+func (t *RTree) splitNode(n *node) *node {
 	var (
 		// All zeros would not be valid split, so start at 1.
 		minSplit = uint64(1)
@@ -113,7 +101,7 @@ func (t *RTree) splitNode(n int) int {
 		// 0001, 0010, 0011, 0100, 0101, 0110, 0111.
 		//
 		// (1 << (4 - 1)) - 1 == 0111, so the maths checks out.
-		maxSplit = uint64((1 << (len(t.nodes[n].entries) - 1)) - 1)
+		maxSplit = uint64((1 << (n.numEntries - 1)) - 1)
 	)
 	bestArea := math.Inf(+1)
 	var bestSplit uint64
@@ -123,18 +111,19 @@ func (t *RTree) splitNode(n int) int {
 		}
 		var boxA, boxB Box
 		var hasA, hasB bool
-		for i, entry := range t.nodes[n].entries {
+		for i := 0; i < n.numEntries; i++ {
+			entryBox := n.entries[i].box
 			if split&(1<<i) == 0 {
 				if hasA {
-					boxA = combine(boxA, entry.box)
+					boxA = combine(boxA, entryBox)
 				} else {
-					boxA = entry.box
+					boxA = entryBox
 				}
 			} else {
 				if hasB {
-					boxB = combine(boxB, entry.box)
+					boxB = combine(boxB, entryBox)
 				} else {
-					boxB = entry.box
+					boxB = entryBox
 				}
 			}
 		}
@@ -146,7 +135,8 @@ func (t *RTree) splitNode(n int) int {
 	}
 
 	var entriesA, entriesB []entry
-	for i, entry := range t.nodes[n].entries {
+	for i := 0; i < n.numEntries; i++ {
+		entry := n.entries[i]
 		if bestSplit&(1<<i) == 0 {
 			entriesA = append(entriesA, entry)
 		} else {
@@ -154,40 +144,44 @@ func (t *RTree) splitNode(n int) int {
 		}
 	}
 
-	// Use the existing node for A, and create a new node for B.
-	t.nodes[n].entries = entriesA
-	t.nodes = append(t.nodes, node{
-		isLeaf:  t.nodes[n].isLeaf,
-		entries: entriesB,
-		parent:  -1,
-	})
-	if !t.nodes[n].isLeaf {
-		for _, entry := range entriesB {
-			t.nodes[entry.index].parent = len(t.nodes) - 1
+	// Use the existing node for A...
+	copy(n.entries[:], entriesA)
+	n.numEntries = len(entriesA)
+
+	// And create a new node for B.
+	newNode := &node{
+		numEntries: len(entriesB),
+		parent:     nil,
+		isLeaf:     n.isLeaf,
+	}
+	copy(newNode.entries[:], entriesB)
+	if !n.isLeaf {
+		for i := 0; i < newNode.numEntries; i++ {
+			newNode.entries[i].child.parent = newNode
 		}
 	}
-	return len(t.nodes) - 1
+	return newNode
 }
 
-func (t *RTree) chooseLeafNode(box Box) int {
-	node := t.rootIndex
-
+func (t *RTree) chooseLeafNode(box Box) *node {
+	node := t.root
 	for {
-		if t.nodes[node].isLeaf {
+		if node.isLeaf {
 			return node
 		}
-		bestDelta := enlargement(box, t.nodes[node].entries[0].box)
+		bestDelta := enlargement(box, node.entries[0].box)
 		bestEntry := 0
-		for i, entry := range t.nodes[node].entries[1:] {
-			delta := enlargement(box, entry.box)
+		for i := 1; i < node.numEntries; i++ {
+			entryBox := node.entries[i].box
+			delta := enlargement(box, entryBox)
 			if delta < bestDelta {
 				bestDelta = delta
 				bestEntry = i
-			} else if delta == bestDelta && area(entry.box) < area(t.nodes[node].entries[bestEntry].box) {
+			} else if delta == bestDelta && area(entryBox) < area(node.entries[bestEntry].box) {
 				// Area is used as a tie breaking if the enlargements are the same.
 				bestEntry = i
 			}
 		}
-		node = t.nodes[node].entries[bestEntry].index
+		node = node.entries[bestEntry].child
 	}
 }

--- a/rtree/rtree.go
+++ b/rtree/rtree.go
@@ -7,18 +7,29 @@ import (
 // node is a node in an R-Tree. nodes can either be leaf nodes holding entries
 // for terminal items, or intermediate nodes holding entries for more nodes.
 type node struct {
-	isLeaf  bool
-	entries []entry
-	parent  int
+	entries    [1 + maxChildren]entry
+	numEntries int
+	parent     *node
+	isLeaf     bool
 }
 
 // entry is an entry under a node, leading either to terminal items, or more nodes.
 type entry struct {
 	box Box
 
-	// For leaf nodes, this is a record ID. For non-leaf nodes, this is the
-	// index of the child node.
-	index int
+	// For leaf nodes, recordID is populated. For non-leaf nodes, child is populated.
+	child    *node
+	recordID int
+}
+
+func (n *node) appendRecord(box Box, recordID int) {
+	n.entries[n.numEntries] = entry{box: box, recordID: recordID}
+	n.numEntries++
+}
+
+func (n *node) appendChild(box Box, child *node) {
+	n.entries[n.numEntries] = entry{box: box, child: child}
+	n.numEntries++
 }
 
 // RTree is an in-memory R-Tree data structure. It holds record ID and bounding
@@ -26,8 +37,7 @@ type entry struct {
 // responsible for storing their own records). Its zero value is an empty
 // R-Tree.
 type RTree struct {
-	rootIndex int
-	nodes     []node
+	root *node
 }
 
 // Stop is a special sentinal error that can be used to stop a search operation
@@ -41,37 +51,38 @@ var Stop = errors.New("stop")
 // case where the special Stop sentinal error is returned (in which case nil
 // will be returned from Search).
 func (t *RTree) Search(box Box, callback func(recordID int) error) error {
-	if len(t.nodes) == 0 {
+	if t.root == nil {
 		return nil
 	}
 	var recurse func(*node) error
 	recurse = func(n *node) error {
-		for _, entry := range n.entries {
+		for i := 0; i < n.numEntries; i++ {
+			entry := n.entries[i]
 			if !overlap(entry.box, box) {
 				continue
 			}
 			if n.isLeaf {
-				if err := callback(entry.index); err == Stop {
+				if err := callback(entry.recordID); err == Stop {
 					return nil
 				} else if err != nil {
 					return err
 				}
 			} else {
-				if err := recurse(&t.nodes[entry.index]); err != nil {
+				if err := recurse(entry.child); err != nil {
 					return err
 				}
 			}
 		}
 		return nil
 	}
-	return recurse(&t.nodes[t.rootIndex])
+	return recurse(t.root)
 }
 
 // Extent gives the Box that most closely bounds the RTree. If the RTree is
 // empty, then false is returned.
 func (t *RTree) Extent() (Box, bool) {
-	if len(t.nodes) == 0 {
+	if t.root == nil || t.root.numEntries == 0 {
 		return Box{}, false
 	}
-	return t.calculateBound(t.rootIndex), true
+	return calculateBound(t.root), true
 }

--- a/rtree/rtree_test.go
+++ b/rtree/rtree_test.go
@@ -28,6 +28,7 @@ func TestRandom(t *testing.T) {
 
 			checkInvariants(t, rt)
 			checkSearch(t, rt, boxes, rnd)
+			checkExtent(t, rt, boxes)
 		})
 		name := fmt.Sprintf("pop_%d", population)
 		t.Run(name, func(t *testing.T) {
@@ -44,6 +45,7 @@ func TestRandom(t *testing.T) {
 			}
 
 			checkSearch(t, rt, boxes, rnd)
+			checkExtent(t, rt, boxes)
 		})
 	}
 }
@@ -70,6 +72,23 @@ func checkSearch(t *testing.T, rt RTree, boxes []Box, rnd *rand.Rand) {
 		if !reflect.DeepEqual(want, got) {
 			t.Logf("search box: %v", searchBB)
 			t.Errorf("search failed, got: %v want: %v", got, want)
+		}
+	}
+}
+
+func checkExtent(t *testing.T, rt RTree, boxes []Box) {
+	got, ok := rt.Extent()
+	if len(boxes) == 0 {
+		if ok {
+			t.Fatal("expected not to get an extent, but got one")
+		}
+	} else {
+		want := boxes[0]
+		for _, b := range boxes[1:] {
+			want = combine(want, b)
+		}
+		if want != got {
+			t.Fatal("unexpected bounding box")
 		}
 	}
 }

--- a/rtree/rtree_test.go
+++ b/rtree/rtree_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestRandom(t *testing.T) {
-	for population := 0; population < 200; population++ {
+	for pop := 0.0; pop < 1000; pop = (pop + 1) * 1.2 {
+		population := int(pop)
+
 		t.Run(fmt.Sprintf("bulk_%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
 			boxes := make([]Box, population)
@@ -88,82 +90,68 @@ func randomBox(rnd *rand.Rand, maxStart, maxWidth float64) Box {
 }
 
 func checkInvariants(t *testing.T, rt RTree) {
-	t.Logf("")
-	t.Logf("RTree description:")
-	t.Logf("node_count=%v, root=%d", len(rt.nodes), rt.rootIndex)
-	for i, n := range rt.nodes {
-		t.Logf("%d: leaf=%t numentries=%d parent=%d", i, n.isLeaf, len(n.entries), n.parent)
-		for j, e := range n.entries {
-			t.Logf("\t%d: index=%d box=%v", j, e.index, e.box)
-		}
-	}
-
-	// Each node has the correct parent set.
-	for i, node := range rt.nodes {
-		if i == rt.rootIndex {
-			if node.parent != -1 {
-				t.Fatalf("expected root to have parent -1, but has %d", node.parent)
+	var recurse func(*node, string)
+	recurse = func(current *node, indent string) {
+		t.Logf("%sNode addr=%p leaf=%t numEntries=%d", indent, current, current.isLeaf, current.numEntries)
+		indent += "\t"
+		if current.isLeaf {
+			for i := 0; i < current.numEntries; i++ {
+				e := current.entries[i]
+				t.Logf("%sEntry[%d] recordID=%d box=%v", indent, i, e.recordID, e.box)
 			}
-			continue
-		}
-		if node.parent == -1 {
-			t.Fatalf("expected parent for non-root not to be -1, but was -1")
-		}
-
-		var matchingChildren int
-		for _, entry := range rt.nodes[node.parent].entries {
-			if entry.index == i {
-				matchingChildren++
-			}
-		}
-		if matchingChildren != 1 {
-			t.Fatalf("expected parent to have 1 matching child, but has %d", matchingChildren)
-		}
-	}
-
-	// For each non-leaf node, its entries should have the smallest bounding boxes that cover its children.
-	for i, parentNode := range rt.nodes {
-		if parentNode.isLeaf {
-			continue
-		}
-		for j, parentEntry := range parentNode.entries {
-			childNode := rt.nodes[parentEntry.index]
-			union := childNode.entries[0].box
-			for _, childEntry := range childNode.entries[1:] {
-				union = combine(childEntry.box, union)
-			}
-			if union != parentEntry.box {
-				t.Fatalf("expected parent to have smallest box that covers its children (node=%d, entry=%d)", i, j)
+		} else {
+			for i := 0; i < current.numEntries; i++ {
+				e := &current.entries[i]
+				t.Logf("%sEntry[%d] box=%v", indent, i, e.box)
+				recurse(e.child, indent+"\t")
 			}
 		}
 	}
+	if rt.root != nil {
+		recurse(rt.root, "")
+	}
 
-	// Each leaf should be reached exactly once from the root. This implies
-	// that the tree has no loops, and there are no orphan leafs. Also checks
-	// that each non-leaf is visited at least once (i.e. no orphan non-leaves).
-	leafCount := make(map[int]int)
-	visited := make(map[int]bool)
-	var recurse func(int)
-	recurse = func(n int) {
-		visited[n] = true
-		node := &rt.nodes[n]
-		if node.isLeaf {
-			leafCount[n]++
-			return
+	var check func(*node)
+	check = func(current *node) {
+		if current.isLeaf {
+			for i := 0; i < current.numEntries; i++ {
+				e := current.entries[i]
+				if e.child != nil {
+					t.Fatal("leaf node has child")
+				}
+			}
+		} else {
+			for i := 0; i < current.numEntries; i++ {
+				e := &current.entries[i]
+				if e.recordID != 0 {
+					t.Fatal("non-leaf has recordID")
+				}
+				if e.child.parent != current {
+					t.Fatalf("node %p has wrong parent", e.child)
+				}
+				box := e.child.entries[0].box
+				for j := 1; j < e.child.numEntries; j++ {
+					box = combine(box, e.child.entries[j].box)
+				}
+				if box != e.box {
+					t.Fatalf("entry box doesn't match smallest box enclosing child")
+				}
+			}
 		}
-		for _, entry := range node.entries {
-			recurse(entry.index)
+		for i := current.numEntries; i < len(current.entries); i++ {
+			e := current.entries[i]
+			if e.box != (Box{}) || e.child != nil || e.recordID != 0 {
+				t.Fatal("entry past numEntries is not the zero value")
+			}
+		}
+		if current.numEntries > maxChildren || (current != rt.root && current.numEntries < minChildren) {
+			t.Fatal("unexpected number of children")
 		}
 	}
-	recurse(rt.rootIndex)
-	for leaf, count := range leafCount {
-		if count != 1 {
-			t.Fatalf("leaf %d visited %d times", leaf, count)
-		}
-	}
-	for i := range rt.nodes {
-		if !visited[i] {
-			t.Fatalf("node %d was not visited", i)
+	if rt.root != nil {
+		check(rt.root)
+		if rt.root.parent != nil {
+			t.Fatalf("root parent should be nil, but is %p", rt.root.parent)
 		}
 	}
 }


### PR DESCRIPTION
## Description

The existing implementation uses an array/index based approach. There
was originally an intention that the data structure would be able to be
serialised to disk, hence an array/index based approach was used. That
seems a bit too specialised, and that approach was becoming very hard to
work with (e.g. to implement delete).

Using a more tradition node/pointer based approach allows easier
implementation of new extensions to the RTree (delete and ranged search
are the main ones in mind, but there may be more in the future).

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- Relates to #194 (although doesn't address it).

## Benchmark Results

There is a decent performance increase for operations that use the rtree (that wasn't really intentional, but not going to complain about it).

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.80µs ± 9%    2.32µs ±14%  -39.01%  (p=0.000 n=14+13)
IntersectsLineStringWithLineString/n=100-4      53.9µs ± 9%    40.2µs ±10%  -25.29%  (p=0.000 n=14+15)
IntersectsLineStringWithLineString/n=1000-4      732µs ± 4%     607µs ±13%  -17.11%  (p=0.000 n=13+15)
IntersectsLineStringWithLineString/n=10000-4    12.7ms ±13%     9.8ms ±17%  -22.40%  (p=0.000 n=15+14)
LineStringIsSimpleZigZag/10-4                   3.86µs ± 7%    2.16µs ± 6%  -44.05%  (p=0.000 n=14+14)
LineStringIsSimpleZigZag/100-4                  99.5µs ±11%    64.1µs ±11%  -35.57%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/1000-4                 1.36ms ± 6%    1.01ms ± 3%  -26.10%  (p=0.000 n=14+14)
LineStringIsSimpleZigZag/10000-4                18.1ms ± 4%    14.1ms ± 8%  -22.23%  (p=0.000 n=12+15)
PolygonSingleRingValidation/n=10-4              4.62µs ±16%    2.48µs ±17%  -46.38%  (p=0.000 n=14+14)
PolygonSingleRingValidation/n=100-4              100µs ± 8%      58µs ± 8%  -42.15%  (p=0.000 n=15+14)
PolygonSingleRingValidation/n=1000-4            1.48ms ± 7%    1.08ms ± 6%  -27.03%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10000-4           22.3ms ±16%    14.5ms ± 4%  -34.98%  (p=0.000 n=14+14)
PolygonMultipleRingsValidation/n=4-4            16.0µs ± 7%    10.7µs ± 6%  -33.40%  (p=0.000 n=14+13)
PolygonMultipleRingsValidation/n=36-4            145µs ± 6%     100µs ± 8%  -31.19%  (p=0.000 n=15+14)
PolygonMultipleRingsValidation/n=400-4          1.88ms ± 7%    1.26ms ± 4%  -32.89%  (p=0.000 n=15+12)
PolygonMultipleRingsValidation/n=4096-4         20.8ms ± 3%    15.1ms ± 9%  -27.44%  (p=0.000 n=13+15)
PolygonZigZagRingsValidation/n=10-4             36.4µs ±10%    26.5µs ± 8%  -27.30%  (p=0.000 n=14+14)
PolygonZigZagRingsValidation/n=100-4             457µs ± 2%     345µs ± 6%  -24.48%  (p=0.000 n=13+13)
PolygonZigZagRingsValidation/n=1000-4           6.02ms ± 9%    4.87ms ±13%  -19.11%  (p=0.000 n=14+15)
PolygonZigZagRingsValidation/n=10000-4          79.3ms ± 3%    63.8ms ± 3%  -19.57%  (p=0.000 n=13+13)
MultipolygonValidation/n=1-4                     387ns ± 7%     356ns ±14%   -8.05%  (p=0.002 n=13+14)
MultipolygonValidation/n=4-4                    1.07µs ± 6%    0.92µs ±14%  -14.11%  (p=0.000 n=14+14)
MultipolygonValidation/n=16-4                   10.0µs ±14%     5.8µs ± 8%  -42.30%  (p=0.000 n=14+14)
MultipolygonValidation/n=64-4                   61.0µs ± 8%    34.8µs ± 8%  -42.92%  (p=0.000 n=14+15)
MultipolygonValidation/n=256-4                   327µs ±15%     208µs ± 9%  -36.34%  (p=0.000 n=14+14)
MultipolygonValidation/n=1024-4                 1.66ms ±12%    1.03ms ± 8%  -37.88%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10-4                   10.5µs ± 7%     7.7µs ±15%  -26.43%  (p=0.000 n=13+14)
MultiPolygonTwoCircles/n=100-4                   140µs ± 8%     108µs ± 8%  -22.95%  (p=0.000 n=15+14)
MultiPolygonTwoCircles/n=1000-4                 1.97ms ±28%    1.57ms ±14%  -20.34%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                27.5ms ±20%    24.0ms ±26%  -12.72%  (p=0.001 n=14+14)
MultiPolygonMultipleTouchingPoints/n=1-4        7.84µs ±10%    6.05µs ± 9%  -22.88%  (p=0.000 n=13+14)
MultiPolygonMultipleTouchingPoints/n=10-4       63.6µs ±12%    52.2µs ±12%  -17.87%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=100-4       733µs ± 7%     613µs ± 4%  -16.34%  (p=0.000 n=14+14)
MultiPolygonMultipleTouchingPoints/n=1000-4     9.19ms ± 5%    7.86ms ± 4%  -14.46%  (p=0.000 n=13+12)
MarshalWKB/polygon/n=10-4                        203ns ±11%     209ns ±21%     ~     (p=0.517 n=13+15)
MarshalWKB/polygon/n=100-4                       597ns ±22%     611ns ±17%     ~     (p=0.382 n=14+13)
MarshalWKB/polygon/n=1000-4                     4.00µs ±17%    4.27µs ±35%     ~     (p=0.511 n=13+13)
MarshalWKB/polygon/n=10000-4                    33.5µs ±35%    33.2µs ±54%     ~     (p=0.683 n=15+13)
UnmarshalWKB/polygon/n=10-4                      343ns ±10%     342ns ±19%     ~     (p=0.705 n=15+15)
UnmarshalWKB/polygon/n=100-4                     729ns ±14%     725ns ±17%     ~     (p=0.765 n=14+13)
UnmarshalWKB/polygon/n=1000-4                   4.14µs ±22%    4.38µs ±21%     ~     (p=0.098 n=13+12)
UnmarshalWKB/polygon/n=10000-4                  41.0µs ±40%    40.3µs ±31%     ~     (p=0.769 n=14+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             52.0µs ±12%    51.9µs ±10%     ~     (p=0.847 n=14+15)
Intersection/n=100-4                            98.3µs ± 7%    95.3µs ± 4%   -3.05%  (p=0.044 n=14+14)
Intersection/n=1000-4                            431µs ±13%     442µs ± 5%     ~     (p=0.128 n=14+13)
Intersection/n=10000-4                          3.68ms ±14%    3.77ms ±12%     ~     (p=0.345 n=15+15)
NoOp/n=10-4                                     3.94µs ± 6%    3.94µs ± 9%     ~     (p=0.949 n=15+14)
NoOp/n=100-4                                    12.8µs ± 3%    12.9µs ± 7%     ~     (p=0.693 n=11+15)
NoOp/n=1000-4                                   91.3µs ± 6%    91.7µs ± 8%     ~     (p=0.839 n=14+14)
NoOp/n=10000-4                                   975µs ±23%     995µs ±15%     ~     (p=0.461 n=15+15)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       3.63kB ± 0%    2.69kB ± 0%  -25.99%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4      40.1kB ± 0%    32.6kB ± 0%  -18.60%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      369kB ± 0%     286kB ± 0%  -22.35%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    5.45MB ± 0%    3.77MB ± 0%  -30.87%  (p=0.000 n=14+13)
LineStringIsSimpleZigZag/10-4                   3.34kB ± 0%    1.44kB ± 0%  -56.94%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/100-4                  64.4kB ± 0%    21.6kB ± 0%  -66.43%  (p=0.000 n=14+15)
LineStringIsSimpleZigZag/1000-4                  667kB ± 0%     230kB ± 0%  -65.58%  (p=0.000 n=14+12)
LineStringIsSimpleZigZag/10000-4                7.33MB ± 0%    2.30MB ± 0%  -68.58%  (p=0.000 n=14+13)
PolygonSingleRingValidation/n=10-4              3.47kB ± 0%    1.47kB ± 0%  -57.60%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=100-4             62.4kB ± 0%    16.2kB ± 0%  -74.12%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=1000-4             666kB ± 0%     217kB ± 0%  -67.39%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10000-4           7.34MB ± 0%    2.23MB ± 0%  -69.68%  (p=0.000 n=12+15)
PolygonMultipleRingsValidation/n=4-4            7.90kB ± 0%    5.28kB ± 0%  -33.20%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=36-4           73.1kB ± 0%    43.3kB ± 0%  -40.72%  (p=0.000 n=15+14)
PolygonMultipleRingsValidation/n=400-4           847kB ± 0%     476kB ± 0%  -43.81%  (p=0.000 n=14+12)
PolygonMultipleRingsValidation/n=4096-4         9.08MB ± 0%    4.88MB ± 0%  -46.20%  (p=0.000 n=12+14)
PolygonZigZagRingsValidation/n=10-4             21.2kB ± 0%    14.0kB ± 0%  -34.14%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4             247kB ± 0%     138kB ± 0%  -44.09%  (p=0.000 n=13+15)
PolygonZigZagRingsValidation/n=1000-4           2.38MB ± 0%    1.26MB ± 0%  -46.95%  (p=0.000 n=15+14)
PolygonZigZagRingsValidation/n=10000-4          30.5MB ± 0%    15.3MB ± 0%  -49.62%  (p=0.000 n=13+14)
MultipolygonValidation/n=1-4                      225B ± 0%      385B ± 0%  +71.11%  (p=0.000 n=15+15)
MultipolygonValidation/n=4-4                      820B ± 0%      676B ± 0%  -17.56%  (p=0.000 n=15+15)
MultipolygonValidation/n=16-4                   8.53kB ± 0%    3.86kB ± 0%  -54.78%  (p=0.000 n=15+15)
MultipolygonValidation/n=64-4                   44.7kB ± 0%    15.4kB ± 0%  -65.49%  (p=0.000 n=14+15)
MultipolygonValidation/n=256-4                   185kB ± 0%      63kB ± 0%  -65.80%  (p=0.000 n=14+15)
MultipolygonValidation/n=1024-4                  783kB ± 0%     259kB ± 0%  -66.96%  (p=0.000 n=15+12)
MultiPolygonTwoCircles/n=10-4                   7.81kB ± 0%    6.88kB ± 0%  -11.88%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                  74.4kB ± 0%    59.4kB ± 0%  -20.16%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  673kB ± 0%     508kB ± 0%  -24.52%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                10.3MB ± 0%     6.9MB ± 0%  -32.83%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4        4.79kB ± 0%    4.18kB ± 0%  -12.70%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4       26.9kB ± 0%    23.8kB ± 0%  -11.55%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       243kB ± 0%     212kB ± 0%  -12.63%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.44MB ± 0%    2.00MB ± 0%  -18.01%  (p=0.000 n=15+14)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       282B ± 0%      282B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
Intersection/n=100-4                            6.33kB ± 0%    6.33kB ± 0%     ~     (all equal)
Intersection/n=1000-4                           55.0kB ± 0%    55.0kB ± 0%     ~     (p=0.156 n=12+15)
Intersection/n=10000-4                           558kB ± 0%     558kB ± 0%     ~     (p=0.871 n=14+15)
NoOp/n=10-4                                       864B ± 0%      864B ± 0%     ~     (all equal)
NoOp/n=100-4                                    5.68kB ± 0%    5.68kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                   49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%     ~     (p=0.068 n=15+14)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         34.0 ± 0%      15.0 ± 0%  -55.88%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4         363 ± 0%       160 ± 0%  -55.92%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      3.06k ± 0%     1.28k ± 0%  -58.14%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4     33.6k ± 0%     19.3k ± 0%  -42.69%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10-4                     27.0 ± 0%       5.0 ± 0%  -81.48%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/100-4                     441 ± 0%        75 ± 0%  -82.99%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/1000-4                  4.62k ± 0%     0.80k ± 0%  -82.74%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10000-4                 46.4k ± 0%      8.0k ± 0%  -82.76%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10-4                30.0 ± 0%       6.0 ± 0%  -80.00%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=100-4                427 ± 0%        57 ± 0%  -86.65%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=1000-4             4.61k ± 0%     0.76k ± 0%  -83.63%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10000-4            46.5k ± 0%      7.7k ± 0%  -83.37%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4-4              90.0 ± 0%      25.0 ± 0%  -72.22%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=36-4              778 ± 0%       203 ± 0%  -73.91%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=400-4           8.89k ± 0%     2.23k ± 0%  -74.94%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4096-4          92.1k ± 0%     22.8k ± 0%  -75.19%  (p=0.000 n=15+14)
PolygonZigZagRingsValidation/n=10-4                209 ± 0%        70 ± 0%  -66.51%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4             2.00k ± 0%     0.64k ± 0%  -68.23%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000-4            18.4k ± 0%      5.5k ± 0%  -70.37%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000-4            194k ± 0%       74k ± 0%  -61.88%  (p=0.000 n=15+15)
MultipolygonValidation/n=1-4                      6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=15+15)
MultipolygonValidation/n=4-4                      11.0 ± 0%       8.0 ± 0%  -27.27%  (p=0.000 n=15+15)
MultipolygonValidation/n=16-4                     68.0 ± 0%      27.0 ± 0%  -60.29%  (p=0.000 n=15+15)
MultipolygonValidation/n=64-4                      325 ± 0%        99 ± 0%  -69.54%  (p=0.000 n=15+15)
MultipolygonValidation/n=256-4                   1.33k ± 0%     0.39k ± 0%  -70.44%  (p=0.000 n=15+15)
MultipolygonValidation/n=1024-4                  5.57k ± 0%     1.58k ± 0%  -71.64%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10-4                     86.0 ± 0%      46.0 ± 0%  -46.51%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                     736 ± 0%       326 ± 0%  -55.71%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  6.13k ± 0%     2.57k ± 0%  -58.11%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                 67.3k ± 0%     38.6k ± 0%  -42.68%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1-4          75.0 ± 0%      51.0 ± 0%  -32.00%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4          432 ± 0%       332 ± 0%  -23.15%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       3.88k ± 0%     3.07k ± 0%  -20.87%  (p=0.000 n=12+14)
MultiPolygonMultipleTouchingPoints/n=1000-4      36.3k ± 0%     29.2k ± 0%  -19.57%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=100-4                              31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                            31.0 ± 0%      31.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                     21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                    21.0 ± 0%      21.0 ± 0%     ~     (all equal)
```
