### PR TITLE
Make bulk loaded rtrees fully balanced

### DIFF
--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -19,16 +19,15 @@ func BulkLoad(items []BulkItem) RTree {
 	}
 
 	levels := calculateLevels(len(items))
-	var tr RTree
-	tr.root = bulkInsert(items, levels)
-	return tr
+	return RTree{bulkInsert(items, levels)}
 }
 
 func calculateLevels(numItems int) int {
 	// We could theoretically do this calculation using math.Log. However,
-	// numerical stability issues can cause off-by-one related problems. Better
-	// to just calculate using integer arithmetic (it will be quick anyway,
-	// since the calculation is logarithmic in the number of items).
+	// float precision issues can cause off-by-one errors in some scenarios.
+	// Instead, we calculate the number of levels using integer arithmetic
+	// only. This will be fast anyway, since the calculation only requires
+	// logarithmic time.
 	var levels int
 	count := 1
 	for count < numItems {
@@ -54,7 +53,7 @@ func bulkInsert(items []BulkItem, level int) *node {
 	}
 
 	// NOTE: bulk loading is hardcoded around the fact that the min and max
-	// node cardinalites are 2 and 4.
+	// node cardinalities are 2 and 4.
 
 	// 6 is the first number of items that can be split into 3 nodes while
 	// respecting the minimum node cardinality, i.e. 6 = 2 + 2 + 2. Anything

--- a/rtree/nearest_test.go
+++ b/rtree/nearest_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 func TestNearest(t *testing.T) {
-	for pop := 0.0; pop < 1000; pop = (pop + 1) * 1.1 {
-		population := int(pop)
-
+	for _, population := range testPopulations(66, 1000, 1.1) {
 		t.Run(fmt.Sprintf("n=%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
 			rt, boxes := testBulkLoad(rnd, population, 0.9, 0.1)

--- a/rtree/nearest_test.go
+++ b/rtree/nearest_test.go
@@ -14,19 +14,8 @@ func TestNearest(t *testing.T) {
 
 		t.Run(fmt.Sprintf("n=%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
-			boxes := make([]Box, population)
-			for i := range boxes {
-				boxes[i] = randomBox(rnd, 0.9, 0.1)
-			}
-
-			inserts := make([]BulkItem, len(boxes))
-			for i := range inserts {
-				inserts[i].Box = boxes[i]
-				inserts[i].RecordID = i
-			}
-			rt := BulkLoad(inserts)
+			rt, boxes := testBulkLoad(rnd, population, 0.9, 0.1)
 			checkInvariants(t, rt, boxes)
-
 			checkNearest(t, rt, boxes, rnd)
 		})
 	}

--- a/rtree/rtree_test.go
+++ b/rtree/rtree_test.go
@@ -21,10 +21,19 @@ func testBulkLoad(rnd *rand.Rand, pop int, maxStart, maxWidth float64) (RTree, [
 	return BulkLoad(inserts), boxes
 }
 
-func TestRandom(t *testing.T) {
-	for pop := 0.0; pop < 1000; pop = (pop + 1) * 1.2 {
-		population := int(pop)
+func testPopulations(manditory, max int, mult float64) []int {
+	var pops []int
+	for i := 0; i < manditory; i++ {
+		pops = append(pops, i)
+	}
+	for pop := float64(manditory); pop < float64(max); pop *= mult {
+		pops = append(pops, int(pop))
+	}
+	return pops
+}
 
+func TestRandom(t *testing.T) {
+	for _, population := range testPopulations(66, 1000, 1.2) {
 		t.Run(fmt.Sprintf("bulk_%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
 			rt, boxes := testBulkLoad(rnd, population, 0.9, 0.1)
@@ -51,9 +60,7 @@ func TestRandom(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	for pop := 0.0; pop < 1000; pop = (pop + 1) * 1.5 {
-		population := int(pop)
-
+	for _, population := range testPopulations(66, 1000, 1.5) {
 		t.Run(fmt.Sprintf("pop=%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
 			rt, boxes := testBulkLoad(rnd, population, 0.9, 0.1)


### PR DESCRIPTION
## Description

This change makes bulk loaded rtrees fully balanced, i.e. each leaf is on the same level in the tree. Previously, some leavs were on level `n` and some on `n+1` (for some `n`).

Some of the algorithms we want to implement (such as a better delete) will rely on the invariant that rtrees are perfectly balanced. Insert already respects this new invariant.

## Check List

Have you:

- Added unit tests? Yes (added a check for the new invariant).

- Add cmprefimpl tests? (if appropriate?). N/A

## Related Issue

Relates to #208 (but doesn't address it)

## Benchmark Results

Some slight perf degredation. I think that's ok, since rtree stuff hasn't been optimised yet.

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.27µs ±13%    2.80µs ±25%  +23.29%  (p=0.000 n=14+15)
IntersectsLineStringWithLineString/n=100-4      41.1µs ±11%    43.2µs ±12%     ~     (p=0.063 n=15+14)
IntersectsLineStringWithLineString/n=1000-4      612µs ±19%     604µs ±13%     ~     (p=0.769 n=14+14)
IntersectsLineStringWithLineString/n=10000-4    9.73ms ±11%   10.07ms ±15%     ~     (p=0.252 n=12+14)
LineStringIsSimpleZigZag/10-4                   2.14µs ± 5%    2.21µs ±13%     ~     (p=0.216 n=12+14)
LineStringIsSimpleZigZag/100-4                  65.3µs ±12%    68.0µs ±18%     ~     (p=0.290 n=14+15)
LineStringIsSimpleZigZag/1000-4                 1.04ms ±16%    1.04ms ±13%     ~     (p=0.867 n=13+14)
LineStringIsSimpleZigZag/10000-4                14.0ms ± 4%    13.9ms ± 6%     ~     (p=0.899 n=14+12)
PolygonSingleRingValidation/n=10-4              2.58µs ±23%    2.44µs ± 8%     ~     (p=0.052 n=14+15)
PolygonSingleRingValidation/n=100-4             57.9µs ± 8%    59.8µs ± 6%   +3.34%  (p=0.019 n=14+14)
PolygonSingleRingValidation/n=1000-4            1.06ms ± 5%    1.09ms ± 9%     ~     (p=0.150 n=14+14)
PolygonSingleRingValidation/n=10000-4           14.4ms ± 4%    14.6ms ± 5%     ~     (p=0.085 n=13+14)
PolygonMultipleRingsValidation/n=4-4            10.8µs ± 3%    11.3µs ± 9%     ~     (p=0.135 n=12+15)
PolygonMultipleRingsValidation/n=36-4            102µs ± 7%     101µs ±12%     ~     (p=0.217 n=15+14)
PolygonMultipleRingsValidation/n=400-4          1.28ms ± 6%    1.28ms ± 9%     ~     (p=0.813 n=15+14)
PolygonMultipleRingsValidation/n=4096-4         15.1ms ± 8%    15.3ms ±12%     ~     (p=0.964 n=13+15)
PolygonZigZagRingsValidation/n=10-4             26.9µs ±10%    25.9µs ±16%     ~     (p=0.217 n=13+15)
PolygonZigZagRingsValidation/n=100-4             349µs ± 7%     354µs ±16%     ~     (p=0.482 n=14+14)
PolygonZigZagRingsValidation/n=1000-4           4.89ms ± 8%    4.81ms ± 8%     ~     (p=0.325 n=15+15)
PolygonZigZagRingsValidation/n=10000-4          65.6ms ± 6%    65.8ms ±20%     ~     (p=0.223 n=13+13)
MultipolygonValidation/n=1-4                     360ns ±13%     357ns ±16%     ~     (p=0.709 n=14+14)
MultipolygonValidation/n=4-4                     910ns ± 8%     902ns ±10%     ~     (p=0.502 n=12+14)
MultipolygonValidation/n=16-4                   5.79µs ± 8%    5.80µs ± 8%     ~     (p=0.919 n=14+14)
MultipolygonValidation/n=64-4                   35.6µs ±12%    34.8µs ± 9%     ~     (p=0.316 n=13+15)
MultipolygonValidation/n=256-4                   209µs ± 9%     203µs ± 6%     ~     (p=0.063 n=15+14)
MultipolygonValidation/n=1024-4                 1.03ms ± 7%    1.02ms ± 9%     ~     (p=0.635 n=14+14)
MultiPolygonTwoCircles/n=10-4                   7.90µs ±12%    7.69µs ±14%     ~     (p=0.313 n=13+12)
MultiPolygonTwoCircles/n=100-4                   113µs ±20%     109µs ± 5%     ~     (p=1.000 n=15+13)
MultiPolygonTwoCircles/n=1000-4                 1.66ms ±25%    1.56ms ± 5%     ~     (p=0.169 n=14+13)
MultiPolygonTwoCircles/n=10000-4                24.2ms ±20%    23.4ms ±17%     ~     (p=0.591 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1-4        6.16µs ± 6%    6.41µs ±19%     ~     (p=0.113 n=13+13)
MultiPolygonMultipleTouchingPoints/n=10-4       51.1µs ±10%    56.2µs ±47%     ~     (p=0.128 n=14+13)
MultiPolygonMultipleTouchingPoints/n=100-4       621µs ± 8%     608µs ± 6%     ~     (p=0.102 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     8.27ms ±11%    8.03ms ±10%     ~     (p=0.227 n=14+14)
MarshalWKB/polygon/n=10-4                        207ns ±19%     213ns ±13%     ~     (p=0.258 n=15+13)
MarshalWKB/polygon/n=100-4                     1.05µs ±158%    0.63µs ±12%     ~     (p=0.494 n=14+12)
MarshalWKB/polygon/n=1000-4                     5.11µs ±67%   8.50µs ±132%     ~     (p=0.839 n=14+14)
MarshalWKB/polygon/n=10000-4                    35.4µs ±42%   64.7µs ±123%  +82.88%  (p=0.034 n=13+13)
UnmarshalWKB/polygon/n=10-4                      324ns ± 9%     357ns ±12%  +10.36%  (p=0.000 n=14+15)
UnmarshalWKB/polygon/n=100-4                     778ns ±15%     977ns ±63%     ~     (p=0.142 n=13+15)
UnmarshalWKB/polygon/n=1000-4                   4.42µs ±16%    5.11µs ±75%     ~     (p=0.720 n=13+14)
UnmarshalWKB/polygon/n=10000-4                  37.9µs ±25%    39.3µs ±25%     ~     (p=0.595 n=14+12)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             50.1µs ± 9%    51.2µs ± 6%     ~     (p=0.150 n=13+11)
Intersection/n=100-4                            99.1µs ±11%    97.6µs ± 9%     ~     (p=0.305 n=15+15)
Intersection/n=1000-4                            423µs ±22%     423µs ±25%     ~     (p=0.967 n=15+15)
Intersection/n=10000-4                          3.73ms ± 6%    3.76ms ±22%     ~     (p=0.525 n=13+15)
NoOp/n=10-4                                     3.98µs ±10%    3.93µs ±12%     ~     (p=1.000 n=14+12)
NoOp/n=100-4                                    13.1µs ±16%    13.4µs ± 8%     ~     (p=0.178 n=14+14)
NoOp/n=1000-4                                   90.6µs ± 6%    93.4µs ±13%     ~     (p=0.786 n=13+15)
NoOp/n=10000-4                                  1.04ms ±17%    0.98ms ±19%     ~     (p=0.150 n=14+14)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.69kB ± 0%    2.82kB ± 0%   +4.76%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4      32.6kB ± 0%    34.4kB ± 0%   +5.29%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      286kB ± 0%     237kB ± 0%  -17.10%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    3.77MB ± 0%    3.15MB ± 0%  -16.35%  (p=0.000 n=15+14)
LineStringIsSimpleZigZag/10-4                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                  21.6kB ± 0%    21.6kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  230kB ± 0%     230kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                2.30MB ± 0%    2.30MB ± 0%     ~     (p=0.564 n=14+15)
PolygonSingleRingValidation/n=10-4              1.47kB ± 0%    1.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4             16.2kB ± 0%    16.2kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             217kB ± 0%     217kB ± 0%     ~     (p=0.322 n=14+13)
PolygonSingleRingValidation/n=10000-4           2.23MB ± 0%    2.23MB ± 0%     ~     (p=0.472 n=14+14)
PolygonMultipleRingsValidation/n=4-4            5.28kB ± 0%    5.28kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           43.3kB ± 0%    43.3kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           476kB ± 0%     476kB ± 0%     ~     (p=0.931 n=14+14)
PolygonMultipleRingsValidation/n=4096-4         4.88MB ± 0%    4.88MB ± 0%   -0.00%  (p=0.042 n=14+14)
PolygonZigZagRingsValidation/n=10-4             14.0kB ± 0%    12.3kB ± 0%  -12.36%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4             138kB ± 0%     143kB ± 0%   +3.75%  (p=0.000 n=12+14)
PolygonZigZagRingsValidation/n=1000-4           1.26MB ± 0%    1.11MB ± 0%  -11.64%  (p=0.000 n=14+14)
PolygonZigZagRingsValidation/n=10000-4          15.3MB ± 0%    13.5MB ± 0%  -12.10%  (p=0.000 n=14+13)
MultipolygonValidation/n=1-4                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                   15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                  63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  259kB ± 0%     259kB ± 0%     ~     (p=0.982 n=14+14)
MultiPolygonTwoCircles/n=10-4                   6.88kB ± 0%    5.73kB ± 0%  -16.74%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                  59.4kB ± 0%    62.9kB ± 0%   +5.82%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  508kB ± 0%     410kB ± 0%  -19.29%  (p=0.000 n=13+15)
MultiPolygonTwoCircles/n=10000-4                6.89MB ± 0%    5.65MB ± 0%  -17.93%  (p=0.000 n=15+12)
MultiPolygonMultipleTouchingPoints/n=1-4        4.18kB ± 0%    4.18kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       23.8kB ± 0%    24.3kB ± 0%   +2.42%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       212kB ± 0%     188kB ± 0%  -11.38%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.00MB ± 0%    2.28MB ± 0%  +13.93%  (p=0.000 n=14+15)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       282B ± 0%      282B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
Intersection/n=100-4                            6.33kB ± 0%    6.33kB ± 0%     ~     (all equal)
Intersection/n=1000-4                           55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
Intersection/n=10000-4                           558kB ± 0%     557kB ± 0%   -0.00%  (p=0.037 n=13+13)
NoOp/n=10-4                                       864B ± 0%      864B ± 0%     ~     (all equal)
NoOp/n=100-4                                    5.68kB ± 0%    5.68kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                   49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%     ~     (p=0.432 n=15+14)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         15.0 ± 0%      18.0 ± 0%  +20.00%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4         160 ± 0%       166 ± 0%   +3.75%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      1.28k ± 0%     1.11k ± 0%  -13.28%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4     19.3k ± 0%     17.8k ± 0%   -7.91%  (p=0.000 n=14+15)
LineStringIsSimpleZigZag/10-4                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                    75.0 ± 0%      75.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                    797 ± 0%       797 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 8.00k ± 0%     8.00k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                6.00 ± 0%      6.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4               57.0 ± 0%      57.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4               755 ± 0%       755 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4            7.73k ± 0%     7.73k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              25.0 ± 0%      25.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              203 ± 0%       203 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           2.23k ± 0%     2.23k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          22.8k ± 0%     22.8k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4               70.0 ± 0%      64.0 ± 0%   -8.57%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4               636 ± 0%       654 ± 0%   +2.83%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000-4            5.46k ± 0%     4.95k ± 0%   -9.34%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000-4           74.1k ± 0%     69.5k ± 0%   -6.23%  (p=0.000 n=15+12)
MultipolygonValidation/n=1-4                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                     392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     46.0 ± 0%      42.0 ± 0%   -8.70%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                     326 ± 0%       338 ± 0%   +3.68%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  2.57k ± 0%     2.23k ± 0%  -13.25%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                 38.6k ± 0%     35.5k ± 0%   -7.93%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4          51.0 ± 0%      51.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          332 ± 0%       334 ± 0%   +0.60%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       3.07k ± 0%     2.99k ± 0%   -2.74%  (p=0.000 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1000-4      29.2k ± 0%     32.3k ± 0%  +10.71%  (p=0.000 n=12+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=100-4                              31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                            31.0 ± 0%      31.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                     21.0 ± 0%      21.0 ± 0%     ~     (all equal)
```
