### PR TITLE
Benchmark for rtree delete

### DIFF
--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -9,16 +9,13 @@ import (
 func BenchmarkDelete(b *testing.B) {
 	for pop := 100; pop <= 10000; pop *= 10 {
 		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
-			var boxes []Box
-			rts := make([]RTree, b.N)
 			for i := 0; i < b.N; i++ {
+				b.StopTimer()
 				rnd := rand.New(rand.NewSource(0))
-				rts[i], boxes = testBulkLoad(rnd, pop, 0.9, 0.1)
-			}
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+				rt, boxes := testBulkLoad(rnd, pop, 0.9, 0.1)
+				b.StartTimer()
 				for j, box := range boxes {
-					if !rts[i].Delete(box, j) {
+					if !rt.Delete(box, j) {
 						b.Fatal("could not delete")
 					}
 				}

--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -1,0 +1,28 @@
+package rtree
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkDelete(b *testing.B) {
+	for pop := 100; pop <= 10000; pop *= 10 {
+		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
+			var boxes []Box
+			rts := make([]RTree, b.N)
+			for i := 0; i < b.N; i++ {
+				rnd := rand.New(rand.NewSource(0))
+				rts[i], boxes = testBulkLoad(rnd, pop, 0.9, 0.1)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for j, box := range boxes {
+					if !rts[i].Delete(box, j) {
+						b.Fatal("could not delete")
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds a benchmark for tracking performance of the rtree delete operation.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- Relates to #208 

## Benchmark Results

- N/A
