### PR TITLE
Use RTree as a pointer type

### DIFF
--- a/geom/rtree.go
+++ b/geom/rtree.go
@@ -7,7 +7,7 @@ import "github.com/peterstace/simplefeatures/rtree"
 // the indices of the lines slice.
 type indexedLines struct {
 	lines []line
-	tree  rtree.RTree
+	tree  *rtree.RTree
 }
 
 func newIndexedLines(lines []line) indexedLines {

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -13,13 +13,13 @@ type BulkItem struct {
 // BulkLoad bulk loads multiple items into a new R-Tree. The bulk load
 // operation is optimised for creating R-Trees with minimal node overlap. This
 // allows for fast searching.
-func BulkLoad(items []BulkItem) RTree {
+func BulkLoad(items []BulkItem) *RTree {
 	if len(items) == 0 {
-		return RTree{}
+		return &RTree{}
 	}
 
 	levels := calculateLevels(len(items))
-	return RTree{bulkInsert(items, levels)}
+	return &RTree{bulkInsert(items, levels)}
 }
 
 func calculateLevels(numItems int) int {

--- a/rtree/nearest_test.go
+++ b/rtree/nearest_test.go
@@ -19,7 +19,7 @@ func TestNearest(t *testing.T) {
 	}
 }
 
-func checkNearest(t *testing.T, rt RTree, boxes []Box, rnd *rand.Rand) {
+func checkNearest(t *testing.T, rt *RTree, boxes []Box, rnd *rand.Rand) {
 	for i := 0; i < 10; i++ {
 		var got []int
 		originBB := randomBox(rnd, 0.9, 0.1)

--- a/rtree/rtree_test.go
+++ b/rtree/rtree_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func testBulkLoad(rnd *rand.Rand, pop int, maxStart, maxWidth float64) (RTree, []Box) {
+func testBulkLoad(rnd *rand.Rand, pop int, maxStart, maxWidth float64) (*RTree, []Box) {
 	boxes := make([]Box, pop)
 	for i := range boxes {
 		boxes[i] = randomBox(rnd, maxStart, maxWidth)
@@ -48,7 +48,7 @@ func TestRandom(t *testing.T) {
 				boxes[i] = randomBox(rnd, 0.9, 0.1)
 			}
 
-			var rt RTree
+			rt := new(RTree)
 			for i, box := range boxes {
 				rt.Insert(box, i)
 				checkInvariants(t, rt, boxes[:i+1])
@@ -76,7 +76,7 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func checkSearch(t *testing.T, rt RTree, boxes []Box, rnd *rand.Rand) {
+func checkSearch(t *testing.T, rt *RTree, boxes []Box, rnd *rand.Rand) {
 	for i := 0; i < 10; i++ {
 		searchBB := randomBox(rnd, 0.5, 0.5)
 		var got []int
@@ -117,7 +117,7 @@ func randomBox(rnd *rand.Rand, maxStart, maxWidth float64) Box {
 	return box
 }
 
-func checkInvariants(t *testing.T, rt RTree, boxes []Box) {
+func checkInvariants(t *testing.T, rt *RTree, boxes []Box) {
 	var recurse func(*node, string)
 	recurse = func(current *node, indent string) {
 		t.Logf("%sNode addr=%p leaf=%t numEntries=%d", indent, current, current.isLeaf, current.numEntries)


### PR DESCRIPTION
## Description

This change modifies the BulkInsert operation to return an RTree as a pointer. This is more consistent with other usages of RTree.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

N/A
