### PR TITLE
Fix bug in multipolygon validation

### DIFF
--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -67,7 +67,7 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 		box := env.box()
 
 		err := tree.RangeSearch(box, func(j int) error {
-			for k := range [...]int{i, j} {
+			for _, k := range [...]int{i, j} {
 				if !polyBoundaryPopulated[k] {
 					polyBoundaries[k] = newIndexedLines(polys[k].Boundary().asLines())
 					polyBoundaryPopulated[k] = true

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -139,6 +139,9 @@ func TestMultiPolygonValidation(t *testing.T) {
 		`MULTIPOLYGON(EMPTY)`,
 		`MULTIPOLYGON(((0 0,0 1,1 0,0 0)),EMPTY)`,
 		`MULTIPOLYGON(EMPTY,((0 0,0 1,1 0,0 0)))`,
+
+		// Replicates a bug.
+		`MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 -1,3 -1,3 0,2 0,2 -1)),((1 1,3 1,3 3,1 3,1 1)))`,
 	} {
 		t.Run(fmt.Sprintf("valid_%d", i), func(t *testing.T) {
 			geomFromWKT(t, wkt)


### PR DESCRIPTION
## Description

Fixes a bug in multipolygon validation. Before the bug fix, index creation for child multipolygons was not targeted at the correct child.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- Fixes #215 

## Benchmark Results

- N/A
