### PR TITLE
Simplify point-in-ring algorithm

### DIFF
--- a/geom/alg_point_in_ring.go
+++ b/geom/alg_point_in_ring.go
@@ -41,9 +41,6 @@ func relatePointToRing(pt XY, ring LineString) side {
 }
 
 func hasCrossing(pt XY, ln line) (crossing, onLine bool) {
-	if ln.a.Y == ln.b.Y {
-		return false, pt.Y == ln.a.Y && ln.minX() <= pt.X && pt.X <= ln.maxX()
-	}
 	lower, upper := ln.a, ln.b
 	if lower.Y > upper.Y {
 		lower, upper = upper, lower
@@ -51,7 +48,7 @@ func hasCrossing(pt XY, ln line) (crossing, onLine bool) {
 	o := orientation(lower, upper, pt)
 
 	crossing = pt.Y >= lower.Y && pt.Y < upper.Y && o == rightTurn
-	onLine = pt == lower || pt == upper || (ln.envelope().Contains(pt) && o == collinear)
+	onLine = ln.envelope().Contains(pt) && o == collinear
 	return
 }
 

--- a/geom/alg_point_in_ring_test.go
+++ b/geom/alg_point_in_ring_test.go
@@ -128,6 +128,15 @@ func TestPointInRing(t *testing.T) {
 				{"POINT(2 3)", boundary},
 			},
 		},
+		{
+			wkt: "POLYGON((0 0,1 0,1.5 0.5,2 1,0 1,0 0.5,0 0))",
+			subTests: []subTestCase{
+				{"POINT(0 0.5)", boundary},
+				{"POINT(1 0.5)", interior},
+				{"POINT(1.5 0.5)", boundary},
+				{"POINT(2 0.5)", exterior},
+			},
+		},
 	} {
 		g, err := UnmarshalWKT(tc.wkt)
 		if err != nil {


### PR DESCRIPTION
## Description

Simplification to the point-in-ring algorithm. The main change is that we no longer explicitly track what the ray being used is.

## Check List

Have you:

- Added unit tests? N/A (same unit tests used).

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

Slight improvement for some benchmarks:

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.57µs ± 7%    2.79µs ±19%   +8.80%  (p=0.020 n=12+14)
IntersectsLineStringWithLineString/n=100-4      42.6µs ±15%    42.2µs ± 9%     ~     (p=0.880 n=14+15)
IntersectsLineStringWithLineString/n=1000-4      602µs ±15%     604µs ± 9%     ~     (p=0.401 n=14+14)
IntersectsLineStringWithLineString/n=10000-4    10.2ms ±17%     9.6ms ± 7%   -5.84%  (p=0.045 n=15+15)
LineStringIsSimpleZigZag/10-4                   2.23µs ± 7%    2.30µs ±20%     ~     (p=0.370 n=14+14)
LineStringIsSimpleZigZag/100-4                  63.8µs ± 6%    65.8µs ±12%     ~     (p=0.085 n=15+14)
LineStringIsSimpleZigZag/1000-4                 1.05ms ±10%    1.05ms ±12%     ~     (p=0.804 n=14+14)
LineStringIsSimpleZigZag/10000-4                13.7ms ± 4%    14.2ms ±13%     ~     (p=0.347 n=12+15)
PolygonSingleRingValidation/n=10-4              2.44µs ± 5%    2.49µs ±13%     ~     (p=0.625 n=13+14)
PolygonSingleRingValidation/n=100-4             58.1µs ± 7%    59.2µs ±13%     ~     (p=0.747 n=14+15)
PolygonSingleRingValidation/n=1000-4            1.08ms ±12%    1.07ms ± 7%     ~     (p=0.949 n=15+14)
PolygonSingleRingValidation/n=10000-4           14.3ms ± 7%    14.3ms ± 4%     ~     (p=0.683 n=15+13)
PolygonMultipleRingsValidation/n=4-4            11.0µs ±10%     8.0µs ± 8%  -27.32%  (p=0.000 n=14+15)
PolygonMultipleRingsValidation/n=36-4            101µs ± 5%      76µs ±12%  -24.78%  (p=0.000 n=14+14)
PolygonMultipleRingsValidation/n=400-4          1.31ms ±17%    1.02ms ± 8%  -22.68%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         14.7ms ± 1%    12.3ms ± 9%  -16.74%  (p=0.000 n=10+15)
PolygonZigZagRingsValidation/n=10-4             25.5µs ± 7%    20.8µs ±11%  -18.42%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4             352µs ± 9%     313µs ± 8%  -11.06%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000-4           4.78ms ± 9%    4.39ms ± 9%   -8.13%  (p=0.001 n=13+15)
PolygonZigZagRingsValidation/n=10000-4          62.4ms ± 3%    61.1ms ±10%   -2.22%  (p=0.037 n=12+15)
MultipolygonValidation/n=1-4                     353ns ±13%     363ns ± 7%     ~     (p=0.121 n=14+12)
MultipolygonValidation/n=4-4                     916ns ±12%     965ns ±19%     ~     (p=0.137 n=14+15)
MultipolygonValidation/n=16-4                   5.90µs ±11%    5.97µs ±15%     ~     (p=0.744 n=15+15)
MultipolygonValidation/n=64-4                   34.0µs ± 4%    35.0µs ± 7%     ~     (p=0.082 n=12+14)
MultipolygonValidation/n=256-4                   200µs ± 2%     205µs ± 7%     ~     (p=0.052 n=13+15)
MultipolygonValidation/n=1024-4                 1.03ms ±10%    1.03ms ± 9%     ~     (p=0.806 n=15+15)
MultiPolygonTwoCircles/n=10-4                   7.59µs ±12%    7.36µs ±17%     ~     (p=0.113 n=14+13)
MultiPolygonTwoCircles/n=100-4                   111µs ± 6%     114µs ±14%     ~     (p=0.624 n=15+15)
MultiPolygonTwoCircles/n=1000-4                 1.56ms ± 9%    1.56ms ±11%     ~     (p=0.839 n=14+14)
MultiPolygonTwoCircles/n=10000-4                22.6ms ± 7%    22.8ms ± 4%     ~     (p=0.614 n=13+13)
MultiPolygonMultipleTouchingPoints/n=1-4        6.19µs ±10%    6.06µs ± 9%     ~     (p=0.104 n=14+14)
MultiPolygonMultipleTouchingPoints/n=10-4       54.2µs ± 9%    48.6µs ±12%  -10.30%  (p=0.000 n=13+15)
MultiPolygonMultipleTouchingPoints/n=100-4       589µs ± 6%     558µs ± 3%   -5.23%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     7.77ms ± 5%    7.38ms ± 6%   -5.06%  (p=0.000 n=13+13)
MarshalWKB/polygon/n=10-4                        202ns ± 7%     204ns ±11%     ~     (p=0.973 n=14+14)
MarshalWKB/polygon/n=100-4                       614ns ±15%     597ns ±11%     ~     (p=0.493 n=15+15)
MarshalWKB/polygon/n=1000-4                     4.23µs ±24%    4.01µs ±19%     ~     (p=0.357 n=14+13)
MarshalWKB/polygon/n=10000-4                    31.9µs ±34%    33.0µs ±21%     ~     (p=0.306 n=14+14)
UnmarshalWKB/polygon/n=10-4                      361ns ±29%     328ns ± 5%     ~     (p=0.068 n=15+12)
UnmarshalWKB/polygon/n=100-4                     817ns ±34%     752ns ±13%     ~     (p=0.437 n=14+13)
UnmarshalWKB/polygon/n=1000-4                   4.10µs ± 9%    4.27µs ±19%     ~     (p=0.193 n=12+14)
UnmarshalWKB/polygon/n=10000-4                  44.5µs ±37%    41.4µs ±33%     ~     (p=0.270 n=14+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             52.9µs ±15%    53.4µs ±13%     ~     (p=0.935 n=15+15)
Intersection/n=100-4                            96.4µs ±12%    96.4µs ±12%     ~     (p=0.683 n=14+15)
Intersection/n=1000-4                            440µs ±13%     413µs ±16%   -6.16%  (p=0.023 n=15+15)
Intersection/n=10000-4                          3.55ms ± 8%    3.50ms ±15%     ~     (p=0.387 n=15+13)
NoOp/n=10-4                                     3.91µs ±12%    3.86µs ±12%     ~     (p=0.356 n=14+13)
NoOp/n=100-4                                    12.7µs ± 5%    12.6µs ± 9%     ~     (p=0.496 n=15+13)
NoOp/n=1000-4                                   93.6µs ±13%    89.7µs ± 3%     ~     (p=0.300 n=15+13)
NoOp/n=10000-4                                   953µs ±23%    1062µs ±36%     ~     (p=0.061 n=14+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                  40.5µs ± 6%    40.9µs ± 4%     ~     (p=0.616 n=14+13)
Delete/n=1000-4                                  800µs ± 5%     804µs ± 4%     ~     (p=0.461 n=15+15)
Delete/n=10000-4                                42.7ms ± 6%    41.8ms ± 6%     ~     (p=0.367 n=15+15)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.82kB ± 0%    2.82kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4      34.4kB ± 0%    34.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      237kB ± 0%     237kB ± 0%     ~     (p=0.738 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    3.15MB ± 0%    3.15MB ± 0%     ~     (p=0.340 n=14+14)
LineStringIsSimpleZigZag/10-4                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                  21.6kB ± 0%    21.6kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  230kB ± 0%     230kB ± 0%   -0.00%  (p=0.006 n=15+12)
LineStringIsSimpleZigZag/10000-4                2.30MB ± 0%    2.30MB ± 0%     ~     (p=0.791 n=15+14)
PolygonSingleRingValidation/n=10-4              1.47kB ± 0%    1.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4             16.2kB ± 0%    16.2kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             217kB ± 0%     217kB ± 0%     ~     (p=0.855 n=15+15)
PolygonSingleRingValidation/n=10000-4           2.23MB ± 0%    2.23MB ± 0%     ~     (p=0.408 n=13+13)
PolygonMultipleRingsValidation/n=4-4            5.31kB ± 0%    5.31kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           43.6kB ± 0%    43.6kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           479kB ± 0%     479kB ± 0%     ~     (p=0.699 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         4.92MB ± 0%    4.92MB ± 0%     ~     (p=0.413 n=14+15)
PolygonZigZagRingsValidation/n=10-4             12.3kB ± 0%    12.3kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             144kB ± 0%     144kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4           1.11MB ± 0%    1.11MB ± 0%     ~     (p=0.229 n=14+15)
PolygonZigZagRingsValidation/n=10000-4          13.5MB ± 0%    13.5MB ± 0%     ~     (p=0.595 n=15+15)
MultipolygonValidation/n=1-4                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                   15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                  63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  259kB ± 0%     259kB ± 0%     ~     (p=0.568 n=13+12)
MultiPolygonTwoCircles/n=10-4                   5.75kB ± 0%    5.75kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                  62.9kB ± 0%    62.9kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  410kB ± 0%     410kB ± 0%   +0.00%  (p=0.026 n=12+14)
MultiPolygonTwoCircles/n=10000-4                5.65MB ± 0%    5.65MB ± 0%     ~     (p=0.168 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1-4        4.19kB ± 0%    4.19kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       24.4kB ± 0%    24.4kB ± 0%     ~     (p=0.964 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       188kB ± 0%     188kB ± 0%     ~     (p=0.937 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.28MB ± 0%    2.28MB ± 0%     ~     (p=0.653 n=15+15)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       282B ± 0%      282B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
Intersection/n=100-4                            6.33kB ± 0%    6.33kB ± 0%     ~     (p=0.056 n=15+12)
Intersection/n=1000-4                           55.0kB ± 0%    55.0kB ± 0%     ~     (p=0.061 n=13+15)
Intersection/n=10000-4                           557kB ± 0%     557kB ± 0%     ~     (p=1.000 n=15+13)
NoOp/n=10-4                                       864B ± 0%      864B ± 0%     ~     (all equal)
NoOp/n=100-4                                    5.68kB ± 0%    5.68kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                   49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%     ~     (p=0.888 n=15+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                 24.2kB ± 0%    24.2kB ± 0%     ~     (all equal)
Delete/n=10000-4                                 465kB ± 0%     465kB ± 0%     ~     (all equal)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         19.0 ± 0%      19.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4         167 ± 0%       167 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      1.11k ± 0%     1.11k ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4     17.8k ± 0%     17.8k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                    75.0 ± 0%      75.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                    797 ± 0%       797 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 8.00k ± 0%     8.00k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                6.00 ± 0%      6.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4               57.0 ± 0%      57.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4               755 ± 0%       755 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4            7.73k ± 0%     7.73k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              29.0 ± 0%      29.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              239 ± 0%       239 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           2.63k ± 0%     2.63k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          26.9k ± 0%     26.9k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4               67.0 ± 0%      67.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4               657 ± 0%       657 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4            4.96k ± 0%     4.96k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4           69.5k ± 0%     69.5k ± 0%     ~     (p=0.337 n=15+15)
MultipolygonValidation/n=1-4                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                     392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     44.0 ± 0%      44.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                     340 ± 0%       340 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  2.23k ± 0%     2.23k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                 35.5k ± 0%     35.5k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4          53.0 ± 0%      53.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          336 ± 0%       336 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4       2.99k ± 0%     2.99k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4      32.3k ± 0%     32.3k ± 0%     ~     (p=0.971 n=15+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=100-4                              31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                            31.0 ± 0%      31.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                     21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                    21.0 ± 0%      21.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                    463 ± 0%       463 ± 0%     ~     (all equal)
Delete/n=10000-4                                 7.98k ± 0%     7.98k ± 0%     ~     (all equal)

```
