### PR TITLE
Add benchmark for bulk inserting

### DIFF
--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -23,3 +23,23 @@ func BenchmarkDelete(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkBulk(b *testing.B) {
+	for _, pop := range [...]int{10, 100, 1000} {
+		rnd := rand.New(rand.NewSource(0))
+		boxes := make([]Box, pop)
+		for i := range boxes {
+			boxes[i] = randomBox(rnd, 0.9, 0.1)
+		}
+		inserts := make([]BulkItem, len(boxes))
+		for i := range inserts {
+			inserts[i].Box = boxes[i]
+			inserts[i].RecordID = i
+		}
+		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				BulkLoad(inserts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds a benchmark for bulk inserting.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- #182 

## Benchmark Results

Initial results:

```
BenchmarkBulk/n=10-4              575140              2163 ns/op            1832 B/op         15 allocs/op
BenchmarkBulk/n=100-4              23161             55530 ns/op           23848 B/op        163 allocs/op
BenchmarkBulk/n=1000-4              1004           1063714 ns/op          130856 B/op       1107 allocs/op
```
