### PR TITLE
Add filter to benchmark script

### DIFF
--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -15,6 +15,7 @@ new="$(mktemp)"
 trap "rm -f $new $old" EXIT
 
 package="./..."
+bench="."
 
 for (( i = 0; i < 15; i++ )); do
 	echo
@@ -24,13 +25,13 @@ for (( i = 0; i < 15; i++ )); do
 	echo "OLD"
 	git checkout "$old_git_sha1"
 	echo
-	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench=. | tee -a "$old"
+	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench="$bench" | tee -a "$old"
 
 	echo
 	echo "NEW"
 	git checkout "$new_git_sha1"
 	echo
-	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench=. | tee -a "$new"
+	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench="$bench" | tee -a "$new"
 done
 
 echo


### PR DESCRIPTION
## Description

Adds a filter to the benchmark script. This is useful for running only a single benchmark at a time.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A
