### PR TITLE
Add benchmark for RTree Insert

### DIFF
--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -43,3 +43,23 @@ func BenchmarkBulk(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkInsert(b *testing.B) {
+	for _, pop := range [...]int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(0))
+			boxes := make([]Box, pop)
+			for i := range boxes {
+				boxes[i] = randomBox(rnd, 0.9, 0.1)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var tree RTree
+				for j, b := range boxes {
+					tree.Insert(b, j)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds a benchmark for RTree Insert

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- #182 

## Benchmark Results

Initial result set:

```
BenchmarkInsert/n=10-4                    647782              1767 ns/op
BenchmarkInsert/n=100-4                    33859             35782 ns/op
BenchmarkInsert/n=1000-4                    2014            595291 ns/op
```
