### PR TITLE
Bulk load perf experiment

### DIFF
--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -43,6 +43,7 @@ func intersectionOfLines(lines1, lines2 []line) (MultiPoint, MultiLineString) {
 		}
 	}
 	tree := rtree.BulkLoad(bulk)
+	defer tree.Recycle()
 
 	var lines []LineString
 	var ptFloats []float64

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -205,6 +205,7 @@ func hasIntersectionBetweenLines(
 		}
 	}
 	tree := rtree.BulkLoad(bulk)
+	defer tree.Recycle()
 
 	// Keep track of an envelope of all of the points that are in the
 	// intersection.

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -103,6 +103,7 @@ func (s LineString) IsSimple() bool {
 	prev := -1
 
 	var tree rtree.RTree
+	defer tree.Recycle()
 	n := s.seq.Length()
 	for i := 0; i < n; i++ {
 		ln, ok := getLine(s.seq, i)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -98,7 +98,7 @@ func (s LineString) IsSimple() bool {
 
 	// We need to track the index of the previous line segments, so that we can
 	// ignore the case where adjacent line segments intersect at a point (due
-	// to their construction). We can just subtract 1 from the current index,
+	// to their construction). We can't just subtract 1 from the current index,
 	// since there could be duplicated vertices in the middle of the sequence.
 	prev := -1
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -59,6 +59,7 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 	polyBoundaryPopulated := make([]bool, len(polys))
 
 	var tree rtree.RTree
+	defer tree.Recycle()
 	for i := range polys {
 		env, ok := polys[i].Envelope()
 		if !ok {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -58,17 +58,8 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 	polyBoundaries := make([]indexedLines, len(polys))
 	polyBoundaryPopulated := make([]bool, len(polys))
 
-	bulkItems := make([]rtree.BulkItem, 0, len(polys))
-	for i, p := range polys {
-		env, ok := p.Envelope()
-		if ok {
-			item := rtree.BulkItem{Box: env.box(), RecordID: i}
-			bulkItems = append(bulkItems, item)
-		}
-	}
-	tree := rtree.BulkLoad(bulkItems)
+	var tree rtree.RTree
 	defer tree.Recycle()
-
 	for i := range polys {
 		env, ok := polys[i].Envelope()
 		if !ok {
@@ -77,10 +68,6 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 		box := env.box()
 
 		err := tree.RangeSearch(box, func(j int) error {
-			if i <= j {
-				return nil
-			}
-
 			for _, k := range [...]int{i, j} {
 				if !polyBoundaryPopulated[k] {
 					polyBoundaries[k] = newIndexedLines(polys[k].Boundary().asLines())
@@ -129,6 +116,8 @@ func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
 		if err != nil {
 			return err
 		}
+
+		tree.Insert(box, i)
 	}
 	return nil
 }

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -75,6 +75,7 @@ func validatePolygon(rings []LineString, opts ...ConstructorOption) error {
 
 	// Check each pair of rings (skipping any pairs that could not possibly intersect).
 	var tree rtree.RTree
+	defer tree.Recycle()
 	for i, currentRing := range rings {
 		env, ok := currentRing.Envelope()
 		if !ok {

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -40,8 +40,7 @@ func calculateLevels(numItems int) int {
 func bulkInsert(items []BulkItem, levels int) *node {
 	if levels == 1 {
 		root := nodePool.Get().(*node)
-		root.isLeaf = true
-		root.numEntries = len(items)
+		*root = node{isLeaf: true, numEntries: len(items)}
 		for i, item := range items {
 			root.entries[i] = entry{
 				box:      item.Box,
@@ -79,7 +78,7 @@ func bulkInsert(items []BulkItem, levels int) *node {
 
 func bulkNode(levels int, parts ...[]BulkItem) *node {
 	root := nodePool.Get().(*node)
-	root.numEntries = len(parts)
+	*root = node{numEntries: len(parts)}
 	for i, part := range parts {
 		child := bulkInsert(part, levels-1)
 		child.parent = root

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -122,6 +122,8 @@ func sortBulkItems(items []BulkItem) {
 	sort.Sort(bulkItems)
 }
 
+// bulkItems implements the sort.Interface interface. This style of sorting is
+// used rather than sort.Slice because it does less allocations.
 type bulkItems struct {
 	horizontal bool
 	items      []BulkItem

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -39,7 +39,9 @@ func calculateLevels(numItems int) int {
 
 func bulkInsert(items []BulkItem, levels int) *node {
 	if levels == 1 {
-		root := &node{isLeaf: true, numEntries: len(items)}
+		root := nodePool.Get().(*node)
+		root.isLeaf = true
+		root.numEntries = len(items)
 		for i, item := range items {
 			root.entries[i] = entry{
 				box:      item.Box,
@@ -76,11 +78,8 @@ func bulkInsert(items []BulkItem, levels int) *node {
 }
 
 func bulkNode(levels int, parts ...[]BulkItem) *node {
-	root := &node{
-		numEntries: len(parts),
-		parent:     nil,
-		isLeaf:     false,
-	}
+	root := nodePool.Get().(*node)
+	root.numEntries = len(parts)
 	for i, part := range parts {
 		child := bulkInsert(part, levels-1)
 		child.parent = root

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -115,14 +115,30 @@ func sortBulkItems(items []BulkItem) {
 	for _, item := range items[1:] {
 		box = combine(box, item.Box)
 	}
-	horizontal := box.MaxX-box.MinX > box.MaxY-box.MinY
-	sort.Slice(items, func(i, j int) bool {
-		bi := items[i].Box
-		bj := items[j].Box
-		if horizontal {
-			return bi.MinX+bi.MaxX < bj.MinX+bj.MaxX
-		} else {
-			return bi.MinY+bi.MaxY < bj.MinY+bj.MaxY
-		}
-	})
+	bulkItems := bulkItems{
+		horizontal: box.MaxX-box.MinX > box.MaxY-box.MinY,
+		items:      items,
+	}
+	sort.Sort(bulkItems)
+}
+
+type bulkItems struct {
+	horizontal bool
+	items      []BulkItem
+}
+
+func (b bulkItems) Len() int {
+	return len(b.items)
+}
+func (b bulkItems) Less(i, j int) bool {
+	bi := b.items[i].Box
+	bj := b.items[j].Box
+	if b.horizontal {
+		return bi.MinX+bi.MaxX < bj.MinX+bj.MaxX
+	} else {
+		return bi.MinY+bi.MaxY < bj.MinY+bj.MaxY
+	}
+}
+func (b bulkItems) Swap(i, j int) {
+	b.items[i], b.items[j] = b.items[j], b.items[i]
 }

--- a/rtree/insert.go
+++ b/rtree/insert.go
@@ -13,7 +13,8 @@ const (
 // Insert adds a new record to the RTree.
 func (t *RTree) Insert(box Box, recordID int) {
 	if t.root == nil {
-		t.root = &node{isLeaf: true}
+		t.root = nodePool.Get().(*node)
+		t.root.isLeaf = true
 	}
 
 	level := t.root.depth() - 1
@@ -49,7 +50,8 @@ func (t *RTree) adjustBoxesUpwards(node *node, box Box) {
 }
 
 func (t *RTree) joinRoots(r1, r2 *node) {
-	newRoot := &node{
+	newRoot := nodePool.Get().(*node)
+	*newRoot = node{
 		entries: [1 + maxChildren]entry{
 			entry{box: calculateBound(r1), child: r1},
 			entry{box: calculateBound(r2), child: r2},
@@ -140,7 +142,8 @@ func (t *RTree) splitNode(n *node) *node {
 
 	// Use the existing node for the 0 bits in the split, and a new node for
 	// the 1 bits in the split.
-	newNode := &node{isLeaf: n.isLeaf}
+	newNode := nodePool.Get().(*node)
+	*newNode = node{isLeaf: n.isLeaf}
 	totalEntries := n.numEntries
 	n.numEntries = 0
 	for i := 0; i < totalEntries; i++ {

--- a/rtree/insert.go
+++ b/rtree/insert.go
@@ -14,7 +14,7 @@ const (
 func (t *RTree) Insert(box Box, recordID int) {
 	if t.root == nil {
 		t.root = nodePool.Get().(*node)
-		t.root.isLeaf = true
+		*t.root = node{isLeaf: true}
 	}
 
 	level := t.root.depth() - 1

--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -63,6 +63,7 @@ func BenchmarkInsert(b *testing.B) {
 				for j, b := range boxes {
 					tree.Insert(b, j)
 				}
+				tree.Recycle()
 			}
 		})
 	}

--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -38,7 +38,8 @@ func BenchmarkBulk(b *testing.B) {
 		}
 		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				BulkLoad(inserts)
+				tr := BulkLoad(inserts)
+				tr.Recycle()
 			}
 		})
 	}

--- a/rtree/rtree.go
+++ b/rtree/rtree.go
@@ -16,6 +16,9 @@ func releaseNode(n *node) {
 	nodePool.Put(n)
 }
 
+// Recycle empties the tree, keeping any internally allocated memory for later
+// use by future RTrees. As a performance optimisation, it's generally a good
+// idea to call Recycle after an RTree is no longer needed.
 func (t *RTree) Recycle() {
 	var recurse func(*node)
 	recurse = func(n *node) {


### PR DESCRIPTION
## Description
Makes some improvements to RTrees, primary around memory usage.

## Check List

Have you:

- Added unit tests? N/A (existing tests)

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- #182

## Benchmark Results

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.58µs ±18%    2.22µs ± 7%  -13.95%  (p=0.000 n=13+14)
IntersectsLineStringWithLineString/n=100-4      41.6µs ±10%    34.8µs ±10%  -16.35%  (p=0.000 n=15+14)
IntersectsLineStringWithLineString/n=1000-4      563µs ± 9%     514µs ± 7%   -8.69%  (p=0.000 n=15+14)
IntersectsLineStringWithLineString/n=10000-4    9.03ms ±10%    8.48ms ±12%   -6.12%  (p=0.001 n=14+15)
LineStringIsSimpleZigZag/10-4                   2.13µs ± 6%    2.32µs ± 7%   +8.89%  (p=0.000 n=13+14)
LineStringIsSimpleZigZag/100-4                  63.0µs ± 3%    40.9µs ± 5%  -35.14%  (p=0.000 n=12+13)
LineStringIsSimpleZigZag/1000-4                 1.04ms ± 8%    0.64ms ± 5%  -38.65%  (p=0.000 n=14+15)
LineStringIsSimpleZigZag/10000-4                13.8ms ± 8%     9.7ms ± 2%  -30.14%  (p=0.000 n=13+13)
PolygonSingleRingValidation/n=10-4              2.48µs ± 7%    3.39µs ±11%  +36.73%  (p=0.000 n=13+15)
PolygonSingleRingValidation/n=100-4             57.6µs ± 7%    47.7µs ± 2%  -17.12%  (p=0.000 n=13+12)
PolygonSingleRingValidation/n=1000-4            1.05ms ± 4%    0.75ms ± 5%  -29.27%  (p=0.000 n=13+14)
PolygonSingleRingValidation/n=10000-4           14.2ms ±12%    10.9ms ± 3%  -23.44%  (p=0.000 n=13+12)
PolygonMultipleRingsValidation/n=4-4            8.54µs ± 6%   10.93µs ± 9%  +28.07%  (p=0.000 n=13+14)
PolygonMultipleRingsValidation/n=36-4           82.5µs ± 7%    94.2µs ± 3%  +14.15%  (p=0.000 n=14+13)
PolygonMultipleRingsValidation/n=400-4          1.10ms ±12%    1.23ms ± 8%  +12.32%  (p=0.000 n=14+14)
PolygonMultipleRingsValidation/n=4096-4         12.6ms ± 7%    14.7ms ± 7%  +16.37%  (p=0.000 n=14+15)
PolygonZigZagRingsValidation/n=10-4             21.9µs ± 9%    20.1µs ± 4%   -8.35%  (p=0.000 n=14+13)
PolygonZigZagRingsValidation/n=100-4             315µs ± 3%     264µs ±13%  -15.97%  (p=0.000 n=12+15)
PolygonZigZagRingsValidation/n=1000-4           4.47ms ±12%    3.49ms ± 8%  -22.08%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000-4          59.5ms ± 6%    51.7ms ± 8%  -13.22%  (p=0.000 n=13+14)
MultipolygonValidation/n=1-4                     393ns ±38%     433ns ± 8%  +10.22%  (p=0.015 n=14+15)
MultipolygonValidation/n=4-4                     960ns ±20%     991ns ±12%     ~     (p=0.221 n=14+15)
MultipolygonValidation/n=16-4                   5.76µs ± 6%    5.39µs ± 3%   -6.45%  (p=0.000 n=13+13)
MultipolygonValidation/n=64-4                   34.5µs ±13%    32.3µs ± 6%   -6.53%  (p=0.000 n=13+14)
MultipolygonValidation/n=256-4                   211µs ±10%     198µs ± 3%   -6.10%  (p=0.000 n=14+13)
MultipolygonValidation/n=1024-4                 1.03ms ± 8%    1.02ms ± 7%     ~     (p=0.591 n=14+15)
MultiPolygonTwoCircles/n=10-4                   7.03µs ± 3%    6.65µs ±12%   -5.44%  (p=0.003 n=12+14)
MultiPolygonTwoCircles/n=100-4                   113µs ±15%      93µs ±13%  -17.70%  (p=0.000 n=14+14)
MultiPolygonTwoCircles/n=1000-4                 1.51ms ± 7%    1.24ms ± 3%  -17.63%  (p=0.000 n=15+13)
MultiPolygonTwoCircles/n=10000-4                22.6ms ±12%    19.1ms ± 6%  -15.30%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4        5.93µs ± 8%    6.32µs ±19%   +6.59%  (p=0.006 n=14+13)
MultiPolygonMultipleTouchingPoints/n=10-4       46.6µs ± 5%    48.0µs ± 9%   +2.87%  (p=0.048 n=14+13)
MultiPolygonMultipleTouchingPoints/n=100-4       559µs ± 7%     558µs ±10%     ~     (p=0.436 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     7.19ms ± 3%    7.59ms ±21%     ~     (p=0.618 n=13+15)
MarshalWKB/polygon/n=10-4                        198ns ± 9%     197ns ±10%     ~     (p=0.598 n=15+14)
MarshalWKB/polygon/n=100-4                       586ns ±13%     599ns ±13%     ~     (p=0.425 n=13+13)
MarshalWKB/polygon/n=1000-4                     4.28µs ±42%    4.35µs ±47%     ~     (p=0.880 n=15+14)
MarshalWKB/polygon/n=10000-4                    33.3µs ±25%    33.0µs ±32%     ~     (p=0.946 n=14+14)
UnmarshalWKB/polygon/n=10-4                      334ns ±10%     344ns ±19%     ~     (p=0.642 n=15+13)
UnmarshalWKB/polygon/n=100-4                     730ns ±17%     750ns ±15%     ~     (p=0.102 n=14+13)
UnmarshalWKB/polygon/n=1000-4                   4.89µs ±49%    4.40µs ±19%     ~     (p=0.706 n=15+14)
UnmarshalWKB/polygon/n=10000-4                  42.0µs ±52%    39.3µs ±23%     ~     (p=0.603 n=14+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             48.1µs ± 8%    49.6µs ±22%     ~     (p=0.467 n=13+15)
Intersection/n=100-4                            94.0µs ± 7%    97.2µs ±13%     ~     (p=0.280 n=13+14)
Intersection/n=1000-4                            405µs ±12%     400µs ±11%     ~     (p=0.567 n=15+15)
Intersection/n=10000-4                          3.55ms ±14%    3.53ms ± 3%     ~     (p=0.936 n=14+11)
NoOp/n=10-4                                     3.95µs ±10%    3.75µs ± 5%   -4.87%  (p=0.002 n=15+15)
NoOp/n=100-4                                    12.7µs ± 8%    13.0µs ±13%     ~     (p=0.375 n=13+14)
NoOp/n=1000-4                                   90.6µs ±10%    90.0µs ± 6%     ~     (p=1.000 n=15+13)
NoOp/n=10000-4                                   976µs ±28%    1006µs ±20%     ~     (p=0.512 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                  40.1µs ± 6%    40.4µs ± 5%     ~     (p=0.505 n=15+14)
Delete/n=1000-4                                  782µs ± 9%     813µs ± 3%   +3.94%  (p=0.001 n=14+15)
Delete/n=10000-4                                41.5ms ± 4%    43.0ms ± 6%   +3.64%  (p=0.003 n=13+15)
Bulk/n=10-4                                     1.89µs ± 7%    1.26µs ± 8%  -33.21%  (p=0.000 n=13+15)
Bulk/n=100-4                                    52.2µs ± 7%    30.8µs ± 7%  -41.01%  (p=0.000 n=15+14)
Bulk/n=1000-4                                    977µs ± 9%     710µs ± 2%  -27.31%  (p=0.000 n=15+14)
Insert/n=10-4                                   1.55µs ±18%    1.36µs ± 3%  -12.47%  (p=0.000 n=13+14)
Insert/n=100-4                                  36.7µs ±16%    33.6µs ± 2%   -8.42%  (p=0.000 n=14+12)
Insert/n=1000-4                                  612µs ± 9%     579µs ± 4%   -5.51%  (p=0.000 n=15+13)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.82kB ± 0%    1.38kB ± 0%  -50.99%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4      34.4kB ± 0%    11.8kB ± 0%  -65.57%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      237kB ± 0%     116kB ± 0%  -51.29%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    3.15MB ± 0%    1.41MB ± 1%  -55.32%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10-4                   1.44kB ± 0%    0.78kB ± 0%  -46.11%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/100-4                  21.6kB ± 0%     5.4kB ± 0%  -75.03%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/1000-4                  230kB ± 0%      50kB ± 0%  -78.34%  (p=0.000 n=12+15)
LineStringIsSimpleZigZag/10000-4                2.30MB ± 0%    0.61MB ± 0%  -73.54%  (p=0.000 n=14+13)
PolygonSingleRingValidation/n=10-4              1.47kB ± 0%    1.13kB ± 0%  -23.37%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=100-4             16.2kB ± 0%     5.7kB ± 0%  -64.65%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=1000-4             217kB ± 0%      50kB ± 0%  -76.94%  (p=0.000 n=15+14)
PolygonSingleRingValidation/n=10000-4           2.23MB ± 0%    0.62MB ± 2%  -72.35%  (p=0.000 n=15+14)
PolygonMultipleRingsValidation/n=4-4            5.31kB ± 0%    5.58kB ± 0%   +4.99%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=36-4           43.6kB ± 0%    44.1kB ± 0%   +1.09%  (p=0.000 n=14+14)
PolygonMultipleRingsValidation/n=400-4           479kB ± 0%     483kB ± 0%   +0.73%  (p=0.000 n=13+15)
PolygonMultipleRingsValidation/n=4096-4         4.92MB ± 0%    4.99MB ± 0%   +1.50%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10-4             12.3kB ± 0%     7.0kB ± 0%  -43.05%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4             144kB ± 0%      42kB ± 0%  -70.79%  (p=0.000 n=12+15)
PolygonZigZagRingsValidation/n=1000-4           1.11MB ± 0%    0.38MB ± 0%  -65.79%  (p=0.000 n=15+13)
PolygonZigZagRingsValidation/n=10000-4          13.5MB ± 0%     4.4MB ± 0%  -67.10%  (p=0.000 n=15+12)
MultipolygonValidation/n=1-4                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   3.86kB ± 0%    1.84kB ± 0%  -52.28%  (p=0.000 n=15+15)
MultipolygonValidation/n=64-4                   15.4kB ± 0%     6.5kB ± 0%  -57.85%  (p=0.000 n=15+15)
MultipolygonValidation/n=256-4                  63.1kB ± 0%    25.3kB ± 0%  -59.98%  (p=0.000 n=15+15)
MultipolygonValidation/n=1024-4                  259kB ± 0%     102kB ± 0%  -60.51%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10-4                   5.75kB ± 0%    5.17kB ± 0%  -10.02%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                  62.9kB ± 0%    57.0kB ± 0%   -9.45%  (p=0.000 n=15+12)
MultiPolygonTwoCircles/n=1000-4                  410kB ± 0%     361kB ± 0%  -11.94%  (p=0.000 n=14+12)
MultiPolygonTwoCircles/n=10000-4                5.65MB ± 0%    4.87MB ± 0%  -13.90%  (p=0.000 n=15+12)
MultiPolygonMultipleTouchingPoints/n=1-4        4.19kB ± 0%    4.00kB ± 0%   -4.58%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4       24.4kB ± 0%    23.0kB ± 0%   -5.51%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       188kB ± 0%     176kB ± 0%   -6.47%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.28MB ± 0%    2.08MB ± 0%   -8.79%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       282B ± 0%      282B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
Intersection/n=100-4                            6.33kB ± 0%    6.33kB ± 0%     ~     (all equal)
Intersection/n=1000-4                           55.0kB ± 0%    55.0kB ± 0%     ~     (p=0.245 n=15+15)
Intersection/n=10000-4                           558kB ± 0%     557kB ± 0%   -0.00%  (p=0.033 n=14+15)
NoOp/n=10-4                                       864B ± 0%      864B ± 0%     ~     (all equal)
NoOp/n=100-4                                    5.68kB ± 0%    5.68kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                   49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%     ~     (p=0.315 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                 24.2kB ± 0%    24.2kB ± 0%     ~     (all equal)
Delete/n=10000-4                                 465kB ± 0%     465kB ± 0%     ~     (all equal)
Bulk/n=10-4                                     1.83kB ± 0%    0.39kB ± 0%  -78.60%  (p=0.000 n=15+15)
Bulk/n=100-4                                    23.8kB ± 0%     1.3kB ± 0%  -94.59%  (p=0.000 n=15+15)
Bulk/n=1000-4                                    131kB ± 0%       9kB ± 0%  -93.46%  (p=0.000 n=14+13)
Insert/n=10-4                                   1.44kB ± 0%    0.29kB ± 0%  -80.00%  (p=0.000 n=15+15)
Insert/n=100-4                                  13.5kB ± 0%     0.3kB ± 0%  -97.87%  (p=0.000 n=15+15)
Insert/n=1000-4                                  138kB ± 0%       0kB ± 3%  -99.73%  (p=0.000 n=14+14)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         19.0 ± 0%       9.0 ± 0%  -52.63%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4         167 ± 0%        37 ± 0%  -77.84%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      1.11k ± 0%     0.26k ± 0%  -76.51%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4     17.8k ± 0%      4.5k ± 1%  -74.44%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10-4                     5.00 ± 0%      6.00 ± 0%  +20.00%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/100-4                    75.0 ± 0%      34.0 ± 0%  -54.67%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/1000-4                    797 ± 0%       258 ± 0%  -67.63%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10000-4                 8.00k ± 0%     4.11k ± 0%  -48.67%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10-4                6.00 ± 0%      8.00 ± 0%  +33.33%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=100-4               57.0 ± 0%      36.0 ± 0%  -36.84%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=1000-4               755 ± 0%       260 ± 0%  -65.56%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10000-4            7.73k ± 0%     4.11k ± 0%  -46.85%  (p=0.000 n=15+14)
PolygonMultipleRingsValidation/n=4-4              29.0 ± 0%      37.0 ± 0%  +27.59%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=36-4              239 ± 0%       293 ± 0%  +22.59%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=400-4           2.63k ± 0%     3.21k ± 0%  +21.96%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4096-4          26.9k ± 0%     32.8k ± 0%  +21.71%  (p=0.000 n=15+12)
PolygonZigZagRingsValidation/n=10-4               67.0 ± 0%      41.0 ± 0%  -38.81%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4               657 ± 0%       181 ± 0%  -72.45%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000-4            4.96k ± 0%     1.30k ± 0%  -73.71%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000-4           69.5k ± 0%     20.5k ± 0%  -70.43%  (p=0.000 n=15+13)
MultipolygonValidation/n=1-4                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     27.0 ± 0%      20.0 ± 0%  -25.93%  (p=0.000 n=15+15)
MultipolygonValidation/n=64-4                     99.0 ± 0%      68.0 ± 0%  -31.31%  (p=0.000 n=15+15)
MultipolygonValidation/n=256-4                     392 ± 0%       260 ± 0%  -33.67%  (p=0.000 n=15+15)
MultipolygonValidation/n=1024-4                  1.58k ± 0%     1.03k ± 0%  -34.60%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10-4                     44.0 ± 0%      32.0 ± 0%  -27.27%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                     340 ± 0%       216 ± 0%  -36.47%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  2.23k ± 0%     1.21k ± 0%  -45.78%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                 35.5k ± 0%     19.1k ± 0%  -46.12%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4          53.0 ± 0%      49.0 ± 0%   -7.55%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4          336 ± 0%       308 ± 0%   -8.33%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       2.99k ± 0%     2.74k ± 0%   -8.45%  (p=0.000 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1000-4      32.3k ± 0%     28.5k ± 0%  -11.77%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=100-4                              31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                            31.0 ± 0%      31.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                     21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                    21.0 ± 0%      21.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                    463 ± 0%       463 ± 0%     ~     (all equal)
Delete/n=10000-4                                 7.98k ± 0%     7.98k ± 0%     ~     (all equal)
Bulk/n=10-4                                       15.0 ± 0%       5.0 ± 0%  -66.67%  (p=0.000 n=15+15)
Bulk/n=100-4                                       163 ± 0%        33 ± 0%  -79.75%  (p=0.000 n=15+15)
Bulk/n=1000-4                                    1.11k ± 0%     0.26k ± 0%  -76.78%  (p=0.000 n=15+15)
Insert/n=10-4                                     5.00 ± 0%      1.00 ± 0%  -80.00%  (p=0.000 n=15+15)
Insert/n=100-4                                    47.0 ± 0%       1.0 ± 0%  -97.87%  (p=0.000 n=15+15)
Insert/n=1000-4                                    480 ± 0%         1 ± 0%  -99.79%  (p=0.000 n=15+15)
```
