### PR TITLE
Avoid allocations for sorting in bulk load

### DIFF
--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -98,7 +98,7 @@ func (s LineString) IsSimple() bool {
 
 	// We need to track the index of the previous line segments, so that we can
 	// ignore the case where adjacent line segments intersect at a point (due
-	// to their construction). We can just subtract 1 from the current index,
+	// to their construction). We can't just subtract 1 from the current index,
 	// since there could be duplicated vertices in the middle of the sequence.
 	prev := -1
 

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -116,14 +116,32 @@ func sortBulkItems(items []BulkItem) {
 	for _, item := range items[1:] {
 		box = combine(box, item.Box)
 	}
-	horizontal := box.MaxX-box.MinX > box.MaxY-box.MinY
-	sort.Slice(items, func(i, j int) bool {
-		bi := items[i].Box
-		bj := items[j].Box
-		if horizontal {
-			return bi.MinX+bi.MaxX < bj.MinX+bj.MaxX
-		} else {
-			return bi.MinY+bi.MaxY < bj.MinY+bj.MaxY
-		}
-	})
+	bulkItems := bulkItems{
+		horizontal: box.MaxX-box.MinX > box.MaxY-box.MinY,
+		items:      items,
+	}
+	sort.Sort(bulkItems)
+}
+
+// bulkItems implements the sort.Interface interface. This style of sorting is
+// used rather than sort.Slice because it does less allocations.
+type bulkItems struct {
+	horizontal bool
+	items      []BulkItem
+}
+
+func (b bulkItems) Len() int {
+	return len(b.items)
+}
+func (b bulkItems) Less(i, j int) bool {
+	bi := b.items[i].Box
+	bj := b.items[j].Box
+	if b.horizontal {
+		return bi.MinX+bi.MaxX < bj.MinX+bj.MaxX
+	} else {
+		return bi.MinY+bi.MaxY < bj.MinY+bj.MaxY
+	}
+}
+func (b bulkItems) Swap(i, j int) {
+	b.items[i], b.items[j] = b.items[j], b.items[i]
 }


### PR DESCRIPTION
## Description

Avoids allocations associated with `sort.Slice` by using the regular `sort.Sort` function.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- #182 

## Benchmark Results

<details>
<summary>expand</summary>

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.53µs ± 7%    2.22µs ±12%  -12.11%  (p=0.000 n=14+13)
IntersectsLineStringWithLineString/n=100-4      40.5µs ± 5%    36.4µs ± 7%  -10.13%  (p=0.000 n=13+15)
IntersectsLineStringWithLineString/n=1000-4      559µs ± 4%     503µs ± 5%  -10.12%  (p=0.000 n=14+14)
IntersectsLineStringWithLineString/n=10000-4    9.22ms ± 8%    8.16ms ± 7%  -11.46%  (p=0.000 n=15+14)
LineStringIsSimpleZigZag/10-4                   2.12µs ± 5%    2.09µs ± 3%     ~     (p=0.226 n=14+12)
LineStringIsSimpleZigZag/100-4                  64.2µs ± 8%    62.1µs ± 3%   -3.37%  (p=0.001 n=15+14)
LineStringIsSimpleZigZag/1000-4                 1.01ms ±10%    1.03ms ± 3%     ~     (p=0.137 n=14+14)
LineStringIsSimpleZigZag/10000-4                13.7ms ± 9%    13.6ms ± 7%     ~     (p=0.477 n=14+15)
PolygonSingleRingValidation/n=10-4              2.42µs ± 5%    2.47µs ± 9%     ~     (p=0.369 n=13+15)
PolygonSingleRingValidation/n=100-4             56.7µs ± 8%    55.3µs ± 2%   -2.41%  (p=0.023 n=14+12)
PolygonSingleRingValidation/n=1000-4            1.04ms ± 4%    1.04ms ± 2%     ~     (p=0.538 n=13+12)
PolygonSingleRingValidation/n=10000-4           14.1ms ± 3%    14.1ms ± 4%     ~     (p=0.413 n=13+15)
PolygonMultipleRingsValidation/n=4-4            8.70µs ± 6%    8.35µs ± 4%   -3.98%  (p=0.013 n=13+15)
PolygonMultipleRingsValidation/n=36-4           81.6µs ± 8%    81.6µs ± 5%     ~     (p=0.821 n=13+15)
PolygonMultipleRingsValidation/n=400-4          1.06ms ± 5%    1.05ms ± 6%     ~     (p=0.137 n=14+14)
PolygonMultipleRingsValidation/n=4096-4         12.9ms ±13%    12.5ms ± 2%     ~     (p=0.586 n=15+13)
PolygonZigZagRingsValidation/n=10-4             21.1µs ± 7%    19.5µs ± 4%   -7.66%  (p=0.000 n=14+14)
PolygonZigZagRingsValidation/n=100-4             318µs ± 6%     294µs ± 4%   -7.81%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000-4           4.27ms ± 4%    4.06ms ± 2%   -4.83%  (p=0.000 n=14+12)
PolygonZigZagRingsValidation/n=10000-4          60.1ms ± 8%    56.3ms ± 4%   -6.25%  (p=0.000 n=13+14)
MultipolygonValidation/n=1-4                     337ns ± 7%     352ns ±14%     ~     (p=0.070 n=13+15)
MultipolygonValidation/n=4-4                     897ns ±10%     892ns ± 8%     ~     (p=0.777 n=14+14)
MultipolygonValidation/n=16-4                   5.71µs ± 9%    5.65µs ± 7%     ~     (p=0.408 n=14+14)
MultipolygonValidation/n=64-4                   33.9µs ± 7%    34.1µs ± 5%     ~     (p=0.461 n=15+15)
MultipolygonValidation/n=256-4                   209µs ± 4%     207µs ± 6%     ~     (p=0.202 n=15+15)
MultipolygonValidation/n=1024-4                 1.02ms ± 5%    1.02ms ± 4%     ~     (p=0.352 n=14+14)
MultiPolygonTwoCircles/n=10-4                   7.19µs ±10%    5.55µs ±10%  -22.72%  (p=0.000 n=15+14)
MultiPolygonTwoCircles/n=100-4                   110µs ± 7%      85µs ±16%  -23.16%  (p=0.000 n=15+14)
MultiPolygonTwoCircles/n=1000-4                 1.46ms ± 3%    1.19ms ± 6%  -18.60%  (p=0.000 n=13+13)
MultiPolygonTwoCircles/n=10000-4                21.9ms ± 5%    18.7ms ± 7%  -14.57%  (p=0.000 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1-4        5.86µs ± 5%    5.57µs ± 3%   -5.01%  (p=0.000 n=15+14)
MultiPolygonMultipleTouchingPoints/n=10-4       46.8µs ± 7%    44.7µs ± 6%   -4.58%  (p=0.001 n=15+14)
MultiPolygonMultipleTouchingPoints/n=100-4       553µs ± 7%     528µs ± 2%   -4.58%  (p=0.000 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-4     7.42ms ± 9%    6.87ms ± 3%   -7.38%  (p=0.000 n=14+13)
MarshalWKB/polygon/n=10-4                        194ns ±10%     194ns ± 7%     ~     (p=0.771 n=15+14)
MarshalWKB/polygon/n=100-4                       558ns ± 7%     567ns ±18%     ~     (p=0.747 n=13+14)
MarshalWKB/polygon/n=1000-4                     3.64µs ±17%    3.82µs ±27%     ~     (p=0.539 n=15+15)
MarshalWKB/polygon/n=10000-4                    32.8µs ±71%    32.9µs ±45%     ~     (p=0.477 n=14+15)
UnmarshalWKB/polygon/n=10-4                      331ns ±10%     323ns ± 7%     ~     (p=0.153 n=14+14)
UnmarshalWKB/polygon/n=100-4                     735ns ±20%     696ns ±10%     ~     (p=0.252 n=14+12)
UnmarshalWKB/polygon/n=1000-4                   3.99µs ±12%    4.06µs ±15%     ~     (p=0.511 n=14+13)
UnmarshalWKB/polygon/n=10000-4                  33.1µs ±12%    31.2µs ± 9%   -5.81%  (p=0.009 n=15+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             48.3µs ± 4%    48.2µs ± 7%     ~     (p=0.751 n=15+13)
Intersection/n=100-4                            93.5µs ± 6%    93.1µs ± 8%     ~     (p=0.762 n=13+13)
Intersection/n=1000-4                            397µs ±12%     405µs ±12%     ~     (p=0.412 n=15+15)
Intersection/n=10000-4                          3.50ms ±13%    3.50ms ±13%     ~     (p=0.880 n=14+15)
NoOp/n=10-4                                     3.74µs ± 4%    3.79µs ± 8%     ~     (p=0.291 n=14+14)
NoOp/n=100-4                                    12.4µs ±14%    12.5µs ± 9%     ~     (p=0.181 n=13+14)
NoOp/n=1000-4                                   89.0µs ± 9%    90.3µs ± 9%     ~     (p=0.250 n=15+15)
NoOp/n=10000-4                                   904µs ±16%     920µs ±26%     ~     (p=0.946 n=14+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                  39.9µs ± 7%    39.5µs ± 6%     ~     (p=0.285 n=14+14)
Delete/n=1000-4                                  766µs ± 2%     813µs ± 5%   +6.21%  (p=0.000 n=14+15)
Delete/n=10000-4                                41.0ms ± 5%    42.5ms ± 5%   +3.59%  (p=0.001 n=15+15)
Bulk/n=10-4                                     1.90µs ±24%    1.35µs ± 9%  -28.89%  (p=0.000 n=14+13)
Bulk/n=100-4                                    50.3µs ± 3%    33.0µs ± 7%  -34.32%  (p=0.000 n=14+14)
Bulk/n=1000-4                                    973µs ± 6%     718µs ± 3%  -26.17%  (p=0.000 n=14+15)
Insert/n=10-4                                   1.51µs ±14%    1.50µs ± 8%     ~     (p=0.865 n=13+15)
Insert/n=100-4                                  36.9µs ±13%    36.7µs ± 6%     ~     (p=0.856 n=13+15)
Insert/n=1000-4                                  591µs ± 6%     594µs ± 3%     ~     (p=0.254 n=13+15)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.82kB ± 0%    2.54kB ± 0%  -10.20%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4      34.4kB ± 0%    31.4kB ± 0%   -8.66%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      237kB ± 0%     213kB ± 0%  -10.31%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    3.15MB ± 0%    2.76MB ± 0%  -12.47%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10-4                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                  21.6kB ± 0%    21.6kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  230kB ± 0%     230kB ± 0%     ~     (p=0.898 n=15+14)
LineStringIsSimpleZigZag/10000-4                2.30MB ± 0%    2.30MB ± 0%     ~     (p=0.821 n=14+15)
PolygonSingleRingValidation/n=10-4              1.47kB ± 0%    1.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4             16.2kB ± 0%    16.2kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             217kB ± 0%     217kB ± 0%     ~     (p=0.051 n=14+15)
PolygonSingleRingValidation/n=10000-4           2.23MB ± 0%    2.23MB ± 0%   +0.00%  (p=0.045 n=15+13)
PolygonMultipleRingsValidation/n=4-4            5.31kB ± 0%    5.31kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           43.6kB ± 0%    43.6kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           479kB ± 0%     479kB ± 0%     ~     (p=0.742 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         4.92MB ± 0%    4.92MB ± 0%     ~     (p=0.366 n=14+15)
PolygonZigZagRingsValidation/n=10-4             12.3kB ± 0%    11.4kB ± 0%   -7.04%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4             144kB ± 0%     135kB ± 0%   -6.22%  (p=0.000 n=14+14)
PolygonZigZagRingsValidation/n=1000-4           1.11MB ± 0%    1.04MB ± 0%   -6.59%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000-4          13.5MB ± 0%    12.3MB ± 0%   -8.75%  (p=0.000 n=12+13)
MultipolygonValidation/n=1-4                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                   15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                  63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  259kB ± 0%     259kB ± 0%     ~     (p=1.000 n=14+14)
MultiPolygonTwoCircles/n=10-4                   5.75kB ± 0%    5.17kB ± 0%  -10.02%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                  62.9kB ± 0%    56.9kB ± 0%   -9.46%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  410kB ± 0%     361kB ± 0%  -11.95%  (p=0.000 n=13+15)
MultiPolygonTwoCircles/n=10000-4                5.65MB ± 0%    4.87MB ± 0%  -13.91%  (p=0.000 n=14+14)
MultiPolygonMultipleTouchingPoints/n=1-4        4.19kB ± 0%    4.00kB ± 0%   -4.58%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4       24.4kB ± 0%    23.0kB ± 0%   -5.52%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       188kB ± 0%     176kB ± 0%   -6.43%  (p=0.000 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.28MB ± 0%    2.10MB ± 0%   -7.85%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       282B ± 0%      282B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
Intersection/n=100-4                            6.33kB ± 0%    6.33kB ± 0%     ~     (all equal)
Intersection/n=1000-4                           55.0kB ± 0%    55.0kB ± 0%     ~     (p=0.133 n=13+15)
Intersection/n=10000-4                           557kB ± 0%     557kB ± 0%     ~     (p=0.171 n=13+13)
NoOp/n=10-4                                       864B ± 0%      864B ± 0%     ~     (all equal)
NoOp/n=100-4                                    5.68kB ± 0%    5.68kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                   49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%     ~     (p=0.819 n=14+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                 24.2kB ± 0%    24.2kB ± 0%     ~     (all equal)
Delete/n=10000-4                                 465kB ± 0%     465kB ± 0%     ~     (all equal)
Bulk/n=10-4                                     1.83kB ± 0%    1.54kB ± 0%  -15.72%  (p=0.000 n=15+15)
Bulk/n=100-4                                    23.8kB ± 0%    20.9kB ± 0%  -12.48%  (p=0.000 n=15+15)
Bulk/n=1000-4                                    131kB ± 0%     106kB ± 0%  -18.71%  (p=0.000 n=13+14)
Insert/n=10-4                                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-4                                  13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-4                                  138kB ± 0%     138kB ± 0%     ~     (p=1.000 n=15+15)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         19.0 ± 0%      13.0 ± 0%  -31.58%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=100-4         167 ± 0%       105 ± 0%  -37.13%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=1000-4      1.11k ± 0%     0.60k ± 0%  -45.90%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10000-4     17.8k ± 0%      9.6k ± 0%  -46.14%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10-4                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                    75.0 ± 0%      75.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                    797 ± 0%       797 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 8.00k ± 0%     8.00k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                6.00 ± 0%      6.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4               57.0 ± 0%      57.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4               755 ± 0%       755 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4            7.73k ± 0%     7.73k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              29.0 ± 0%      29.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              239 ± 0%       239 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           2.63k ± 0%     2.63k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          26.9k ± 0%     26.9k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4               67.0 ± 0%      49.0 ± 0%  -26.87%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100-4               657 ± 0%       471 ± 0%  -28.31%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000-4            4.96k ± 0%     3.42k ± 0%  -30.88%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000-4           69.5k ± 0%     44.9k ± 0%  -35.35%  (p=0.000 n=14+15)
MultipolygonValidation/n=1-4                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                     392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     44.0 ± 0%      32.0 ± 0%  -27.27%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                     340 ± 0%       216 ± 0%  -36.47%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                  2.23k ± 0%     1.21k ± 0%  -45.78%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                 35.5k ± 0%     19.1k ± 0%  -46.13%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4          53.0 ± 0%      49.0 ± 0%   -7.55%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4          336 ± 0%       308 ± 0%   -8.33%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       2.99k ± 0%     2.74k ± 0%   -8.43%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1000-4      32.3k ± 0%     28.6k ± 0%  -11.54%  (p=0.000 n=15+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=100-4                              31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                            31.0 ± 0%      31.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                     21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                    21.0 ± 0%      21.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                    463 ± 0%       463 ± 0%     ~     (all equal)
Delete/n=10000-4                                 7.98k ± 0%     7.98k ± 0%     ~     (all equal)
Bulk/n=10-4                                       15.0 ± 0%       9.0 ± 0%  -40.00%  (p=0.000 n=15+15)
Bulk/n=100-4                                       163 ± 0%       101 ± 0%  -38.04%  (p=0.000 n=15+15)
Bulk/n=1000-4                                    1.11k ± 0%     0.60k ± 0%  -46.07%  (p=0.000 n=15+15)
Insert/n=10-4                                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-4                                    47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-4                                    480 ± 0%       480 ± 0%     ~     (all equal)
```

</details>