### PR TITLE
Simplify 3-way split function in RTree bulk load

### DIFF
--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -97,18 +97,15 @@ func splitBulkItems2Ways(items []BulkItem) ([]BulkItem, []BulkItem) {
 }
 
 func splitBulkItems3Ways(items []BulkItem) ([]BulkItem, []BulkItem, []BulkItem) {
+	// We only need to split 3 ways when we have 6 or 7 elements. By making use
+	// of that assumption, we greatly simplify the logic in this function
+	// compared to if we were to implement a 3 way split in the general case.
+	if ln := len(items); ln != 6 && ln != 7 {
+		panic(len(items))
+	}
+
 	sortBulkItems(items)
-	cutA := len(items) / 3
-	cutB := cutA
-	remaining := len(items)/3 - 3*cutA
-	if remaining == 1 {
-		cutA++
-	}
-	if remaining == 2 {
-		cutA++
-		cutB++
-	}
-	return items[:cutA], items[cutA : cutA+cutB], items[cutA+cutB:]
+	return items[:2], items[2:4], items[4:]
 }
 
 func sortBulkItems(items []BulkItem) {


### PR DESCRIPTION
## Description

Simplifies the 3-way split bulk load function. Because it is only used in very specific contexts, we can make certain assumptions that simplify the implementation.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

N/A

## Benchmark Results

No material change:

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.23µs ± 7%    2.22µs ±10%    ~     (p=0.803 n=14+13)
IntersectsLineStringWithLineString/n=100-4      36.4µs ± 6%    36.1µs ±12%    ~     (p=0.310 n=15+14)
IntersectsLineStringWithLineString/n=1000-4      514µs ± 8%     499µs ± 5%  -3.06%  (p=0.025 n=13+14)
IntersectsLineStringWithLineString/n=10000-4    8.26ms ± 8%    8.14ms ± 9%    ~     (p=0.310 n=15+14)
LineStringIsSimpleZigZag/10-4                   2.11µs ±10%    2.12µs ±10%    ~     (p=0.659 n=15+13)
LineStringIsSimpleZigZag/100-4                  62.6µs ± 3%    62.6µs ± 8%    ~     (p=0.235 n=13+15)
LineStringIsSimpleZigZag/1000-4                 1.01ms ± 6%    1.01ms ± 8%    ~     (p=0.967 n=15+15)
LineStringIsSimpleZigZag/10000-4                13.6ms ± 6%    13.3ms ± 7%    ~     (p=0.068 n=14+13)
PolygonSingleRingValidation/n=10-4              2.45µs ± 9%    2.45µs ± 9%    ~     (p=0.734 n=14+14)
PolygonSingleRingValidation/n=100-4             55.4µs ± 5%    57.0µs ± 6%  +2.96%  (p=0.007 n=13+15)
PolygonSingleRingValidation/n=1000-4            1.05ms ± 4%    1.05ms ± 4%    ~     (p=0.780 n=15+14)
PolygonSingleRingValidation/n=10000-4           14.3ms ± 7%    14.4ms ± 7%    ~     (p=0.412 n=15+15)
PolygonMultipleRingsValidation/n=4-4            8.45µs ± 8%    8.40µs ± 8%    ~     (p=0.352 n=14+14)
PolygonMultipleRingsValidation/n=36-4           79.2µs ± 7%    77.9µs ± 3%    ~     (p=0.172 n=14+15)
PolygonMultipleRingsValidation/n=400-4          1.04ms ± 5%    1.05ms ±11%    ~     (p=0.650 n=13+14)
PolygonMultipleRingsValidation/n=4096-4         12.6ms ± 6%    12.5ms ±10%    ~     (p=0.430 n=14+13)
PolygonZigZagRingsValidation/n=10-4             19.1µs ± 7%    19.8µs ±11%    ~     (p=0.118 n=13+15)
PolygonZigZagRingsValidation/n=100-4             298µs ± 8%     291µs ± 3%    ~     (p=0.093 n=15+14)
PolygonZigZagRingsValidation/n=1000-4           4.14ms ± 8%    4.03ms ± 3%  -2.72%  (p=0.041 n=15+12)
PolygonZigZagRingsValidation/n=10000-4          56.0ms ± 4%    56.8ms ± 6%    ~     (p=0.068 n=13+14)
MultipolygonValidation/n=1-4                     348ns ±20%     331ns ± 6%    ~     (p=0.087 n=14+13)
MultipolygonValidation/n=4-4                     870ns ±12%     880ns ± 5%    ~     (p=0.158 n=14+13)
MultipolygonValidation/n=16-4                   5.60µs ± 6%    5.63µs ± 6%    ~     (p=0.650 n=13+13)
MultipolygonValidation/n=64-4                   33.9µs ± 8%    34.3µs ±10%    ~     (p=0.425 n=14+15)
MultipolygonValidation/n=256-4                   204µs ± 6%     201µs ±13%  -1.86%  (p=0.012 n=14+13)
MultipolygonValidation/n=1024-4                 1.03ms ± 9%    0.98ms ±11%  -4.59%  (p=0.005 n=15+14)
MultiPolygonTwoCircles/n=10-4                   5.66µs ± 7%    6.71µs ±84%    ~     (p=0.125 n=14+14)
MultiPolygonTwoCircles/n=100-4                  79.3µs ± 2%    83.0µs ±13%  +4.57%  (p=0.005 n=13+13)
MultiPolygonTwoCircles/n=1000-4                 1.20ms ± 5%    1.20ms ± 5%    ~     (p=0.715 n=15+14)
MultiPolygonTwoCircles/n=10000-4                18.8ms ± 9%    18.6ms ± 4%    ~     (p=0.440 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1-4        5.63µs ±11%    5.49µs ± 9%    ~     (p=0.139 n=15+13)
MultiPolygonMultipleTouchingPoints/n=10-4       44.9µs ±11%    43.3µs ± 3%  -3.56%  (p=0.000 n=13+13)
MultiPolygonMultipleTouchingPoints/n=100-4       530µs ± 5%     535µs ±12%    ~     (p=0.899 n=14+12)
MultiPolygonMultipleTouchingPoints/n=1000-4     6.98ms ± 9%    6.88ms ± 9%    ~     (p=0.354 n=15+14)
MarshalWKB/polygon/n=10-4                        195ns ± 8%     190ns ±10%    ~     (p=0.213 n=15+13)
MarshalWKB/polygon/n=100-4                       540ns ±17%     564ns ±17%    ~     (p=0.331 n=14+13)
MarshalWKB/polygon/n=1000-4                     3.51µs ±14%    3.42µs ±17%    ~     (p=0.399 n=15+12)
MarshalWKB/polygon/n=10000-4                    29.9µs ±39%    27.3µs ±26%  -8.94%  (p=0.029 n=13+13)
UnmarshalWKB/polygon/n=10-4                      321ns ± 9%     322ns ±12%    ~     (p=0.554 n=14+15)
UnmarshalWKB/polygon/n=100-4                     757ns ±30%     699ns ±18%    ~     (p=0.319 n=14+13)
UnmarshalWKB/polygon/n=1000-4                   4.22µs ±30%    3.93µs ±18%    ~     (p=0.135 n=15+12)
UnmarshalWKB/polygon/n=10000-4                  35.6µs ±27%    34.1µs ±10%    ~     (p=1.000 n=13+13)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             47.6µs ± 6%    47.5µs ±10%    ~     (p=0.595 n=14+14)
Intersection/n=100-4                            91.7µs ± 4%    92.7µs ± 5%    ~     (p=0.427 n=14+14)
Intersection/n=1000-4                            400µs ±12%     396µs ±11%    ~     (p=0.806 n=15+15)
Intersection/n=10000-4                          3.42ms ±11%    3.51ms ± 9%    ~     (p=0.148 n=15+15)
NoOp/n=10-4                                     3.84µs ±10%    3.82µs ± 4%    ~     (p=0.490 n=14+14)
NoOp/n=100-4                                    12.5µs ± 6%    12.2µs ± 4%  -2.20%  (p=0.043 n=14+13)
NoOp/n=1000-4                                   89.7µs ±11%    88.4µs ± 5%    ~     (p=1.000 n=15+13)
NoOp/n=10000-4                                   978µs ±32%     956µs ±23%    ~     (p=0.683 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                  38.6µs ± 9%    38.1µs ± 6%    ~     (p=0.683 n=15+15)
Delete/n=1000-4                                  791µs ± 4%     804µs ± 5%  +1.69%  (p=0.023 n=15+15)
Delete/n=10000-4                                41.9ms ± 1%    42.1ms ± 3%    ~     (p=0.168 n=12+13)
Bulk/n=10-4                                     1.32µs ±12%    1.41µs ±37%    ~     (p=0.308 n=13+14)
Bulk/n=100-4                                    33.2µs ± 7%    33.9µs ±11%    ~     (p=0.412 n=15+15)
Bulk/n=1000-4                                    727µs ± 4%     727µs ± 8%    ~     (p=0.821 n=15+13)
Bulk/n=10000-4                                  11.5ms ±19%    11.1ms ± 6%    ~     (p=0.217 n=15+13)
Bulk/n=100000-4                                  133ms ± 3%     134ms ± 5%    ~     (p=0.448 n=13+13)
Insert/n=10-4                                   1.56µs ±16%    1.55µs ±17%    ~     (p=0.558 n=14+13)
Insert/n=100-4                                  36.4µs ± 8%    36.0µs ±10%    ~     (p=0.185 n=15+13)
Insert/n=1000-4                                  594µs ± 5%     592µs ±10%  -0.44%  (p=0.038 n=14+13)
Insert/n=10000-4                                8.26ms ± 5%    8.29ms ± 9%    ~     (p=0.806 n=15+15)
Insert/n=100000-4                                104ms ± 7%     103ms ± 3%    ~     (p=0.105 n=14+13)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4       2.54kB ± 0%    2.54kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=100-4      31.4kB ± 0%    31.4kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      213kB ± 0%     213kB ± 0%    ~     (p=0.333 n=15+15)
IntersectsLineStringWithLineString/n=10000-4    2.76MB ± 0%    2.76MB ± 0%    ~     (p=0.487 n=14+14)
LineStringIsSimpleZigZag/10-4                   1.44kB ± 0%    1.44kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/100-4                  21.6kB ± 0%    21.6kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  230kB ± 0%     230kB ± 0%    ~     (p=1.000 n=15+15)
LineStringIsSimpleZigZag/10000-4                2.30MB ± 0%    2.30MB ± 0%    ~     (p=0.945 n=15+13)
PolygonSingleRingValidation/n=10-4              1.47kB ± 0%    1.47kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=100-4             16.2kB ± 0%    16.2kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=1000-4             217kB ± 0%     217kB ± 0%    ~     (p=0.195 n=15+14)
PolygonSingleRingValidation/n=10000-4           2.23MB ± 0%    2.23MB ± 0%    ~     (p=0.243 n=14+14)
PolygonMultipleRingsValidation/n=4-4            5.31kB ± 0%    5.31kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           43.6kB ± 0%    43.6kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           479kB ± 0%     479kB ± 0%    ~     (p=0.137 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         4.92MB ± 0%    4.92MB ± 0%    ~     (p=0.362 n=15+15)
PolygonZigZagRingsValidation/n=10-4             11.4kB ± 0%    11.4kB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             135kB ± 0%     135kB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4           1.04MB ± 0%    1.04MB ± 0%    ~     (p=0.423 n=15+15)
PolygonZigZagRingsValidation/n=10000-4          12.3MB ± 0%    12.3MB ± 0%  +0.00%  (p=0.026 n=15+15)
MultipolygonValidation/n=1-4                      385B ± 0%      385B ± 0%    ~     (all equal)
MultipolygonValidation/n=4-4                      676B ± 0%      676B ± 0%    ~     (all equal)
MultipolygonValidation/n=16-4                   3.86kB ± 0%    3.86kB ± 0%    ~     (all equal)
MultipolygonValidation/n=64-4                   15.4kB ± 0%    15.4kB ± 0%    ~     (all equal)
MultipolygonValidation/n=256-4                  63.1kB ± 0%    63.1kB ± 0%    ~     (all equal)
MultipolygonValidation/n=1024-4                  259kB ± 0%     259kB ± 0%    ~     (p=0.685 n=15+15)
MultiPolygonTwoCircles/n=10-4                   5.17kB ± 0%    5.17kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=100-4                  56.9kB ± 0%    56.9kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  361kB ± 0%     361kB ± 0%    ~     (p=1.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                4.87MB ± 0%    4.87MB ± 0%    ~     (p=0.803 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4        4.00kB ± 0%    4.00kB ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       23.0kB ± 0%    23.0kB ± 0%    ~     (p=0.348 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       176kB ± 0%     176kB ± 0%  +0.02%  (p=0.001 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.10MB ± 0%    2.10MB ± 0%    ~     (p=0.418 n=15+15)
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%    ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%    ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%    ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       282B ± 0%      282B ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.19kB ± 0%    1.19kB ± 0%    ~     (all equal)
Intersection/n=100-4                            6.33kB ± 0%    6.33kB ± 0%    ~     (p=0.518 n=15+15)
Intersection/n=1000-4                           55.0kB ± 0%    55.0kB ± 0%    ~     (p=0.328 n=15+15)
Intersection/n=10000-4                           557kB ± 0%     557kB ± 0%    ~     (p=0.352 n=15+12)
NoOp/n=10-4                                       864B ± 0%      864B ± 0%    ~     (all equal)
NoOp/n=100-4                                    5.68kB ± 0%    5.68kB ± 0%    ~     (all equal)
NoOp/n=1000-4                                   49.5kB ± 0%    49.5kB ± 0%    ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%    ~     (p=0.640 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    712B ± 0%      712B ± 0%    ~     (all equal)
Delete/n=1000-4                                 24.2kB ± 0%    24.2kB ± 0%    ~     (all equal)
Delete/n=10000-4                                 465kB ± 0%     465kB ± 0%    ~     (all equal)
Bulk/n=10-4                                     1.54kB ± 0%    1.54kB ± 0%    ~     (all equal)
Bulk/n=100-4                                    20.9kB ± 0%    20.9kB ± 0%    ~     (all equal)
Bulk/n=1000-4                                    106kB ± 0%     106kB ± 0%    ~     (all equal)
Bulk/n=10000-4                                  1.70MB ± 0%    1.70MB ± 0%    ~     (p=0.249 n=13+14)
Bulk/n=100000-4                                 21.5MB ± 0%    21.5MB ± 0%    ~     (all equal)
Insert/n=10-4                                   1.44kB ± 0%    1.44kB ± 0%    ~     (all equal)
Insert/n=100-4                                  13.5kB ± 0%    13.5kB ± 0%    ~     (all equal)
Insert/n=1000-4                                  138kB ± 0%     138kB ± 0%    ~     (p=0.735 n=15+15)
Insert/n=10000-4                                1.34MB ± 0%    1.34MB ± 0%    ~     (p=0.377 n=14+15)
Insert/n=100000-4                               13.5MB ± 0%    13.5MB ± 0%    ~     (p=0.478 n=12+12)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
IntersectsLineStringWithLineString/n=10-4         13.0 ± 0%      13.0 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=100-4         105 ± 0%       105 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4        601 ± 0%       601 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4     9.56k ± 0%     9.56k ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10-4                     5.00 ± 0%      5.00 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/100-4                    75.0 ± 0%      75.0 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/1000-4                    797 ± 0%       797 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 8.00k ± 0%     8.00k ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10-4                6.00 ± 0%      6.00 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=100-4               57.0 ± 0%      57.0 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=1000-4               755 ± 0%       755 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10000-4            7.73k ± 0%     7.73k ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              29.0 ± 0%      29.0 ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              239 ± 0%       239 ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           2.63k ± 0%     2.63k ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          26.9k ± 0%     26.9k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10-4               49.0 ± 0%      49.0 ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=100-4               471 ± 0%       471 ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4            3.42k ± 0%     3.42k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4           44.9k ± 0%     44.9k ± 0%  +0.00%  (p=0.034 n=12+15)
MultipolygonValidation/n=1-4                      5.00 ± 0%      5.00 ± 0%    ~     (all equal)
MultipolygonValidation/n=4-4                      8.00 ± 0%      8.00 ± 0%    ~     (all equal)
MultipolygonValidation/n=16-4                     27.0 ± 0%      27.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=64-4                     99.0 ± 0%      99.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=256-4                     392 ± 0%       392 ± 0%    ~     (all equal)
MultipolygonValidation/n=1024-4                  1.58k ± 0%     1.58k ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     32.0 ± 0%      32.0 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=100-4                     216 ± 0%       216 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  1.21k ± 0%     1.21k ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                 19.1k ± 0%     19.1k ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4          49.0 ± 0%      49.0 ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          308 ± 0%       308 ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4       2.74k ± 0%     2.74k ± 0%  +0.02%  (p=0.008 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000-4      28.6k ± 0%     28.6k ± 0%    ~     (p=0.482 n=15+15)
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               31.0 ± 0%      31.0 ± 0%    ~     (all equal)
Intersection/n=100-4                              31.0 ± 0%      31.0 ± 0%    ~     (all equal)
Intersection/n=1000-4                             31.0 ± 0%      31.0 ± 0%    ~     (all equal)
Intersection/n=10000-4                            31.0 ± 0%      31.0 ± 0%    ~     (all equal)
NoOp/n=10-4                                       21.0 ± 0%      21.0 ± 0%    ~     (all equal)
NoOp/n=100-4                                      21.0 ± 0%      21.0 ± 0%    ~     (all equal)
NoOp/n=1000-4                                     21.0 ± 0%      21.0 ± 0%    ~     (all equal)
NoOp/n=10000-4                                    21.0 ± 0%      21.0 ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    65.0 ± 0%      65.0 ± 0%    ~     (all equal)
Delete/n=1000-4                                    463 ± 0%       463 ± 0%    ~     (all equal)
Delete/n=10000-4                                 7.98k ± 0%     7.98k ± 0%    ~     (all equal)
Bulk/n=10-4                                       9.00 ± 0%      9.00 ± 0%    ~     (all equal)
Bulk/n=100-4                                       101 ± 0%       101 ± 0%    ~     (all equal)
Bulk/n=1000-4                                      597 ± 0%       597 ± 0%    ~     (all equal)
Bulk/n=10000-4                                   9.56k ± 0%     9.56k ± 0%    ~     (all equal)
Bulk/n=100000-4                                   104k ± 0%      104k ± 0%    ~     (all equal)
Insert/n=10-4                                     5.00 ± 0%      5.00 ± 0%    ~     (all equal)
Insert/n=100-4                                    47.0 ± 0%      47.0 ± 0%    ~     (all equal)
Insert/n=1000-4                                    480 ± 0%       480 ± 0%    ~     (all equal)
Insert/n=10000-4                                 4.66k ± 0%     4.66k ± 0%    ~     (all equal)
Insert/n=100000-4                                46.9k ± 0%     46.9k ± 0%  -0.00%  (p=0.020 n=15+12)

```
