### PR TITLE
Add benchmark for RTree range search

### DIFF
--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -78,7 +78,6 @@ func BenchmarkRangeSearch(b *testing.B) {
 	for _, pop := range [...]int{10, 100, 1000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
-			//tree, boxes := testBulkLoad(rnd, pop, 0.9, 0.1)
 			tree, _ := testBulkLoad(rnd, pop, 0.9, 0.1)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/rtree/perf_test.go
+++ b/rtree/perf_test.go
@@ -73,3 +73,17 @@ func BenchmarkInsert(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkRangeSearch(b *testing.B) {
+	for _, pop := range [...]int{10, 100, 1000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(0))
+			//tree, boxes := testBulkLoad(rnd, pop, 0.9, 0.1)
+			tree, _ := testBulkLoad(rnd, pop, 0.9, 0.1)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tree.RangeSearch(Box{0.5, 0.5, 0.5, 0.5}, func(int) error { return nil })
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds a benchmark for RTree range searches.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

Initial run:
```
BenchmarkRangeSearch/n=10-4             55447660                22.4 ns/op             0 B/op          0 allocs/op
BenchmarkRangeSearch/n=100-4            11952896               122 ns/op               0 B/op          0 allocs/op
BenchmarkRangeSearch/n=1000-4            4639147               261 ns/op               0 B/op          0 allocs/op
BenchmarkRangeSearch/n=10000-4           1242669               910 ns/op               0 B/op          0 allocs/op
BenchmarkRangeSearch/n=100000-4           112510             11510 ns/op               0 B/op          0 allocs/op
```
