### PR TITLE
Add Area calculation options (signed and transform)

### DIFF
--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -530,22 +530,22 @@ func (g Geometry) Centroid() Point {
 
 // Area gives the area of the Polygon or MultiPolygon or GeometryCollection.
 // If the Geometry is none of those types, then 0 is returned.
-func (g Geometry) Area() float64 {
+func (g Geometry) Area(opts ...AreaOption) float64 {
 	switch g.gtype {
 	case TypeGeometryCollection:
-		return g.AsGeometryCollection().Area()
+		return g.AsGeometryCollection().Area(opts...)
 	case TypePoint:
 		return 0
 	case TypeLineString:
 		return 0
 	case TypePolygon:
-		return g.AsPolygon().Area()
+		return g.AsPolygon().Area(opts...)
 	case TypeMultiPoint:
 		return 0
 	case TypeMultiLineString:
 		return 0
 	case TypeMultiPolygon:
-		return g.AsMultiPolygon().Area()
+		return g.AsMultiPolygon().Area(opts...)
 	default:
 		panic("unknown geometry: " + g.gtype.String())
 	}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -240,12 +240,12 @@ func (c GeometryCollection) Length() float64 {
 }
 
 // Area in the case of a GeometryCollection is the sum of the areas of its parts.
-func (c GeometryCollection) Area() float64 {
+func (c GeometryCollection) Area(opts ...AreaOption) float64 {
 	var sum float64
 	n := c.NumGeometries()
 	for i := 0; i < n; i++ {
 		g := c.GeometryN(i)
-		sum += g.Area()
+		sum += g.Area(opts...)
 	}
 	return sum
 }

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -360,23 +360,13 @@ func (m MultiPolygon) EqualsExact(other Geometry, opts ...EqualsExactOption) boo
 }
 
 // Area in the case of a MultiPolygon is the sum of the areas of its polygons.
-func (m MultiPolygon) Area() float64 {
+func (m MultiPolygon) Area(opts ...AreaOption) float64 {
 	var area float64
 	n := m.NumPolygons()
 	for i := 0; i < n; i++ {
-		area += m.PolygonN(i).Area()
+		area += m.PolygonN(i).Area(opts...)
 	}
 	return area
-}
-
-// SignedArea returns the sum of the signed areas of the constituent polygons.
-func (m MultiPolygon) SignedArea() float64 {
-	var signedArea float64
-	n := m.NumPolygons()
-	for i := 0; i < n; i++ {
-		signedArea += m.PolygonN(i).SignedArea()
-	}
-	return signedArea
 }
 
 // Centroid returns the multi polygon's centroid point. It returns the empty


### PR DESCRIPTION
## Description

It's useful to calculate the area of a geometry under a transformation. This is possible without this change. The user would have to first call `TransformXY`, and then call `Area`. This has two problems though:

- `TransformXY` gives back an error that the user doesn't really care about. They could add the `DisableAllValidations` option when transforming, but they still have the error returned that they should check.
- Transforming creates a whole new geometry, which would only be needed for the area calculation. This is a bunch of unnecessary allocations.

This PR instead adds options to the `Area` methods, that can specify a transformation. The transformation can be done on the fly, which solves both problems.

I also refactored the "signed" area calculations into the same options framework. Signed areas and transformed areas are orthogonal, so should be able to be used together in any combination.

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- #238 

## Benchmark Results

- TODO (not expecting any change)
