### PR TITLE
Omit invalid ctor option

### DIFF
--- a/geom/ctor_options.go
+++ b/geom/ctor_options.go
@@ -62,13 +62,3 @@ func newOptionSet(opts []ConstructorOption) ctorOptionSet {
 	}
 	return cos
 }
-
-func skipValidations(opts []ConstructorOption) bool {
-	os := newOptionSet(opts)
-	return os.skipValidations
-}
-
-func omitInvalid(opts []ConstructorOption) bool {
-	os := newOptionSet(opts)
-	return os.omitInvalid
-}

--- a/geom/ctor_options.go
+++ b/geom/ctor_options.go
@@ -23,9 +23,10 @@ func DisableAllValidations(o *ctorOptionSet) {
 // OmitInvalid causes geometry constructors to omit any geometries or
 // sub-geometries that are invalid.
 //
-// Behaviour for each geometry type is:
+// The behaviour for each geometry type is:
 //
-// * Point and MultiPoint: no effect.
+// * Point and MultiPoint: no effect (because Point and MultiPoint don't have
+// geometry constraints).
 //
 // * LineString: if the LineString is invalid (e.g. doesn't contain at least 2
 // distinct points), then it is replaced with an empty LineString.

--- a/geom/ctor_options.go
+++ b/geom/ctor_options.go
@@ -20,8 +20,34 @@ func DisableAllValidations(o *ctorOptionSet) {
 	o.skipValidations = true
 }
 
+// OmitInvalid causes geometry constructors to omit any geometries or
+// sub-geometries that are invalid.
+//
+// Behaviour for each geometry type is:
+//
+// * Point and MultiPoint: no effect.
+//
+// * LineString: if the LineString is invalid (e.g. doesn't contain at least 2
+// distinct points), then it is replaced with an empty LineString.
+//
+// * MultiLineString: if a child LineString is invalid, then it is omitted from
+// the MultiLineString.
+//
+// * Polygon: if the Polygon is invalid (e.g. self intersecting rings or rings
+// that intersect in an invalid way), then it is replaced with an empty
+// Polygon.
+//
+// * MultiPolygon: if a child Polygon is invalid, then it is omitted from the
+// MultiPolygon. If two child Polygons (that weren't previously omitted)
+// interact in an invalid way, then the MultiPolygon is replaced with an empty
+// MultiPolygon.
+func OmitInvalid(o *ctorOptionSet) {
+	o.omitInvalid = true
+}
+
 type ctorOptionSet struct {
 	skipValidations bool
+	omitInvalid     bool
 }
 
 func newOptionSet(opts []ConstructorOption) ctorOptionSet {
@@ -41,4 +67,9 @@ func newOptionSet(opts []ConstructorOption) ctorOptionSet {
 func skipValidations(opts []ConstructorOption) bool {
 	os := newOptionSet(opts)
 	return os.skipValidations
+}
+
+func omitInvalid(opts []ConstructorOption) bool {
+	os := newOptionSet(opts)
+	return os.omitInvalid
 }

--- a/geom/ctor_options.go
+++ b/geom/ctor_options.go
@@ -30,17 +30,16 @@ func DisableAllValidations(o *ctorOptionSet) {
 // * LineString: if the LineString is invalid (e.g. doesn't contain at least 2
 // distinct points), then it is replaced with an empty LineString.
 //
-// * MultiLineString: if a child LineString is invalid, then it is omitted from
-// the MultiLineString.
+// * MultiLineString: if a child LineString is invalid, then it is replaced
+// with an empty LineString within the MultiLineString.
 //
 // * Polygon: if the Polygon is invalid (e.g. self intersecting rings or rings
 // that intersect in an invalid way), then it is replaced with an empty
 // Polygon.
 //
-// * MultiPolygon: if a child Polygon is invalid, then it is omitted from the
-// MultiPolygon. If two child Polygons (that weren't previously omitted)
-// interact in an invalid way, then the MultiPolygon is replaced with an empty
-// MultiPolygon.
+// * MultiPolygon: if a child Polygon is invalid, then it is replaced with an
+// empty Polygon within the MultiPolygon. If two child Polygons  interact in an
+// invalid way, then the MultiPolygon is replaced with an empty MultiPolygon.
 func OmitInvalid(o *ctorOptionSet) {
 	o.omitInvalid = true
 }

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -71,6 +71,22 @@ func TestOmitInvalid(t *testing.T) {
 			"POLYGON((0 0,1 1,0 1,1 0,0 0))",
 			"POLYGON EMPTY",
 		},
+		{
+			"MULTIPOLYGON(((0 0,1 1,0 1,1 0,0 0)))",
+			"MULTIPOLYGON(EMPTY)",
+		},
+		{
+			"MULTIPOLYGON(((0 0,1 1,0 1,1 0,0 0)),((0 0,0 1,1 0,0 0)))",
+			"MULTIPOLYGON(EMPTY,((0 0,0 1,1 0,0 0)))",
+		},
+		{
+			"MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((0 0,1 1,0 1,1 0,0 0)))",
+			"MULTIPOLYGON(((0 0,0 1,1 0,0 0)),EMPTY)",
+		},
+		{
+			"MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)),((1 1,1 3,3 3,3 1,1 1)))",
+			"MULTIPOLYGON EMPTY",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g, err := geom.UnmarshalWKT(tt.input, geom.OmitInvalid)

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -87,6 +87,14 @@ func TestOmitInvalid(t *testing.T) {
 			"MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)),((1 1,1 3,3 3,3 1,1 1)))",
 			"MULTIPOLYGON EMPTY",
 		},
+		{
+			"GEOMETRYCOLLECTION(LINESTRING(2 2,2 2))",
+			"GEOMETRYCOLLECTION(LINESTRING EMPTY)",
+		},
+		{
+			"GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(LINESTRING(2 2,2 2)))",
+			"GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(LINESTRING EMPTY))",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g, err := geom.UnmarshalWKT(tt.input, geom.OmitInvalid)

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -67,6 +67,10 @@ func TestOmitInvalid(t *testing.T) {
 			"MULTILINESTRING((7 7,7 7),(8 8,9 9))",
 			"MULTILINESTRING(EMPTY,(8 8,9 9))",
 		},
+		{
+			"POLYGON((0 0,1 1,0 1,1 0,0 0))",
+			"POLYGON EMPTY",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g, err := geom.UnmarshalWKT(tt.input, geom.OmitInvalid)

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -48,8 +48,24 @@ func TestOmitInvalid(t *testing.T) {
 		output string
 	}{
 		{
-			"LINESTRING(0 0,0 0)",
+			"LINESTRING(1 1)",
 			"LINESTRING EMPTY",
+		},
+		{
+			"LINESTRING(2 2,2 2)",
+			"LINESTRING EMPTY",
+		},
+		{
+			"MULTILINESTRING((3 3))",
+			"MULTILINESTRING(EMPTY)",
+		},
+		{
+			"MULTILINESTRING((4 4,5 5),(6 6,6 6))",
+			"MULTILINESTRING((4 4,5 5),EMPTY)",
+		},
+		{
+			"MULTILINESTRING((7 7,7 7),(8 8,9 9))",
+			"MULTILINESTRING(EMPTY,(8 8,9 9))",
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -41,3 +41,21 @@ func TestDisableValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestOmitInvalid(t *testing.T) {
+	for i, tt := range []struct {
+		input  string
+		output string
+	}{
+		{
+			"LINESTRING(0 0,0 0)",
+			"LINESTRING EMPTY",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			g, err := geom.UnmarshalWKT(tt.input, geom.OmitInvalid)
+			expectNoErr(t, err)
+			expectGeomEq(t, g, geomFromWKT(t, tt.output))
+		})
+	}
+}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -24,7 +24,8 @@ type LineString struct {
 // XY values (otherwise an error is returned).
 func NewLineString(seq Sequence, opts ...ConstructorOption) (LineString, error) {
 	n := seq.Length()
-	if skipValidations(opts) || n == 0 {
+	ctorOpts := newOptionSet(opts)
+	if ctorOpts.skipValidations || n == 0 {
 		return LineString{seq}, nil
 	}
 
@@ -35,6 +36,11 @@ func NewLineString(seq Sequence, opts ...ConstructorOption) (LineString, error) 
 			return LineString{seq}, nil
 		}
 	}
+
+	if ctorOpts.omitInvalid {
+		return LineString{}, nil
+	}
+
 	return LineString{}, errors.New("non-empty LineStrings " +
 		"must contain at least 2 points with distinct XY values")
 }

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -44,14 +44,18 @@ func NewMultiPolygonFromPolygons(polys []Polygon, opts ...ConstructorOption) (Mu
 		polys[i] = polys[i].ForceCoordinatesType(ctype)
 	}
 
-	if err := validateMultiPolygon(polys, opts...); err != nil {
+	ctorOpts := newOptionSet(opts)
+	if err := validateMultiPolygon(polys, ctorOpts); err != nil {
+		if ctorOpts.omitInvalid {
+			return MultiPolygon{}, nil
+		}
 		return MultiPolygon{}, err
 	}
 	return MultiPolygon{polys, ctype}, nil
 }
 
-func validateMultiPolygon(polys []Polygon, opts ...ConstructorOption) error {
-	if skipValidations(opts) {
+func validateMultiPolygon(polys []Polygon, opts ctorOptionSet) error {
+	if opts.skipValidations {
 		return nil
 	}
 

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -48,14 +48,18 @@ func NewPolygonFromRings(rings []LineString, opts ...ConstructorOption) (Polygon
 		rings[i] = rings[i].ForceCoordinatesType(ctype)
 	}
 
-	if err := validatePolygon(rings, opts...); err != nil {
+	ctorOpts := newOptionSet(opts)
+	if err := validatePolygon(rings, ctorOpts); err != nil {
+		if ctorOpts.omitInvalid {
+			return Polygon{}, nil
+		}
 		return Polygon{}, err
 	}
 	return Polygon{rings, ctype}, nil
 }
 
-func validatePolygon(rings []LineString, opts ...ConstructorOption) error {
-	if len(rings) == 0 || skipValidations(opts) {
+func validatePolygon(rings []LineString, opts ctorOptionSet) error {
+	if len(rings) == 0 || opts.skipValidations {
 		return nil
 	}
 

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -283,8 +283,9 @@ func (p *wkbParser) parseMultiPolygon(ctype CoordinatesType) MultiPolygon {
 		geom := p.inner()
 		if !geom.IsPolygon() {
 			p.setErr(errors.New("non-Polygon found in MultiPolygon"))
+		} else {
+			polys = append(polys, geom.AsPolygon())
 		}
-		polys = append(polys, geom.AsPolygon())
 	}
 	mpoly, err := NewMultiPolygonFromPolygons(polys, p.opts...)
 	p.setErr(err)


### PR DESCRIPTION
## Description

Adds a new constructor option "OmitInvalid". This replaces any invalid geometries with their empty variant (see doc comment for details.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue
#74 

## Benchmark Results

As expected, no real change:

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-2                        448ns ±20%     453ns ±35%     ~     (p=0.990 n=13+15)
MarshalWKB/polygon/n=100-2                      1.12µs ±69%    0.93µs ±43%  -17.52%  (p=0.037 n=14+15)
MarshalWKB/polygon/n=1000-2                     5.15µs ±36%    4.74µs ±15%     ~     (p=0.246 n=14+14)
MarshalWKB/polygon/n=10000-2                    42.0µs ±32%    40.8µs ±15%     ~     (p=0.719 n=15+12)
UnmarshalWKB/polygon/n=10-2                      485ns ±20%     471ns ± 9%     ~     (p=0.572 n=15+12)
UnmarshalWKB/polygon/n=100-2                     944ns ±27%     937ns ±19%     ~     (p=0.937 n=15+13)
UnmarshalWKB/polygon/n=1000-2                   5.63µs ±29%    5.63µs ±44%     ~     (p=0.880 n=14+15)
UnmarshalWKB/polygon/n=10000-2                  54.2µs ±55%    53.8µs ±20%     ~     (p=0.804 n=14+14)
IntersectsLineStringWithLineString/n=10-2       2.76µs ±13%    2.80µs ±16%     ~     (p=0.527 n=14+12)
IntersectsLineStringWithLineString/n=100-2      38.1µs ±15%    40.9µs ±49%     ~     (p=0.935 n=15+15)
IntersectsLineStringWithLineString/n=1000-2      377µs ±18%     367µs ±22%     ~     (p=0.512 n=15+15)
IntersectsLineStringWithLineString/n=10000-2    5.35ms ±20%    5.01ms ± 9%   -6.38%  (p=0.037 n=15+13)
LineStringIsSimpleZigZag/10-2                   3.42µs ±29%    3.32µs ±18%     ~     (p=0.511 n=14+14)
LineStringIsSimpleZigZag/100-2                  92.5µs ±12%    93.5µs ±16%     ~     (p=0.856 n=13+15)
LineStringIsSimpleZigZag/1000-2                 1.52ms ±17%    1.52ms ±17%     ~     (p=0.683 n=13+15)
LineStringIsSimpleZigZag/10000-2                20.3ms ±19%    20.0ms ± 6%     ~     (p=0.860 n=14+12)
PolygonSingleRingValidation/n=10-2              3.86µs ±30%    3.81µs ±28%     ~     (p=0.935 n=15+15)
PolygonSingleRingValidation/n=100-2             86.5µs ±25%    83.4µs ±19%     ~     (p=0.329 n=14+14)
PolygonSingleRingValidation/n=1000-2            1.54ms ±13%    1.50ms ± 6%     ~     (p=0.403 n=14+12)
PolygonSingleRingValidation/n=10000-2           21.7ms ±24%    20.8ms ±16%     ~     (p=0.413 n=15+13)
PolygonMultipleRingsValidation/n=4-2            13.5µs ±18%    13.4µs ±10%     ~     (p=0.742 n=14+12)
PolygonMultipleRingsValidation/n=36-2            120µs ±13%     123µs ±15%     ~     (p=0.667 n=14+14)
PolygonMultipleRingsValidation/n=400-2          1.61ms ±13%    1.56ms ± 9%     ~     (p=0.072 n=15+13)
PolygonMultipleRingsValidation/n=4096-2         18.7ms ±14%    19.3ms ±18%     ~     (p=0.302 n=13+14)
PolygonZigZagRingsValidation/n=10-2             27.0µs ± 6%    27.7µs ±22%     ~     (p=0.920 n=13+13)
PolygonZigZagRingsValidation/n=100-2             380µs ±15%     403µs ±29%     ~     (p=0.085 n=14+13)
PolygonZigZagRingsValidation/n=1000-2           4.67ms ± 6%    4.92ms ±13%     ~     (p=0.095 n=12+14)
PolygonZigZagRingsValidation/n=10000-2          61.9ms ± 7%    64.4ms ±15%     ~     (p=0.152 n=12+13)
MultipolygonValidation/n=1-2                     502ns ± 7%     541ns ±29%     ~     (p=0.109 n=14+15)
MultipolygonValidation/n=4-2                    1.34µs ±13%    1.39µs ±24%     ~     (p=0.616 n=15+15)
MultipolygonValidation/n=16-2                   8.72µs ±17%    8.31µs ±13%     ~     (p=0.202 n=14+13)
MultipolygonValidation/n=64-2                   49.6µs ±12%    50.7µs ±21%     ~     (p=0.685 n=13+14)
MultipolygonValidation/n=256-2                   301µs ±20%     299µs ±18%     ~     (p=0.793 n=13+14)
MultipolygonValidation/n=1024-2                 1.45ms ±15%    1.48ms ±16%     ~     (p=0.486 n=15+15)
MultiPolygonTwoCircles/n=10-2                   7.44µs ±44%    6.53µs ±14%     ~     (p=0.205 n=14+15)
MultiPolygonTwoCircles/n=100-2                  74.7µs ±35%    70.9µs ±15%     ~     (p=0.652 n=14+15)
MultiPolygonTwoCircles/n=1000-2                  725µs ± 6%     738µs ±13%     ~     (p=0.519 n=13+14)
MultiPolygonTwoCircles/n=10000-2                9.80ms ± 8%   10.07ms ±12%     ~     (p=0.120 n=14+11)
MultiPolygonMultipleTouchingPoints/n=1-2        8.04µs ±13%    8.03µs ± 8%     ~     (p=0.792 n=14+12)
MultiPolygonMultipleTouchingPoints/n=10-2       63.4µs ±11%    65.4µs ±10%     ~     (p=0.239 n=14+13)
MultiPolygonMultipleTouchingPoints/n=100-2       687µs ±11%     722µs ±16%     ~     (p=0.141 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1000-2     8.13ms ±12%    9.07ms ±25%  +11.63%  (p=0.002 n=13+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-2                             74.8µs ±26%    82.5µs ±38%     ~     (p=0.069 n=14+14)
Intersection/n=100-2                             144µs ±13%     155µs ±10%   +7.90%  (p=0.014 n=14+13)
Intersection/n=1000-2                            633µs ±15%     687µs ±21%   +8.54%  (p=0.009 n=13+14)
Intersection/n=10000-2                          5.46ms ±18%    5.59ms ±24%     ~     (p=0.583 n=14+13)
NoOp/n=10-2                                     5.56µs ±12%    5.76µs ±13%     ~     (p=0.274 n=13+14)
NoOp/n=100-2                                    19.4µs ±18%    19.1µs ±10%     ~     (p=0.928 n=15+13)
NoOp/n=1000-2                                    138µs ±16%     143µs ±15%     ~     (p=0.285 n=14+14)
NoOp/n=10000-2                                  1.45ms ±23%    1.41ms ±19%     ~     (p=0.756 n=14+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-2                                  45.6µs ±18%    45.0µs ±16%     ~     (p=0.561 n=15+14)
Delete/n=1000-2                                 1.01ms ±14%    1.12ms ±43%     ~     (p=0.201 n=14+15)
Delete/n=10000-2                                45.5ms ±13%    47.2ms ±23%     ~     (p=0.250 n=15+15)
Bulk/n=10-2                                     1.20µs ±12%    1.26µs ±13%     ~     (p=0.186 n=14+15)
Bulk/n=100-2                                    20.1µs ± 9%    20.9µs ±22%     ~     (p=0.412 n=15+15)
Bulk/n=1000-2                                    310µs ± 5%     318µs ±14%     ~     (p=0.239 n=13+14)
Bulk/n=10000-2                                  4.33ms ± 6%    4.55ms ±19%     ~     (p=0.525 n=13+15)
Bulk/n=100000-2                                 53.7ms ±14%    57.5ms ±29%     ~     (p=0.137 n=14+14)
Insert/n=10-2                                   2.08µs ± 8%    2.18µs ±12%   +5.01%  (p=0.038 n=14+14)
Insert/n=100-2                                  51.0µs ±12%    50.7µs ±10%     ~     (p=0.830 n=14+13)
Insert/n=1000-2                                  869µs ±12%     855µs ±13%     ~     (p=0.290 n=15+14)
Insert/n=10000-2                                12.0ms ±22%    11.8ms ±13%     ~     (p=0.821 n=15+13)
Insert/n=100000-2                                144ms ± 9%     150ms ±14%     ~     (p=0.094 n=14+14)
RangeSearch/n=10-2                              21.9ns ± 9%    22.1ns ±11%     ~     (p=0.883 n=15+13)
RangeSearch/n=100-2                             88.1ns ± 8%    87.6ns ± 5%     ~     (p=0.733 n=14+12)
RangeSearch/n=1000-2                             321ns ± 7%     319ns ± 4%     ~     (p=0.990 n=15+12)
RangeSearch/n=10000-2                           1.13µs ± 8%    1.13µs ± 6%     ~     (p=0.830 n=14+13)
RangeSearch/n=100000-2                          11.5µs ±12%    11.3µs ±10%     ~     (p=0.401 n=14+14)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-2                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-2                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-2                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-2                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-2                       282B ± 0%      284B ± 0%   +0.71%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=100-2                    1.90kB ± 0%    1.90kB ± 0%   +0.11%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=1000-2                   16.5kB ± 0%    16.5kB ± 0%   +0.01%  (p=0.000 n=15+15)
UnmarshalWKB/polygon/n=10000-2                   164kB ± 0%     164kB ± 0%   +0.00%  (p=0.000 n=15+15)
IntersectsLineStringWithLineString/n=10-2       2.44kB ± 0%    2.44kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-2      30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-2      205kB ± 0%     205kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-2    2.63MB ± 0%    2.63MB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-2                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-2                  21.6kB ± 0%    21.6kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-2                  230kB ± 0%     230kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-2                2.30MB ± 0%    2.30MB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-2              1.47kB ± 0%    1.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-2             16.2kB ± 0%    16.2kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-2             217kB ± 0%     217kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-2           2.23MB ± 0%    2.23MB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-2            5.31kB ± 0%    5.31kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-2           43.6kB ± 0%    43.6kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-2           479kB ± 0%     479kB ± 0%     ~     (p=1.040 n=12+13)
PolygonMultipleRingsValidation/n=4096-2         4.92MB ± 0%    4.92MB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-2             11.1kB ± 0%    11.1kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-2             132kB ± 0%     132kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-2           1.02MB ± 0%    1.02MB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-2          11.9MB ± 0%    11.9MB ± 0%     ~     (all equal)
MultipolygonValidation/n=1-2                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-2                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-2                   3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-2                   15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-2                  63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-2                  259kB ± 0%     259kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-2                   4.98kB ± 0%    4.98kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-2                  55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-2                  344kB ± 0%     344kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-2                4.60MB ± 0%    4.60MB ± 0%     ~     (p=0.758 n=14+14)
MultiPolygonMultipleTouchingPoints/n=1-2        3.94kB ± 0%    3.94kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-2       22.6kB ± 0%    22.6kB ± 0%     ~     (p=1.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-2       172kB ± 0%     172kB ± 0%     ~     (p=0.368 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-2     2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.395 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-2                             1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
Intersection/n=100-2                            6.33kB ± 0%    6.33kB ± 0%     ~     (all equal)
Intersection/n=1000-2                           55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
Intersection/n=10000-2                           557kB ± 0%     557kB ± 0%   -0.00%  (p=0.042 n=11+12)
NoOp/n=10-2                                       864B ± 0%      864B ± 0%     ~     (all equal)
NoOp/n=100-2                                    5.68kB ± 0%    5.68kB ± 0%     ~     (all equal)
NoOp/n=1000-2                                   49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-2                                   492kB ± 0%     492kB ± 0%     ~     (p=0.134 n=12+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-2                                    712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-2                                 26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-2                                 412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10-2                                     1.45kB ± 0%    1.45kB ± 0%     ~     (all equal)
Bulk/n=100-2                                    19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-2                                   98.2kB ± 0%    98.2kB ± 0%     ~     (all equal)
Bulk/n=10000-2                                  1.57MB ± 0%    1.57MB ± 0%     ~     (p=0.938 n=15+15)
Bulk/n=100000-2                                 20.4MB ± 0%    20.4MB ± 0%     ~     (all equal)
Insert/n=10-2                                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-2                                  13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-2                                  132kB ± 0%     132kB ± 0%     ~     (all equal)
Insert/n=10000-2                                1.34MB ± 0%    1.34MB ± 0%     ~     (all equal)
Insert/n=100000-2                               13.5MB ± 0%    13.5MB ± 0%     ~     (all equal)
RangeSearch/n=10-2                               0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-2                              0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-2                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-2                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-2                           0.00B          0.00B          ~     (all equal)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-2                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-2                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-2                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-2                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-2                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-2                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-2                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-2                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-2         10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-2        74.0 ± 0%      74.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-2        346 ± 0%       346 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-2     5.47k ± 0%     5.47k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-2                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-2                    75.0 ± 0%      75.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-2                    797 ± 0%       797 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-2                 8.00k ± 0%     8.00k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-2                6.00 ± 0%      6.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-2               57.0 ± 0%      57.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-2               755 ± 0%       755 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-2            7.73k ± 0%     7.73k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-2              29.0 ± 0%      29.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-2              239 ± 0%       239 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-2           2.63k ± 0%     2.63k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-2          26.9k ± 0%     26.9k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-2               40.0 ± 0%      40.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-2               378 ± 0%       378 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-2            2.66k ± 0%     2.66k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-2           32.6k ± 0%     32.6k ± 0%     ~     (all equal)
MultipolygonValidation/n=1-2                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-2                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-2                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-2                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-2                     392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-2                  1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-2                     26.0 ± 0%      26.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-2                     154 ± 0%       154 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-2                    698 ± 0%       698 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-2                 10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-2          47.0 ± 0%      47.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-2          294 ± 0%       294 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-2       2.61k ± 0%     2.61k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-2      26.7k ± 0%     26.7k ± 0%     ~     (p=0.461 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-2                               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=100-2                              31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=1000-2                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
Intersection/n=10000-2                            31.0 ± 0%      31.0 ± 0%     ~     (all equal)
NoOp/n=10-2                                       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=100-2                                      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=1000-2                                     21.0 ± 0%      21.0 ± 0%     ~     (all equal)
NoOp/n=10000-2                                    21.0 ± 0%      21.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-2                                    65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-2                                    480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-2                                 7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-2                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-2                                      70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-2                                      342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-2                                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-2                                  71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-2                                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-2                                    47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-2                                    457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-2                                 4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-2                                46.8k ± 0%     46.8k ± 0%     ~     (all equal)
RangeSearch/n=10-2                                0.00           0.00          ~     (all equal)
RangeSearch/n=100-2                               0.00           0.00          ~     (all equal)
RangeSearch/n=1000-2                              0.00           0.00          ~     (all equal)
RangeSearch/n=10000-2                             0.00           0.00          ~     (all equal)
RangeSearch/n=100000-2                            0.00           0.00          ~     (all equal)
```