### PR TITLE
DCEL Re-Noding

### DIFF
--- a/geom/doubly_connected_edge_list.go
+++ b/geom/doubly_connected_edge_list.go
@@ -146,12 +146,14 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 	fmt.Println("DEBUG reNodeComponent")
 	e := start
 	for {
+		fmt.Println("  ITER")
+
 		// Gather cut locations.
 		ln := line{
 			e.origin.coords,
 			e.twin.origin.coords,
 		}
-		fmt.Printf("  ln: %v\n", ln)
+		fmt.Printf("    ln: %v\n", ln)
 		xys := []XY{ln.a, ln.b}
 		indexed.tree.RangeSearch(ln.envelope().box(), func(i int) error {
 			other := indexed.lines[i]
@@ -159,7 +161,7 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 			if inter.empty {
 				return nil
 			}
-			fmt.Printf("    intersect: %v\n", inter)
+			fmt.Printf("      intersect: %v\n", inter)
 			xys = append(xys, inter.ptA, inter.ptB)
 			return nil
 		})
@@ -173,13 +175,13 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 			}
 		}
 
-		fmt.Printf("  xys: %v\n", xys)
+		fmt.Printf("    xys: %v\n", xys)
 
 		// Perform cuts.
 		cuts := len(xys) - 2
 		for i := 0; i < cuts; i++ {
 			xy := xys[i+1]
-			fmt.Printf("    cut i:%d xys:%v\n", i, xy)
+			fmt.Printf("      cut i:%d xys:%v\n", i, xy)
 			cutVert, ok := d.vertices[xy]
 			if !ok {
 				cutVert = &vertexRecord{
@@ -200,14 +202,23 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 }
 
 func (d *doublyConnectedEdgeList) reNodeEdge(e *halfEdgeRecord, cut *vertexRecord) {
-	fmt.Println("  DEBUG reNodeEdge")
-	fmt.Printf("    e.origin.coords: %v\n", e.origin.coords)
-	fmt.Printf("    e.next.origin.coords: %v\n", e.next.origin.coords)
-	fmt.Printf("    e.next.next.origin.coords: %v\n", e.next.next.origin.coords)
-	fmt.Printf("    e.next.prev.origin.coords: %v\n", e.next.prev.origin.coords)
-	fmt.Printf("    e.next.next.prev.origin.coords: %v\n", e.next.next.prev.origin.coords)
-	fmt.Printf("    e.next.next.prev.prev.origin.coords: %v\n", e.next.next.prev.prev.origin.coords)
-	fmt.Printf("    cut.coords: %v\n", cut.coords)
+	fmt.Println("    DEBUG reNodeEdge")
+	fmt.Printf("      cut --- cut.coords: %v\n", cut.coords)
+	fmt.Printf("      e.origin.coords: %v\n", e.origin.coords)
+	fmt.Printf("      e.next.origin.coords: %v\n", e.next.origin.coords)
+	fmt.Printf("      e.next.next.origin.coords: %v\n", e.next.next.origin.coords)
+	fmt.Printf("      e.next.prev.origin.coords: %v\n", e.next.prev.origin.coords)
+	fmt.Printf("      e.next.next.prev.origin.coords: %v\n", e.next.next.prev.origin.coords)
+	fmt.Printf("      e.next.next.prev.prev.origin.coords: %v\n", e.next.next.prev.prev.origin.coords)
+	fmt.Printf("      e.prev.origin.coords: %v\n", e.prev.origin.coords)
+	fmt.Printf("      e.prev.prev.origin.coords: %v\n", e.prev.prev.origin.coords)
+	fmt.Printf("      e.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.origin.coords)
+	fmt.Printf("      e.prev.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.prev.origin.coords)
+	fmt.Printf("      e.twin.next.origin.coords: %v\n", e.twin.next.origin.coords)
+	fmt.Printf("      e.twin.prev.origin.coords: %v\n", e.twin.prev.origin.coords)
+	fmt.Printf("      e.twin.prev.prev.origin.coords: %v\n", e.twin.prev.prev.origin.coords)
+	fmt.Printf("      e.twin.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.origin.coords)
+	fmt.Printf("      e.twin.prev.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.prev.origin.coords)
 
 	// Store original values we need later.
 	dest := e.twin.origin
@@ -226,7 +237,7 @@ func (d *doublyConnectedEdgeList) reNodeEdge(e *halfEdgeRecord, cut *vertexRecor
 		twin:     ePrime,
 		incident: e.twin.incident,
 		next:     e.twin,
-		prev:     next,
+		prev:     next.twin,
 	}
 	ePrime.twin = ePrimeTwin
 
@@ -241,11 +252,20 @@ func (d *doublyConnectedEdgeList) reNodeEdge(e *halfEdgeRecord, cut *vertexRecor
 
 	d.halfEdges = append(d.halfEdges, ePrime, ePrimeTwin)
 
-	fmt.Printf("    AFTER\n")
-	fmt.Printf("    e.origin.coords: %v\n", e.origin.coords)
-	fmt.Printf("    e.next.origin.coords: %v\n", e.next.origin.coords)
-	fmt.Printf("    e.next.next.origin.coords: %v\n", e.next.next.origin.coords)
-	fmt.Printf("    e.next.prev.origin.coords: %v\n", e.next.prev.origin.coords)
-	fmt.Printf("    e.next.next.prev.origin.coords: %v\n", e.next.next.prev.origin.coords)
-	fmt.Printf("    e.next.next.prev.prev.origin.coords: %v\n", e.next.next.prev.prev.origin.coords)
+	fmt.Printf("      AFTER\n")
+	fmt.Printf("      e.origin.coords: %v\n", e.origin.coords)
+	fmt.Printf("      e.next.origin.coords: %v\n", e.next.origin.coords)
+	fmt.Printf("      e.next.next.origin.coords: %v\n", e.next.next.origin.coords)
+	fmt.Printf("      e.next.prev.origin.coords: %v\n", e.next.prev.origin.coords)
+	fmt.Printf("      e.next.next.prev.origin.coords: %v\n", e.next.next.prev.origin.coords)
+	fmt.Printf("      e.next.next.prev.prev.origin.coords: %v\n", e.next.next.prev.prev.origin.coords)
+	fmt.Printf("      e.prev.origin.coords: %v\n", e.prev.origin.coords)
+	fmt.Printf("      e.prev.prev.origin.coords: %v\n", e.prev.prev.origin.coords)
+	fmt.Printf("      e.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.origin.coords)
+	fmt.Printf("      e.prev.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.prev.origin.coords)
+	fmt.Printf("      e.twin.next.origin.coords: %v\n", e.twin.next.origin.coords)
+	fmt.Printf("      e.twin.prev.origin.coords: %v\n", e.twin.prev.origin.coords)
+	fmt.Printf("      e.twin.prev.prev.origin.coords: %v\n", e.twin.prev.prev.origin.coords)
+	fmt.Printf("      e.twin.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.origin.coords)
+	fmt.Printf("      e.twin.prev.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.prev.origin.coords)
 }

--- a/geom/doubly_connected_edge_list.go
+++ b/geom/doubly_connected_edge_list.go
@@ -123,3 +123,7 @@ func newDCELFromPolygon(poly Polygon) *doublyConnectedEdgeList {
 
 	return dcel
 }
+
+func (d *doublyConnectedEdgeList) reNode(other Polygon) {
+	// TODO
+}

--- a/geom/doubly_connected_edge_list.go
+++ b/geom/doubly_connected_edge_list.go
@@ -1,7 +1,5 @@
 package geom
 
-import "fmt"
-
 type doublyConnectedEdgeList struct {
 	faces     []*faceRecord
 	halfEdges []*halfEdgeRecord
@@ -143,17 +141,13 @@ func (d *doublyConnectedEdgeList) reNodeFace(face *faceRecord, indexed indexedLi
 }
 
 func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed indexedLines) {
-	fmt.Println("DEBUG reNodeComponent")
 	e := start
 	for {
-		fmt.Println("  ITER")
-
 		// Gather cut locations.
 		ln := line{
 			e.origin.coords,
 			e.twin.origin.coords,
 		}
-		fmt.Printf("    ln: %v\n", ln)
 		xys := []XY{ln.a, ln.b}
 		indexed.tree.RangeSearch(ln.envelope().box(), func(i int) error {
 			other := indexed.lines[i]
@@ -161,7 +155,6 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 			if inter.empty {
 				return nil
 			}
-			fmt.Printf("      intersect: %v\n", inter)
 			xys = append(xys, inter.ptA, inter.ptB)
 			return nil
 		})
@@ -175,13 +168,10 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 			}
 		}
 
-		fmt.Printf("    xys: %v\n", xys)
-
 		// Perform cuts.
 		cuts := len(xys) - 2
 		for i := 0; i < cuts; i++ {
 			xy := xys[i+1]
-			fmt.Printf("      cut i:%d xys:%v\n", i, xy)
 			cutVert, ok := d.vertices[xy]
 			if !ok {
 				cutVert = &vertexRecord{
@@ -202,24 +192,6 @@ func (d *doublyConnectedEdgeList) reNodeComponent(start *halfEdgeRecord, indexed
 }
 
 func (d *doublyConnectedEdgeList) reNodeEdge(e *halfEdgeRecord, cut *vertexRecord) {
-	fmt.Println("    DEBUG reNodeEdge")
-	fmt.Printf("      cut --- cut.coords: %v\n", cut.coords)
-	fmt.Printf("      e.origin.coords: %v\n", e.origin.coords)
-	fmt.Printf("      e.next.origin.coords: %v\n", e.next.origin.coords)
-	fmt.Printf("      e.next.next.origin.coords: %v\n", e.next.next.origin.coords)
-	fmt.Printf("      e.next.prev.origin.coords: %v\n", e.next.prev.origin.coords)
-	fmt.Printf("      e.next.next.prev.origin.coords: %v\n", e.next.next.prev.origin.coords)
-	fmt.Printf("      e.next.next.prev.prev.origin.coords: %v\n", e.next.next.prev.prev.origin.coords)
-	fmt.Printf("      e.prev.origin.coords: %v\n", e.prev.origin.coords)
-	fmt.Printf("      e.prev.prev.origin.coords: %v\n", e.prev.prev.origin.coords)
-	fmt.Printf("      e.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.origin.coords)
-	fmt.Printf("      e.prev.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.prev.origin.coords)
-	fmt.Printf("      e.twin.next.origin.coords: %v\n", e.twin.next.origin.coords)
-	fmt.Printf("      e.twin.prev.origin.coords: %v\n", e.twin.prev.origin.coords)
-	fmt.Printf("      e.twin.prev.prev.origin.coords: %v\n", e.twin.prev.prev.origin.coords)
-	fmt.Printf("      e.twin.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.origin.coords)
-	fmt.Printf("      e.twin.prev.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.prev.origin.coords)
-
 	// Store original values we need later.
 	dest := e.twin.origin
 	next := e.next
@@ -251,21 +223,4 @@ func (d *doublyConnectedEdgeList) reNodeEdge(e *halfEdgeRecord, cut *vertexRecor
 	dest.incident = ePrimeTwin
 
 	d.halfEdges = append(d.halfEdges, ePrime, ePrimeTwin)
-
-	fmt.Printf("      AFTER\n")
-	fmt.Printf("      e.origin.coords: %v\n", e.origin.coords)
-	fmt.Printf("      e.next.origin.coords: %v\n", e.next.origin.coords)
-	fmt.Printf("      e.next.next.origin.coords: %v\n", e.next.next.origin.coords)
-	fmt.Printf("      e.next.prev.origin.coords: %v\n", e.next.prev.origin.coords)
-	fmt.Printf("      e.next.next.prev.origin.coords: %v\n", e.next.next.prev.origin.coords)
-	fmt.Printf("      e.next.next.prev.prev.origin.coords: %v\n", e.next.next.prev.prev.origin.coords)
-	fmt.Printf("      e.prev.origin.coords: %v\n", e.prev.origin.coords)
-	fmt.Printf("      e.prev.prev.origin.coords: %v\n", e.prev.prev.origin.coords)
-	fmt.Printf("      e.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.origin.coords)
-	fmt.Printf("      e.prev.prev.prev.prev.origin.coords: %v\n", e.prev.prev.prev.prev.origin.coords)
-	fmt.Printf("      e.twin.next.origin.coords: %v\n", e.twin.next.origin.coords)
-	fmt.Printf("      e.twin.prev.origin.coords: %v\n", e.twin.prev.origin.coords)
-	fmt.Printf("      e.twin.prev.prev.origin.coords: %v\n", e.twin.prev.prev.origin.coords)
-	fmt.Printf("      e.twin.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.origin.coords)
-	fmt.Printf("      e.twin.prev.prev.prev.prev.origin.coords: %v\n", e.twin.prev.prev.prev.prev.origin.coords)
 }

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -1,6 +1,7 @@
 package geom
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -46,6 +47,15 @@ func CheckFaceComponents(
 }
 
 func CheckComponent(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []XY) {
+	fmt.Println("CheckComponent")
+	fmt.Println("start.origin.coords", start.origin.coords)
+	fmt.Println("start.prev.origin.coords", start.prev.origin.coords)
+	fmt.Println("start.prev.prev.origin.coords", start.prev.prev.origin.coords)
+	fmt.Println("start.prev.prev.prev.origin.coords", start.prev.prev.prev.origin.coords)
+	fmt.Println("start.prev.prev.prev.prev.origin.coords", start.prev.prev.prev.prev.origin.coords)
+	fmt.Println("start.prev.prev.prev.prev.prev.origin.coords", start.prev.prev.prev.prev.prev.origin.coords)
+	fmt.Println("start.prev.prev.prev.prev.prev.prev.origin.coords", start.prev.prev.prev.prev.prev.prev.origin.coords)
+
 	// Check component matches forward order when following 'next' pointer.
 	e := start
 	var got []XY
@@ -65,9 +75,15 @@ func CheckComponent(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []X
 	CheckXYs(t, got, want)
 
 	// Check component matches reverse order when following 'prev' pointer.
+	var i int
 	e = start
 	got = nil
 	for {
+		i++
+		if i == 20 {
+			t.Fatal("inf loop")
+		}
+
 		if e.incident != f {
 			t.Errorf("half edge has incorrect incident face")
 		}
@@ -296,7 +312,7 @@ func TestGraphReNode(t *testing.T) {
 	eqInt(t, len(dcel.faces), 2)
 
 	f0 := dcel.faces[0]
-	//f1 := dcel.faces[1]
+	f1 := dcel.faces[1]
 
 	v0 := XY{0, 0}
 	v1 := XY{2, 0}
@@ -310,12 +326,10 @@ func TestGraphReNode(t *testing.T) {
 		nil,
 		[]XY{v1, v0, v4, v3, v2},
 	)
-
-	// TODO: this check causes an infinite loop
-	//CheckFaceComponents(
-	//	t, f1,
-	//	[]XY{v0, v1, v2, v3, v4},
-	//)
+	CheckFaceComponents(
+		t, f1,
+		[]XY{v0, v1, v2, v3, v4},
+	)
 }
 
 func eqInt(t *testing.T, i1, i2 int) {

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -358,7 +358,9 @@ func TestGraphReNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel.reNode(other.AsPolygon())
+	//dcel.reNodeGraph(other.AsPolygon())
+	_ = dcel
+	_ = other
 
 	/*
 

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -1,7 +1,6 @@
 package geom
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -47,15 +46,6 @@ func CheckFaceComponents(
 }
 
 func CheckComponent(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []XY) {
-	fmt.Println("CheckComponent")
-	fmt.Println("start.origin.coords", start.origin.coords)
-	fmt.Println("start.prev.origin.coords", start.prev.origin.coords)
-	fmt.Println("start.prev.prev.origin.coords", start.prev.prev.origin.coords)
-	fmt.Println("start.prev.prev.prev.origin.coords", start.prev.prev.prev.origin.coords)
-	fmt.Println("start.prev.prev.prev.prev.origin.coords", start.prev.prev.prev.prev.origin.coords)
-	fmt.Println("start.prev.prev.prev.prev.prev.origin.coords", start.prev.prev.prev.prev.prev.origin.coords)
-	fmt.Println("start.prev.prev.prev.prev.prev.prev.origin.coords", start.prev.prev.prev.prev.prev.prev.origin.coords)
-
 	// Check component matches forward order when following 'next' pointer.
 	e := start
 	var got []XY

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -2,24 +2,56 @@ package geom
 
 import "testing"
 
-func CheckFaceOuterComponent(t *testing.T, f *faceRecord, want ...XY) {
+func CheckVertexIncidents(t *testing.T, verts map[XY]*vertexRecord) {
+	t.Helper()
+	for xy, vr := range verts {
+		if xy != vr.coords {
+			t.Errorf("xy in vertex map doesn't match record")
+		}
+		if vr.incident.origin != vr {
+			t.Errorf("incident edge of vert doesn't have vert as its origin")
+		}
+	}
+}
+
+func CheckFaceComponents(
+	t *testing.T, f *faceRecord, wantOuter []XY, wantInners ...[]XY,
+) {
 	t.Helper()
 
-	if len(want) == 0 {
+	if len(wantOuter) == 0 {
 		if f.outerComponent != nil {
 			t.Errorf("want no outer component but outer component is not nil")
 		}
 		return
 	}
-	if len(want) != 0 && f.outerComponent == nil {
+	if len(wantOuter) != 0 && f.outerComponent == nil {
 		t.Errorf("want outer component but outer component is nil")
 		return
 	}
+	CheckComponent(t, f, f.outerComponent, wantOuter)
 
-	start := f.outerComponent
+	if len(f.innerComponents) != len(wantInners) {
+		t.Errorf("len want inners not equal to actual inners: %d vs %d",
+			len(wantInners), len(f.innerComponents))
+		return
+	}
+	for i, wantInner := range wantInners {
+		CheckComponent(t, f, f.innerComponents[i], wantInner)
+	}
+}
+
+func CheckComponent(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []XY) {
+	// Check component matches forward order when following 'next' pointer.
 	e := start
 	var got []XY
 	for {
+		if e.incident != f {
+			t.Errorf("half edge has incorrect incident face")
+		}
+		if e.origin == nil {
+			t.Errorf("edge origin not set")
+		}
 		got = append(got, e.origin.coords)
 		e = e.next
 		if e == start {
@@ -27,6 +59,49 @@ func CheckFaceOuterComponent(t *testing.T, f *faceRecord, want ...XY) {
 		}
 	}
 	CheckXYs(t, got, want)
+
+	// Check component matches reverse order when following 'prev' pointer.
+	e = start
+	got = nil
+	for {
+		if e.incident != f {
+			t.Errorf("half edge has incorrect incident face")
+		}
+		if e.origin == nil {
+			t.Errorf("edge origin not set")
+		}
+		got = append(got, e.origin.coords)
+		e = e.prev
+		if e == start {
+			break
+		}
+	}
+	for i := 0; i < len(got)/2; i++ {
+		j := len(got) - i - 1
+		got[i], got[j] = got[j], got[i]
+	}
+	CheckXYs(t, got, want)
+
+	// Check 'twin' assertions.
+	e = start
+	for {
+		if e.twin == nil {
+			t.Fatalf("twin not populated")
+		}
+		if e.twin.twin != e {
+			t.Fatalf("twin's twin is not itself")
+		}
+		if e.origin != e.twin.next.origin {
+			t.Fatalf("edge's origin doesn't match twin's next origin")
+		}
+		if e.next.origin != e.twin.origin {
+			t.Fatalf("edge's next origin doesn't match twin's origin ")
+		}
+		e = e.next
+		if e == start {
+			break
+		}
+	}
 }
 
 func CheckXYs(t *testing.T, got, want []XY) {
@@ -74,80 +149,23 @@ func TestGraphTriangle(t *testing.T) {
 	eqInt(t, len(dcel.halfEdges), 6)
 	eqInt(t, len(dcel.faces), 2)
 
-	v0 := dcel.vertices[XY{0, 0}]
-	v1 := dcel.vertices[XY{1, 0}]
-	v2 := dcel.vertices[XY{0, 1}]
-
-	e0 := dcel.halfEdges[0]
-	e1 := dcel.halfEdges[1]
-	e2 := dcel.halfEdges[2]
-	e3 := dcel.halfEdges[3]
-	e4 := dcel.halfEdges[4]
-	e5 := dcel.halfEdges[5]
-
 	f0 := dcel.faces[0]
 	f1 := dcel.faces[1]
 
-	// half edges should have their incident face populated
-	eqFace(t, e0.incident, f1)
-	eqFace(t, e1.incident, f0)
-	eqFace(t, e2.incident, f1)
-	eqFace(t, e3.incident, f0)
-	eqFace(t, e4.incident, f1)
-	eqFace(t, e5.incident, f0)
+	v0 := XY{0, 0}
+	v1 := XY{1, 0}
+	v2 := XY{0, 1}
 
-	// half edge twins should be populated
-	eqEdge(t, e0.twin, e1)
-	eqEdge(t, e1.twin, e0)
-	eqEdge(t, e2.twin, e3)
-	eqEdge(t, e3.twin, e2)
-	eqEdge(t, e4.twin, e5)
-	eqEdge(t, e5.twin, e4)
-
-	// next edge should be populated
-	eqEdge(t, e0.next, e2)
-	eqEdge(t, e2.next, e4)
-	eqEdge(t, e4.next, e0)
-	eqEdge(t, e1.next, e5)
-	eqEdge(t, e5.next, e3)
-	eqEdge(t, e3.next, e1)
-
-	// prev edge should be populated
-	eqEdge(t, e0.prev, e4)
-	eqEdge(t, e4.prev, e2)
-	eqEdge(t, e2.prev, e0)
-	eqEdge(t, e1.prev, e3)
-	eqEdge(t, e3.prev, e5)
-	eqEdge(t, e5.prev, e1)
-
-	// edge origins should be populated
-	eqVertex(t, e0.origin, v0)
-	eqVertex(t, e1.origin, v1)
-	eqVertex(t, e2.origin, v1)
-	eqVertex(t, e3.origin, v2)
-	eqVertex(t, e4.origin, v2)
-	eqVertex(t, e5.origin, v0)
-
-	// vertex incidents should be populated
-	eqEdge(t, v0.incident, e0)
-	eqEdge(t, v1.incident, e2)
-	eqEdge(t, v2.incident, e4)
-
-	// face components are populated
-	eqEdge(t, f0.outerComponent, nil)
-	eqInt(t, len(f0.innerComponents), 1)
-	eqEdge(t, f0.innerComponents[0], e1)
-	eqEdge(t, f1.outerComponent, e0)
-	eqInt(t, len(f1.innerComponents), 0)
-
-	//--- New testing style:
-
-	u0 := XY{0, 0}
-	u1 := XY{1, 0}
-	u2 := XY{0, 1}
-
-	CheckFaceOuterComponent(t, f0)
-	CheckFaceOuterComponent(t, f1, u2, u0, u1)
+	CheckVertexIncidents(t, dcel.vertices)
+	CheckFaceComponents(
+		t, f0,
+		nil,
+		[]XY{v2, v1, v0},
+	)
+	CheckFaceComponents(
+		t, f1,
+		[]XY{v0, v1, v2},
+	)
 }
 
 func TestGraphWithHoles(t *testing.T) {
@@ -200,205 +218,44 @@ func TestGraphWithHoles(t *testing.T) {
 	eqInt(t, len(dcel.halfEdges), 24)
 	eqInt(t, len(dcel.faces), 4)
 
-	v0 := dcel.vertices[XY{0, 0}]
-	v1 := dcel.vertices[XY{5, 0}]
-	v2 := dcel.vertices[XY{5, 5}]
-	v3 := dcel.vertices[XY{0, 5}]
-	v4 := dcel.vertices[XY{1, 1}]
-	v5 := dcel.vertices[XY{1, 2}]
-	v6 := dcel.vertices[XY{2, 2}]
-	v7 := dcel.vertices[XY{2, 1}]
-	v8 := dcel.vertices[XY{3, 3}]
-	v9 := dcel.vertices[XY{3, 4}]
-	v10 := dcel.vertices[XY{4, 4}]
-	v11 := dcel.vertices[XY{4, 3}]
-
-	e0 := dcel.halfEdges[0]
-	e1 := dcel.halfEdges[1]
-	e2 := dcel.halfEdges[2]
-	e3 := dcel.halfEdges[3]
-	e4 := dcel.halfEdges[4]
-	e5 := dcel.halfEdges[5]
-	e6 := dcel.halfEdges[6]
-	e7 := dcel.halfEdges[7]
-	e8 := dcel.halfEdges[8]
-	e9 := dcel.halfEdges[9]
-	e10 := dcel.halfEdges[10]
-	e11 := dcel.halfEdges[11]
-	e12 := dcel.halfEdges[12]
-	e13 := dcel.halfEdges[13]
-	e14 := dcel.halfEdges[14]
-	e15 := dcel.halfEdges[15]
-	e16 := dcel.halfEdges[16]
-	e17 := dcel.halfEdges[17]
-	e18 := dcel.halfEdges[18]
-	e19 := dcel.halfEdges[19]
-	e20 := dcel.halfEdges[20]
-	e21 := dcel.halfEdges[21]
-	e22 := dcel.halfEdges[22]
-	e23 := dcel.halfEdges[23]
-
 	f0 := dcel.faces[0]
 	f1 := dcel.faces[1]
 	f2 := dcel.faces[2]
 	f3 := dcel.faces[3]
 
-	// half edges should have their incident face populated
-	eqFace(t, e0.incident, f1)
-	eqFace(t, e1.incident, f0)
-	eqFace(t, e2.incident, f1)
-	eqFace(t, e3.incident, f0)
-	eqFace(t, e4.incident, f1)
-	eqFace(t, e5.incident, f0)
-	eqFace(t, e6.incident, f1)
-	eqFace(t, e7.incident, f0)
-	eqFace(t, e8.incident, f1)
-	eqFace(t, e9.incident, f2)
-	eqFace(t, e10.incident, f1)
-	eqFace(t, e11.incident, f2)
-	eqFace(t, e12.incident, f1)
-	eqFace(t, e13.incident, f2)
-	eqFace(t, e14.incident, f1)
-	eqFace(t, e15.incident, f2)
-	eqFace(t, e16.incident, f1)
-	eqFace(t, e17.incident, f3)
-	eqFace(t, e18.incident, f1)
-	eqFace(t, e19.incident, f3)
-	eqFace(t, e20.incident, f1)
-	eqFace(t, e21.incident, f3)
-	eqFace(t, e22.incident, f1)
-	eqFace(t, e23.incident, f3)
+	v0 := XY{0, 0}
+	v1 := XY{5, 0}
+	v2 := XY{5, 5}
+	v3 := XY{0, 5}
+	v4 := XY{1, 1}
+	v5 := XY{1, 2}
+	v6 := XY{2, 2}
+	v7 := XY{2, 1}
+	v8 := XY{3, 3}
+	v9 := XY{3, 4}
+	v10 := XY{4, 4}
+	v11 := XY{4, 3}
 
-	// half edge twins should be populated
-	eqEdge(t, e0.twin, e1)
-	eqEdge(t, e1.twin, e0)
-	eqEdge(t, e2.twin, e3)
-	eqEdge(t, e3.twin, e2)
-	eqEdge(t, e4.twin, e5)
-	eqEdge(t, e5.twin, e4)
-	eqEdge(t, e6.twin, e7)
-	eqEdge(t, e7.twin, e6)
-	eqEdge(t, e8.twin, e9)
-	eqEdge(t, e9.twin, e8)
-	eqEdge(t, e10.twin, e11)
-	eqEdge(t, e11.twin, e10)
-	eqEdge(t, e12.twin, e13)
-	eqEdge(t, e13.twin, e12)
-	eqEdge(t, e14.twin, e15)
-	eqEdge(t, e15.twin, e14)
-	eqEdge(t, e16.twin, e17)
-	eqEdge(t, e17.twin, e16)
-	eqEdge(t, e18.twin, e19)
-	eqEdge(t, e19.twin, e18)
-	eqEdge(t, e20.twin, e21)
-	eqEdge(t, e21.twin, e20)
-	eqEdge(t, e22.twin, e23)
-	eqEdge(t, e23.twin, e22)
-
-	// next edge should be populated
-	eqEdge(t, e0.next, e2)
-	eqEdge(t, e1.next, e7)
-	eqEdge(t, e2.next, e4)
-	eqEdge(t, e3.next, e1)
-	eqEdge(t, e4.next, e6)
-	eqEdge(t, e5.next, e3)
-	eqEdge(t, e6.next, e0)
-	eqEdge(t, e7.next, e5)
-	eqEdge(t, e8.next, e10)
-	eqEdge(t, e9.next, e15)
-	eqEdge(t, e10.next, e12)
-	eqEdge(t, e11.next, e9)
-	eqEdge(t, e12.next, e14)
-	eqEdge(t, e13.next, e11)
-	eqEdge(t, e14.next, e8)
-	eqEdge(t, e15.next, e13)
-	eqEdge(t, e16.next, e18)
-	eqEdge(t, e17.next, e23)
-	eqEdge(t, e18.next, e20)
-	eqEdge(t, e19.next, e17)
-	eqEdge(t, e20.next, e22)
-	eqEdge(t, e21.next, e19)
-	eqEdge(t, e22.next, e16)
-	eqEdge(t, e23.next, e21)
-
-	// prev edge should be populated
-	eqEdge(t, e2.prev, e0)
-	eqEdge(t, e7.prev, e1)
-	eqEdge(t, e4.prev, e2)
-	eqEdge(t, e1.prev, e3)
-	eqEdge(t, e6.prev, e4)
-	eqEdge(t, e3.prev, e5)
-	eqEdge(t, e0.prev, e6)
-	eqEdge(t, e5.prev, e7)
-	eqEdge(t, e10.prev, e8)
-	eqEdge(t, e15.prev, e9)
-	eqEdge(t, e12.prev, e10)
-	eqEdge(t, e9.prev, e11)
-	eqEdge(t, e14.prev, e12)
-	eqEdge(t, e11.prev, e13)
-	eqEdge(t, e8.prev, e14)
-	eqEdge(t, e13.prev, e15)
-	eqEdge(t, e18.prev, e16)
-	eqEdge(t, e23.prev, e17)
-	eqEdge(t, e20.prev, e18)
-	eqEdge(t, e17.prev, e19)
-	eqEdge(t, e22.prev, e20)
-	eqEdge(t, e19.prev, e21)
-	eqEdge(t, e16.prev, e22)
-	eqEdge(t, e21.prev, e23)
-
-	// edge origins should be populated
-	eqVertex(t, e0.origin, v0)
-	eqVertex(t, e1.origin, v1)
-	eqVertex(t, e2.origin, v1)
-	eqVertex(t, e3.origin, v2)
-	eqVertex(t, e4.origin, v2)
-	eqVertex(t, e5.origin, v3)
-	eqVertex(t, e6.origin, v3)
-	eqVertex(t, e7.origin, v0)
-	eqVertex(t, e8.origin, v4)
-	eqVertex(t, e9.origin, v5)
-	eqVertex(t, e10.origin, v5)
-	eqVertex(t, e11.origin, v6)
-	eqVertex(t, e12.origin, v6)
-	eqVertex(t, e13.origin, v7)
-	eqVertex(t, e14.origin, v7)
-	eqVertex(t, e15.origin, v4)
-	eqVertex(t, e16.origin, v8)
-	eqVertex(t, e17.origin, v9)
-	eqVertex(t, e18.origin, v9)
-	eqVertex(t, e19.origin, v10)
-	eqVertex(t, e20.origin, v10)
-	eqVertex(t, e21.origin, v11)
-	eqVertex(t, e22.origin, v11)
-	eqVertex(t, e23.origin, v8)
-
-	// vertex incidents should be populated
-	eqEdge(t, v0.incident, e0)
-	eqEdge(t, v1.incident, e2)
-	eqEdge(t, v2.incident, e4)
-	eqEdge(t, v3.incident, e6)
-	eqEdge(t, v4.incident, e8)
-	eqEdge(t, v5.incident, e10)
-	eqEdge(t, v6.incident, e12)
-	eqEdge(t, v7.incident, e14)
-	eqEdge(t, v8.incident, e16)
-	eqEdge(t, v9.incident, e18)
-	eqEdge(t, v10.incident, e20)
-	eqEdge(t, v11.incident, e22)
-
-	// face components are populated
-	eqEdge(t, f0.outerComponent, nil)
-	eqInt(t, len(f0.innerComponents), 1)
-	eqEdge(t, f0.innerComponents[0], e1)
-	eqEdge(t, f1.outerComponent, e0)
-	eqInt(t, len(f1.innerComponents), 2)
-	eqEdge(t, f1.innerComponents[0], e8)
-	eqEdge(t, f1.innerComponents[1], e16)
-	eqEdge(t, f2.outerComponent, e9)
-	eqInt(t, len(f2.innerComponents), 0)
-	eqEdge(t, f3.outerComponent, e17)
-	eqInt(t, len(f2.innerComponents), 0)
+	CheckVertexIncidents(t, dcel.vertices)
+	CheckFaceComponents(
+		t, f0,
+		nil,
+		[]XY{v3, v2, v1, v0},
+	)
+	CheckFaceComponents(
+		t, f1,
+		[]XY{v3, v0, v1, v2},
+		[]XY{v5, v6, v7, v4},
+		[]XY{v9, v10, v11, v8},
+	)
+	CheckFaceComponents(
+		t, f2,
+		[]XY{v4, v7, v6, v5},
+	)
+	CheckFaceComponents(
+		t, f3,
+		[]XY{v8, v11, v10, v9},
+	)
 }
 
 func TestGraphReNode(t *testing.T) {
@@ -436,27 +293,6 @@ func TestGraphReNode(t *testing.T) {
 	 V0 . <----------e1------------  . V1
 
 	*/
-}
-
-func eqFace(t *testing.T, f1, f2 *faceRecord) {
-	t.Helper()
-	if f1 != f2 {
-		t.Errorf("faces not equal: %p vs %p", f1, f2)
-	}
-}
-
-func eqEdge(t *testing.T, e1, e2 *halfEdgeRecord) {
-	t.Helper()
-	if e1 != e2 {
-		t.Errorf("edges not equal: %p vs %p", e1, e2)
-	}
-}
-
-func eqVertex(t *testing.T, v1, v2 *vertexRecord) {
-	t.Helper()
-	if v1 != v2 {
-		t.Errorf("vertices not equal: %p vs %p", v1, v2)
-	}
 }
 
 func eqInt(t *testing.T, i1, i2 int) {

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -347,6 +347,41 @@ func TestGraphWithHoles(t *testing.T) {
 	eqInt(t, len(f2.innerComponents), 0)
 }
 
+func TestGraphReNode(t *testing.T) {
+	poly, err := UnmarshalWKT("POLYGON((0 0,2 0,1 2,0 0))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dcel := newDCELFromPolygon(poly.AsPolygon())
+
+	other, err := UnmarshalWKT("POLYGON((0 1,2 1,1 3,0 1))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dcel.reNode(other.AsPolygon())
+
+	/*
+
+	                 V3
+	                  .
+	               ^     \
+	              /  / ^  \            F0
+	             /  e4  \  e7
+	           e5  /    e6  \
+	           /  v       \  \
+	                       \  v
+	       V4 .               .  V2
+	                         ^  \
+	       ^  /               \  \
+	      /  e8      F1       e2  e3
+	    e9  /                   \  \
+	    /  v                     \  v
+	        ---------e0--------->
+	 V0 . <----------e1------------  . V1
+
+	*/
+}
+
 func eqFace(t *testing.T, f1, f2 *faceRecord) {
 	t.Helper()
 	if f1 != f2 {


### PR DESCRIPTION
## Description

Adds re-noding algorithm for DCELs. This places additional nodes in the graph in locations where there would be a crossing point with another geometry.

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A