### PR TITLE
Support holes when extracting Polygons from DCEL

### DIFF
--- a/geom/alg_binary_op.go
+++ b/geom/alg_binary_op.go
@@ -40,5 +40,5 @@ func binaryOp(a, b Geometry, include func(uint8) bool) Geometry {
 	dcelB.reNodeGraph(polyA)
 
 	dcelA.overlay(dcelB)
-	return dcelA.toPolygon(include)
+	return dcelA.toGeometry(include)
 }

--- a/geom/alg_binary_op.go
+++ b/geom/alg_binary_op.go
@@ -5,25 +5,25 @@ import "fmt"
 // Union returns a geometry that represents the parts that are common to either
 // geometry A or geometry B (or both).
 func Union(a, b Geometry) Geometry {
-	return binaryOp(a, b, func(label uint8) bool { return label != 0 })
+	return binaryOp(a, b, selectUnion)
 }
 
 // Intersection returns a geometry that represents the parts that are common to
 // both geometry A and geometry B.
 func Intersection(a, b Geometry) Geometry {
-	return binaryOp(a, b, func(label uint8) bool { return label == 0b11 })
+	return binaryOp(a, b, selectIntersection)
 }
 
 // Difference returns a geometry that represents the parts of input geometry A
 // that do not intersect with any parts of input geometry B.
 func Difference(a, b Geometry) Geometry {
-	return binaryOp(a, b, func(label uint8) bool { return label == 0b01 })
+	return binaryOp(a, b, selectDifference)
 }
 
 // SymmetricDifference returns a geometry that represents the parts of geometry
 // A and B that do not intersect with each other.
 func SymmetricDifference(a, b Geometry) Geometry {
-	return binaryOp(a, b, func(label uint8) bool { return label == 0b01 || label == 0b10 })
+	return binaryOp(a, b, selectSymmetricDifference)
 }
 
 func binaryOp(a, b Geometry, include func(uint8) bool) Geometry {
@@ -34,8 +34,8 @@ func binaryOp(a, b Geometry, include func(uint8) bool) Geometry {
 	polyA := a.AsPolygon()
 	polyB := b.AsPolygon()
 
-	dcelA := newDCELFromPolygon(polyA, 0b01)
-	dcelB := newDCELFromPolygon(polyB, 0b10)
+	dcelA := newDCELFromPolygon(polyA, inputAValue|inputAPresent)
+	dcelB := newDCELFromPolygon(polyB, inputBValue|inputBPresent)
 	dcelA.reNodeGraph(polyB)
 	dcelB.reNodeGraph(polyA)
 

--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -95,7 +95,7 @@ func TestBinaryOp(t *testing.T) {
 			union:  "POLYGON((0 0,3 0,3 3,0 3,0 0))",
 
 			// TODO: The following tests are disabled because they currently don't pass.
-			//inter: "POLYGON((1 1,2 1,2 2,1 2,1 1))",
+			inter: "POLYGON((1 1,2 1,2 2,1 2,1 1))",
 			//fwdDiff: "POLYGON((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1)))",
 			//revDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?
 			//symDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?

--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -95,7 +95,7 @@ func TestBinaryOp(t *testing.T) {
 			union:  "POLYGON((0 0,3 0,3 3,0 3,0 0))",
 
 			// TODO: The following tests are disabled because they currently don't pass.
-			//inter:   "POLYGON((1 1,2 1,2 2,1 2,1 1))",
+			//inter: "POLYGON((1 1,2 1,2 2,1 2,1 1))",
 			//fwdDiff: "POLYGON((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1)))",
 			//revDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?
 			//symDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?

--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -90,15 +90,13 @@ func TestBinaryOp(t *testing.T) {
 			   |                 |
 			   +-----------------+
 			*/
-			input1: "POLYGON((0 0,3 0,3 3,0 3,0 0))",
-			input2: "POLYGON((1 1,2 1,2 2,1 2,1 1))",
-			union:  "POLYGON((0 0,3 0,3 3,0 3,0 0))",
-
-			// TODO: The following tests are disabled because they currently don't pass.
-			inter: "POLYGON((1 1,2 1,2 2,1 2,1 1))",
-			//fwdDiff: "POLYGON((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1)))",
-			//revDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?
-			//symDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?
+			input1:  "POLYGON((0 0,3 0,3 3,0 3,0 0))",
+			input2:  "POLYGON((1 1,2 1,2 2,1 2,1 1))",
+			union:   "POLYGON((0 0,3 0,3 3,0 3,0 0))",
+			inter:   "POLYGON((1 1,2 1,2 2,1 2,1 1))",
+			fwdDiff: "POLYGON((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))",
+			revDiff: "POLYGON EMPTY", // TODO: should this be GEOMETRYCOLLECTION EMPTY?
+			symDiff: "POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,2 1,2 2,1 2,1 1))",
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -117,7 +115,7 @@ func TestBinaryOp(t *testing.T) {
 			} {
 				t.Run(opCase.opName, func(t *testing.T) {
 					if opCase.want == "" {
-						// TODO: remove skips once everything passes
+						// Allows tests to be skipped by just commenting them out.
 						t.Skip("Skipping test because it would fail")
 					}
 					want := geomFromWKT(t, opCase.want)

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -1,5 +1,7 @@
 package geom
 
+import "fmt"
+
 const (
 	// TODO: Better names?
 	inputAValue   uint8 = 0b0001
@@ -15,10 +17,9 @@ const (
 )
 
 func assertPresenceBits(label uint8) {
-	// TODO: re-enable
-	//if presenceMask&label != presenceMask {
-	//	panic(fmt.Sprintf("all presence bits in label not set: %v", label))
-	//}
+	if presenceMask&label != presenceMask {
+		panic(fmt.Sprintf("all presence bits in label not set: %v", label))
+	}
 }
 
 func selectUnion(label uint8) bool {

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -14,6 +14,8 @@ const (
 
 	inputAMask uint8 = 0b0011
 	inputBMask uint8 = 0b1100
+
+	extracted uint8 = 0b010000
 )
 
 func assertPresenceBits(label uint8) {

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -1,0 +1,43 @@
+package geom
+
+const (
+	// TODO: Better names?
+	inputAValue   uint8 = 0b0001
+	inputAPresent uint8 = 0b0010
+	inputBValue   uint8 = 0b0100
+	inputBPresent uint8 = 0b1000
+
+	presenceMask uint8 = 0b1010
+	valueMask    uint8 = 0b0101
+
+	inputAMask uint8 = 0b0011
+	inputBMask uint8 = 0b1100
+)
+
+func assertPresenceBits(label uint8) {
+	// TODO: re-enable
+	//if presenceMask&label != presenceMask {
+	//	panic(fmt.Sprintf("all presence bits in label not set: %v", label))
+	//}
+}
+
+func selectUnion(label uint8) bool {
+	assertPresenceBits(label)
+	return label&valueMask != 0
+}
+
+func selectIntersection(label uint8) bool {
+	assertPresenceBits(label)
+	return label&valueMask == valueMask
+}
+
+func selectDifference(label uint8) bool {
+	assertPresenceBits(label)
+	return label&valueMask == inputAValue
+}
+
+func selectSymmetricDifference(label uint8) bool {
+	assertPresenceBits(label)
+	vals := label & valueMask
+	return vals == inputAValue || vals == inputBValue
+}

--- a/geom/doubly_connected_edge_list.go
+++ b/geom/doubly_connected_edge_list.go
@@ -642,6 +642,9 @@ func (d *doublyConnectedEdgeList) extractPolygons(include func(uint8) bool) []Po
 			}
 			rings = append(rings, ring)
 		}
+
+		// Construct the polygon.
+		orderCCWRingFirst(rings)
 		poly, err := NewPolygonFromRings(rings)
 		if err != nil {
 			panic(fmt.Sprintf("could not create Polygon: %v", err))
@@ -712,4 +715,15 @@ func findFacesMakingPolygon(include func(uint8) bool, start *faceRecord) []*face
 		list = append(list, f)
 	}
 	return list
+}
+
+// orderCCWRingFirst reorders rings such that if it contains at least one CCW
+// ring, then a CCW ring is the first element.
+func orderCCWRingFirst(rings []LineString) {
+	for i, r := range rings {
+		if ccw := signedAreaOfLinearRing(r, nil) > 0; ccw {
+			rings[i], rings[0] = rings[0], rings[i]
+			return
+		}
+	}
 }

--- a/geom/doubly_connected_edge_list.go
+++ b/geom/doubly_connected_edge_list.go
@@ -30,7 +30,7 @@ type vertexRecord struct {
 	incident *halfEdgeRecord
 }
 
-func newDCELFromPolygon(poly Polygon, label uint8) *doublyConnectedEdgeList {
+func newDCELFromPolygon(poly Polygon, mask uint8) *doublyConnectedEdgeList {
 	poly = poly.ForceCCW()
 
 	dcel := &doublyConnectedEdgeList{vertices: make(map[XY]*vertexRecord)}
@@ -55,11 +55,12 @@ func newDCELFromPolygon(poly Polygon, label uint8) *doublyConnectedEdgeList {
 	infFace := &faceRecord{
 		outerComponent:  nil, // left nil
 		innerComponents: nil, // populated later
+		label:           presenceMask & mask,
 	}
 	polyFace := &faceRecord{
 		outerComponent:  nil, // populated later
 		innerComponents: nil, // populated later
-		label:           label,
+		label:           mask,
 	}
 	dcel.faces = append(dcel.faces, infFace, polyFace)
 
@@ -67,12 +68,14 @@ func newDCELFromPolygon(poly Polygon, label uint8) *doublyConnectedEdgeList {
 		interiorFace := polyFace
 		exteriorFace := infFace
 		if ringIdx > 0 {
-			// For inner rings, the exterior face is a hole rather than the
-			// infinite face.
-			exteriorFace = &faceRecord{
+			holeFace := &faceRecord{
 				outerComponent:  nil, // left nil
 				innerComponents: nil, // populated later
+				label:           presenceMask & mask,
 			}
+			// For inner rings, the exterior face is a hole rather than the
+			// infinite face.
+			exteriorFace = holeFace
 			dcel.faces = append(dcel.faces, exteriorFace)
 		}
 

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -214,7 +214,7 @@ func TestGraphTriangle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel := newDCELFromPolygon(poly.AsPolygon(), 0b01)
+	dcel := newDCELFromPolygon(poly.AsPolygon(), inputAMask)
 
 	/*
 
@@ -254,8 +254,8 @@ func TestGraphTriangle(t *testing.T) {
 		[]XY{v0, v1, v2},
 	)
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b01)
+	eqUint8(t, f0.label, inputAPresent)
+	eqUint8(t, f1.label, inputAPresent|inputAValue)
 }
 
 func TestGraphWithHoles(t *testing.T) {
@@ -302,7 +302,7 @@ func TestGraphWithHoles(t *testing.T) {
 		V0                                                        V1
 	*/
 
-	dcel := newDCELFromPolygon(poly.AsPolygon(), 0b10)
+	dcel := newDCELFromPolygon(poly.AsPolygon(), inputBMask)
 
 	eqInt(t, len(dcel.vertices), 12)
 	eqInt(t, len(dcel.halfEdges), 24)
@@ -347,10 +347,10 @@ func TestGraphWithHoles(t *testing.T) {
 		[]XY{v8, v11, v10, v9},
 	)
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b10)
-	eqUint8(t, f2.label, 0b00)
-	eqUint8(t, f3.label, 0b00)
+	eqUint8(t, f0.label, inputBPresent)
+	eqUint8(t, f1.label, inputBPresent|inputBValue)
+	eqUint8(t, f2.label, inputBPresent)
+	eqUint8(t, f3.label, inputBPresent)
 }
 
 func TestGraphReNode(t *testing.T) {
@@ -358,7 +358,7 @@ func TestGraphReNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel := newDCELFromPolygon(poly.AsPolygon(), 0b01)
+	dcel := newDCELFromPolygon(poly.AsPolygon(), inputAMask)
 
 	other, err := UnmarshalWKT("POLYGON((0 1,2 1,1 3,0 1))")
 	if err != nil {
@@ -404,8 +404,8 @@ func TestGraphReNode(t *testing.T) {
 		[]XY{v0, v1, v2, v3, v4},
 	)
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b01)
+	eqUint8(t, f0.label, inputAPresent)
+	eqUint8(t, f1.label, inputAPresent|inputAValue)
 }
 
 func TestGraphReNodeTwoCutsInOneEdge(t *testing.T) {
@@ -413,7 +413,7 @@ func TestGraphReNodeTwoCutsInOneEdge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel := newDCELFromPolygon(poly.AsPolygon(), 0b10)
+	dcel := newDCELFromPolygon(poly.AsPolygon(), inputBMask)
 
 	other, err := UnmarshalWKT("POLYGON((0 -1,1 1,2 -1,0 -1))")
 	if err != nil {
@@ -459,8 +459,8 @@ func TestGraphReNodeTwoCutsInOneEdge(t *testing.T) {
 		[]XY{v0, v1, v2, v3, v4},
 	)
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b10)
+	eqUint8(t, f0.label, inputBPresent)
+	eqUint8(t, f1.label, inputBPresent|inputBValue)
 }
 
 func TestGraphReNodeOverlappingEdge(t *testing.T) {
@@ -468,7 +468,7 @@ func TestGraphReNodeOverlappingEdge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel := newDCELFromPolygon(poly.AsPolygon(), 0b01)
+	dcel := newDCELFromPolygon(poly.AsPolygon(), inputAMask)
 
 	other, err := UnmarshalWKT("POLYGON((1 2,2 2,2 3,1 3,1 2))")
 	if err != nil {
@@ -512,8 +512,8 @@ func TestGraphReNodeOverlappingEdge(t *testing.T) {
 		[]XY{v4, v3, v2, v1, v0},
 	)
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b01)
+	eqUint8(t, f0.label, inputAPresent)
+	eqUint8(t, f1.label, inputAPresent|inputAValue)
 }
 
 func TestGraphOverlayDisjoint(t *testing.T) {
@@ -521,13 +521,13 @@ func TestGraphOverlayDisjoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcelA := newDCELFromPolygon(polyA.AsPolygon(), 0b01)
+	dcelA := newDCELFromPolygon(polyA.AsPolygon(), inputAMask)
 
 	polyB, err := UnmarshalWKT("POLYGON((2 2,2 3,3 3,3 2,2 2))")
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcelB := newDCELFromPolygon(polyB.AsPolygon(), 0b10)
+	dcelB := newDCELFromPolygon(polyB.AsPolygon(), inputBMask)
 
 	dcelA.reNodeGraph(polyB.AsPolygon())
 	dcelB.reNodeGraph(polyA.AsPolygon())
@@ -579,9 +579,11 @@ func TestGraphOverlayDisjoint(t *testing.T) {
 	CheckFaceComponents(t, f1, []XY{v0, v1, v2, v3})
 	CheckFaceComponents(t, f2, []XY{v4, v5, v6, v7})
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b01)
-	eqUint8(t, f2.label, 0b10)
+	// TODO: The parts of the test below were commented out to make it pass,
+	// but the behaviour is not correct.
+	eqUint8(t, f0.label, inputAPresent|inputBPresent)
+	eqUint8(t, f1.label, inputAPresent /*|inputBPresent*/ |inputAValue)
+	eqUint8(t, f2.label /*inputAPresent|*/, inputBPresent|inputBValue)
 }
 
 func TestGraphOverlayIntersecting(t *testing.T) {
@@ -589,13 +591,13 @@ func TestGraphOverlayIntersecting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcelA := newDCELFromPolygon(polyA.AsPolygon(), 0b01)
+	dcelA := newDCELFromPolygon(polyA.AsPolygon(), inputAMask)
 
 	polyB, err := UnmarshalWKT("POLYGON((0 1,2 1,1 3,0 1))")
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcelB := newDCELFromPolygon(polyB.AsPolygon(), 0b10)
+	dcelB := newDCELFromPolygon(polyB.AsPolygon(), inputBMask)
 
 	dcelA.reNodeGraph(polyB.AsPolygon())
 	dcelB.reNodeGraph(polyA.AsPolygon())
@@ -650,10 +652,77 @@ func TestGraphOverlayIntersecting(t *testing.T) {
 	CheckFaceComponents(t, f2, []XY{v5, v4, v3, v2, v6, v7})
 	CheckFaceComponents(t, f3, []XY{v4, v2, v3})
 
-	eqUint8(t, f0.label, 0b00)
-	eqUint8(t, f1.label, 0b01)
-	eqUint8(t, f2.label, 0b10)
-	eqUint8(t, f3.label, 0b11)
+	eqUint8(t, f0.label, presenceMask)
+	eqUint8(t, f1.label, presenceMask|inputAValue)
+	eqUint8(t, f2.label, presenceMask|inputBValue)
+	eqUint8(t, f3.label, presenceMask|inputAValue|inputBValue)
+}
+
+func TestGraphOverlayInside(t *testing.T) {
+	polyA, err := UnmarshalWKT("POLYGON((0 0,3 0,3 3,0 3,0 0))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dcelA := newDCELFromPolygon(polyA.AsPolygon(), inputAMask)
+
+	polyB, err := UnmarshalWKT("POLYGON((1 1,2 1,2 2,1 2,1 1))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dcelB := newDCELFromPolygon(polyB.AsPolygon(), inputBMask)
+
+	dcelA.reNodeGraph(polyB.AsPolygon())
+	dcelB.reNodeGraph(polyA.AsPolygon())
+
+	dcelA.overlay(dcelB)
+
+	/*
+	  v3-----------------v2
+	   |                 |
+	   |                 |
+	   |    v7-----v6    |
+	   |     | f2  |     |
+	   |     |     |     |
+	   |    v4-----v5    |  f0
+	   |                 |
+	   |       f1        |
+	  v0-----------------v1
+
+	*/
+
+	v0 := XY{0, 0}
+	v1 := XY{3, 0}
+	v2 := XY{3, 3}
+	v3 := XY{0, 3}
+	v4 := XY{1, 1}
+	v5 := XY{2, 1}
+	v6 := XY{2, 2}
+	v7 := XY{1, 2}
+
+	eqInt(t, len(dcelA.vertices), 8)
+	eqInt(t, len(dcelA.halfEdges), 16)
+
+	CheckHalfEdgeLoop(t, findEdge(t, dcelA, v0, v1), []XY{v0, v1, v2, v3})
+	CheckHalfEdgeLoop(t, findEdge(t, dcelA, v1, v0), []XY{v0, v3, v2, v1})
+	CheckHalfEdgeLoop(t, findEdge(t, dcelA, v4, v5), []XY{v4, v5, v6, v7})
+	CheckHalfEdgeLoop(t, findEdge(t, dcelA, v5, v4), []XY{v5, v4, v7, v6})
+
+	eqInt(t, len(dcelA.faces), 3)
+	// TODO: trial and error was used to find the right permutation of face
+	// labels. It relies on the permutation being stable. There is probably a
+	// better way to test this.
+	f0 := dcelA.faces[1]
+	f1 := dcelA.faces[2]
+	f2 := dcelA.faces[0]
+	CheckFaceComponents(t, f0, nil, []XY{v1, v0, v3, v2})
+	CheckFaceComponents(t, f1, []XY{v0, v1, v2, v3}, []XY{v7, v6, v5, v4})
+	CheckFaceComponents(t, f2, []XY{v4, v5, v6, v7})
+
+	// TODO: The parts of the test below were commented out to make it pass,
+	// but the behaviour is not correct.
+	eqUint8(t, f0.label, inputAPresent /*|inputBPresent*/)
+	eqUint8(t, f1.label, inputAPresent|inputBPresent|inputAValue)
+	eqUint8(t, f2.label /*inputAPresent|*/, inputBPresent /*|inputAValue*/ |inputBValue)
 }
 
 func eqInt(t *testing.T, i1, i2 int) {

--- a/geom/doubly_connected_edge_list_test.go
+++ b/geom/doubly_connected_edge_list_test.go
@@ -579,11 +579,9 @@ func TestGraphOverlayDisjoint(t *testing.T) {
 	CheckFaceComponents(t, f1, []XY{v0, v1, v2, v3})
 	CheckFaceComponents(t, f2, []XY{v4, v5, v6, v7})
 
-	// TODO: The parts of the test below were commented out to make it pass,
-	// but the behaviour is not correct.
 	eqUint8(t, f0.label, inputAPresent|inputBPresent)
-	eqUint8(t, f1.label, inputAPresent /*|inputBPresent*/ |inputAValue)
-	eqUint8(t, f2.label /*inputAPresent|*/, inputBPresent|inputBValue)
+	eqUint8(t, f1.label, inputAPresent|inputBPresent|inputAValue)
+	eqUint8(t, f2.label, inputAPresent|inputBPresent|inputBValue)
 }
 
 func TestGraphOverlayIntersecting(t *testing.T) {
@@ -718,11 +716,9 @@ func TestGraphOverlayInside(t *testing.T) {
 	CheckFaceComponents(t, f1, []XY{v0, v1, v2, v3}, []XY{v7, v6, v5, v4})
 	CheckFaceComponents(t, f2, []XY{v4, v5, v6, v7})
 
-	// TODO: The parts of the test below were commented out to make it pass,
-	// but the behaviour is not correct.
-	eqUint8(t, f0.label, inputAPresent /*|inputBPresent*/)
+	eqUint8(t, f0.label, inputAPresent|inputBPresent)
 	eqUint8(t, f1.label, inputAPresent|inputBPresent|inputAValue)
-	eqUint8(t, f2.label /*inputAPresent|*/, inputBPresent /*|inputAValue*/ |inputBValue)
+	eqUint8(t, f2.label, inputAPresent|inputBPresent|inputAValue|inputBValue)
 }
 
 func eqInt(t *testing.T, i1, i2 int) {


### PR DESCRIPTION
## Description

- Considers holes when extracting Polygons from DCELs.

- Revamps the face label system, to keep track of which labels have are populated (otherwise it was impossible to tell between a "0" label, and a label that hadn't been set yet).

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) Not yet.

## Related Issue

- N/A

## Benchmark Results

- N/A