### PR TITLE
Handle LineString inputs that have overlapping segments

### DIFF
--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -634,16 +634,6 @@ func TestBinaryOp(t *testing.T) {
 			revDiff: "POINT(0.5 0.5)",
 			symDiff: "GEOMETRYCOLLECTION(POINT(0.5 0.5),LINESTRING(0 0,0 1),LINESTRING(0 1,1 1),LINESTRING(1 1,1 0),LINESTRING(1 0,0 0))",
 		},
-		{
-			// Reproduces a bug that caused an infinite loop.
-			input1:  "LINESTRING(-1 0.5,4 0.5)",
-			input2:  "LINESTRING(0 0,1 1,0 0)",
-			union:   "MULTILINESTRING((-1 0.5,0.5 0.5),(0.5 0.5,4 0.5),(0 0,0.5 0.5),(0.5 0.5,1 1))",
-			inter:   "POINT(0.5 0.5)",
-			fwdDiff: "MULTILINESTRING((-1 0.5,0.5 0.5),(0.5 0.5,4 0.5))",
-			revDiff: "MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1))",
-			symDiff: "MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1),(-1 0.5,0.5 0.5),(0.5 0.5,4 0.5))",
-		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g1 := geomFromWKT(t, geomCase.input1)

--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -618,6 +618,32 @@ func TestBinaryOp(t *testing.T) {
 			revDiff: "GEOMETRYCOLLECTION EMPTY",
 			symDiff: "POLYGON((0 0,0 1,0.5 0.5,1 0,0 0))",
 		},
+		{
+			/*
+			   +-------+
+			   |       |
+			   |   +   |
+			   |       |
+			   +-------+
+			*/
+			input1:  "LINESTRING(0 0,0 1,1 1,1 0,0 0,0 1)", // overlapping line segment
+			input2:  "POINT(0.5 0.5)",
+			union:   "GEOMETRYCOLLECTION(POINT(0.5 0.5),LINESTRING(0 0,0 1),LINESTRING(0 1,1 1),LINESTRING(1 1,1 0),LINESTRING(1 0,0 0))",
+			inter:   "GEOMETRYCOLLECTION EMPTY",
+			fwdDiff: "MULTILINESTRING((0 0,0 1),(0 1,1 1),(1 1,1 0),(1 0,0 0))",
+			revDiff: "POINT(0.5 0.5)",
+			symDiff: "GEOMETRYCOLLECTION(POINT(0.5 0.5),LINESTRING(0 0,0 1),LINESTRING(0 1,1 1),LINESTRING(1 1,1 0),LINESTRING(1 0,0 0))",
+		},
+		{
+			// Reproduces a bug that caused an infinite loop.
+			input1:  "LINESTRING(-1 0.5,4 0.5)",
+			input2:  "LINESTRING(0 0,1 1,0 0)",
+			union:   "MULTILINESTRING((-1 0.5,0.5 0.5),(0.5 0.5,4 0.5),(0 0,0.5 0.5),(0.5 0.5,1 1))",
+			inter:   "POINT(0.5 0.5)",
+			fwdDiff: "MULTILINESTRING((-1 0.5,0.5 0.5),(0.5 0.5,4 0.5))",
+			revDiff: "MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1))",
+			symDiff: "MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1),(-1 0.5,0.5 0.5),(0.5 0.5,4 0.5))",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g1 := geomFromWKT(t, geomCase.input1)


### PR DESCRIPTION
## Description

Add handling for input linear elements that have overlapping segments.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A
