### PR TITLE
Add workaround for near-collinear points being output from Graham scan

### DIFF
--- a/geom/alg_convex_hull_test.go
+++ b/geom/alg_convex_hull_test.go
@@ -188,6 +188,11 @@ func TestConvexHull(t *testing.T) {
 			input:  `MULTIPOINT((0.532 0.548),(0.385 0.378),(0.428 0.463),(0.506 0.443),(0.372 0.613),(0.648 0.636),(0.417 0.447))`,
 			output: `POLYGON((0.385 0.378,0.506 0.443,0.648 0.636,0.372 0.613,0.385 0.378))`,
 		},
+		{
+			// collinear points, but with numerical issues
+			input:  `MULTIPOINT(0 1,0.333333333333333 0.666666666666667,1 0)`,
+			output: `LINESTRING(1 0,0 1)`,
+		},
 
 		// Reproduced a bug.
 		{

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -70,3 +70,10 @@ func (w XY) Less(o XY) bool {
 	}
 	return w.Y < o.Y
 }
+
+// squareDistanceTo calculates the square of the distance between this XY and
+// another.
+func (w XY) squareDistanceTo(o XY) float64 {
+	s := w.Sub(o)
+	return s.Dot(s)
+}


### PR DESCRIPTION
## Description

Adds a fix for a crash in `ConvexHull` where the input consists of near-collinear points.

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A
