### PR TITLE
Only sort verticies if there are at least 3

### DIFF
--- a/geom/dcel_overlay.go
+++ b/geom/dcel_overlay.go
@@ -115,18 +115,17 @@ func (d *doublyConnectedEdgeList) fixVertices() {
 
 func (d *doublyConnectedEdgeList) fixVertex(v *vertexRecord) {
 	// Sort the edges radially.
-	//
-	// TODO: Might be able to use regular vector operations rather than
-	// trigonometry here.
-	sort.Slice(v.incidents, func(i, j int) bool {
-		ei := v.incidents[i]
-		ej := v.incidents[j]
-		di := ei.twin.origin.coords.Sub(ei.origin.coords)
-		dj := ej.twin.origin.coords.Sub(ej.origin.coords)
-		aI := math.Atan2(di.Y, di.X)
-		aJ := math.Atan2(dj.Y, dj.X)
-		return aI < aJ
-	})
+	if len(v.incidents) >= 3 {
+		sort.Slice(v.incidents, func(i, j int) bool {
+			ei := v.incidents[i]
+			ej := v.incidents[j]
+			di := ei.twin.origin.coords.Sub(ei.origin.coords)
+			dj := ej.twin.origin.coords.Sub(ej.origin.coords)
+			aI := math.Atan2(di.Y, di.X)
+			aJ := math.Atan2(dj.Y, dj.X)
+			return aI < aJ
+		})
+	}
 
 	// Fix pointers.
 	for i := range v.incidents {


### PR DESCRIPTION
## Description

During DCEL generation, we "fix" nodes by re-ordering the edges coming out of them, and re-creating linkages between them (next and prev pointers).

This is wasteful if there are only 2 edges, since their ordering doesn't matter.

Also removes a TODO about not using trigonometry, since there isn't a cleaner way to do it with just vector operations.

## Check List

Have you:

- Added unit tests? N/A - existing tests are fine.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/280

## Benchmark Results

- N/A