### PR TITLE
Remove inner components from DCEL faces

### DIFF
--- a/geom/alg_binary_op.go
+++ b/geom/alg_binary_op.go
@@ -71,15 +71,21 @@ func binaryOp(a, b Geometry, include func(uint8) bool) (Geometry, error) {
 }
 
 func createOverlay(a, b Geometry) (*doublyConnectedEdgeList, error) {
-	a, b, err := reNodeGeometries(a, b)
+	aGhost := connectGeometry(a)
+	bGhost := connectGeometry(b)
+	joinGhost := connectGeometries(a, b)
+	ghosts := mergeMultiLineStrings([]MultiLineString{aGhost, bGhost, joinGhost.AsMultiLineString()})
+
+	a, b, ghosts, err := reNodeGeometries(a, b, ghosts)
 	if err != nil {
 		return nil, err
 	}
-	dcelA, err := newDCELFromGeometry(a, inputAMask)
+
+	dcelA, err := newDCELFromGeometry(a, ghosts, inputAMask)
 	if err != nil {
 		return nil, err
 	}
-	dcelB, err := newDCELFromGeometry(b, inputBMask)
+	dcelB, err := newDCELFromGeometry(b, ghosts, inputBMask)
 	if err != nil {
 		return nil, err
 	}

--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -137,11 +137,11 @@ func TestBinaryOp(t *testing.T) {
 			*/
 			input1:  "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,2 3,2 1,0 1)))",
 			input2:  "MULTIPOLYGON(((4 0,4 1,5 1,5 0,4 0)),((1 0,1 2,3 2,3 0,1 0)))",
-			union:   "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,2 3,2 2,3 2,3 0,1 0,1 1,0 1)),((4 0,4 1,5 1,5 0,4 0)))",
+			union:   "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,1 3,2 3,2 2,3 2,3 1,3 0,1 0,1 1,0 1)),((4 0,4 1,5 1,5 0,4 0)))",
 			inter:   "POLYGON((2 2,2 1,1 1,1 2,2 2))",
-			fwdDiff: "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,2 3,2 2,1 2,1 1,0 1)))",
-			revDiff: "MULTIPOLYGON(((4 0,4 1,5 1,5 0,4 0)),((1 0,1 1,2 1,2 2,3 2,3 0,1 0)))",
-			symDiff: "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,2 3,2 2,1 2,1 1,0 1)),((1 1,2 1,2 2,3 2,3 0,1 0,1 1)),((4 0,4 1,5 1,5 0,4 0)))",
+			fwdDiff: "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,1 3,2 3,2 2,1 2,1 1,0 1)))",
+			revDiff: "MULTIPOLYGON(((4 0,4 1,5 1,5 0,4 0)),((1 0,1 1,2 1,2 2,3 2,3 1,3 0,1 0)))",
+			symDiff: "MULTIPOLYGON(((0 4,0 5,1 5,1 4,0 4)),((0 1,0 3,1 3,2 3,2 2,1 2,1 1,0 1)),((1 1,2 1,2 2,3 2,3 1,3 0,1 0,1 1)),((4 0,4 1,5 1,5 0,4 0)))",
 		},
 		{
 			/*
@@ -190,7 +190,7 @@ func TestBinaryOp(t *testing.T) {
 
 			*/
 			input1:  "MULTIPOLYGON(((0 2,1 1,2 2,1 3,0 2)),((2 2,3 1,4 2,3 3,2 2)))",
-			input2:  "MULTIPOLYGON(((1 0,0 1,1 2,2 1,1 0)),((3 0,4 1,3 2,2 1,3 0)))",
+			input2:  "MULTIPOLYGON(((0 1,1 2,2 1,1 0,0 1)),((2 1,3 0,4 1,3 2,2 1)))",
 			union:   "MULTIPOLYGON(((0.5 1.5,0 2,1 3,2 2,1.5 1.5,2 1,1 0,0 1,0.5 1.5)),((2.5 1.5,2 2,3 3,4 2,3.5 1.5,4 1,3 0,2 1,2.5 1.5)))",
 			inter:   "MULTIPOLYGON(((1.5 1.5,1 1,0.5 1.5,1 2,1.5 1.5)),((3.5 1.5,3 1,2.5 1.5,3 2,3.5 1.5)))",
 			fwdDiff: "MULTIPOLYGON(((0.5 1.5,0 2,1 3,2 2,1.5 1.5,1 2,0.5 1.5)),((2.5 1.5,2 2,3 3,4 2,3.5 1.5,3 2,2.5 1.5)))",
@@ -325,8 +325,8 @@ func TestBinaryOp(t *testing.T) {
 			   |A&B|
 			   +---+
 			*/
-			input1:  "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((1 2,2 2,2 3,1 3,1 2)))",
-			input2:  "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 1,3 1,3 2,2 2,2 1)))",
+			input1:  "MULTIPOLYGON(((1 1,1 0,0 0,0 1,1 1)),((1 2,2 2,2 3,1 3,1 2)))",
+			input2:  "MULTIPOLYGON(((1 1,1 0,0 0,0 1,1 1)),((2 1,3 1,3 2,2 2,2 1)))",
 			union:   "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 2,1 2,1 3,2 3,2 2)),((2 2,3 2,3 1,2 1,2 2)))",
 			inter:   "GEOMETRYCOLLECTION(POINT(2 2),POLYGON((0 0,0 1,1 1,1 0,0 0)))",
 			fwdDiff: "POLYGON((2 2,1 2,1 3,2 3,2 2))",
@@ -576,11 +576,11 @@ func TestBinaryOp(t *testing.T) {
 			*/
 			input1:  "POLYGON((0 0,0 2,2 2,2 0,0 0))",
 			input2:  "MULTIPOINT(1 1,3 1)",
-			union:   "GEOMETRYCOLLECTION(POINT(3 1),POLYGON((0 0,0 2,2 2,2 0,0 0)))",
+			union:   "GEOMETRYCOLLECTION(POINT(3 1),POLYGON((0 0,0 2,2 2,2 1,2 0,0 0)))",
 			inter:   "POINT(1 1)",
-			fwdDiff: "POLYGON((0 0,0 2,2 2,2 0,0 0))",
+			fwdDiff: "POLYGON((0 0,0 2,2 2,2 1,2 0,0 0))",
 			revDiff: "POINT(3 1)",
-			symDiff: "GEOMETRYCOLLECTION(POINT(3 1),POLYGON((0 0,0 2,2 2,2 0,0 0)))",
+			symDiff: "GEOMETRYCOLLECTION(POINT(3 1),POLYGON((0 0,0 2,2 2,2 1,2 0,0 0)))",
 		},
 		{
 			/*
@@ -741,7 +741,7 @@ func TestBinaryOp(t *testing.T) {
 		},
 		{
 			input1:  "POLYGON((0 0,1 1,1 0,0 0))",
-			input2:  "POLYGON((2 1,2 2,3 2,3 1,2 1))",
+			input2:  "POLYGON((2 2,3 2,3 1,2 1,2 2))",
 			union:   "MULTIPOLYGON(((0 0,1 0,1 1,0 0)),((2 1,2 2,3 2,3 1,2 1)))",
 			inter:   "GEOMETRYCOLLECTION EMPTY",
 			fwdDiff: "POLYGON((0 0,1 1,1 0,0 0))",
@@ -750,21 +750,12 @@ func TestBinaryOp(t *testing.T) {
 		},
 		{
 			input1:  "LINESTRING(0 1,1 0)",
-			input2:  "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 1,2 2,3 2,3 1,2 1)))",
-			union:   "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 1,2 2,3 2,3 1,2 1)))",
+			input2:  "MULTIPOLYGON(((1 1,1 0,0 0,0 1,1 1)),((2 1,2 2,3 2,3 1,2 1)))",
+			union:   "MULTIPOLYGON(((1 1,1 0,0 0,0 1,1 1)),((2 1,2 2,3 2,3 1,2 1)))",
 			inter:   "LINESTRING(0 1,1 0)",
 			fwdDiff: "GEOMETRYCOLLECTION EMPTY",
 			revDiff: "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 1,2 2,3 2,3 1,2 1)))",
 			symDiff: "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 1,2 2,3 2,3 1,2 1)))",
-		},
-		{
-			input1:  "LINESTRING(0 1,1 3)",
-			input2:  "MULTIPOLYGON(((1 0,0 1,0.5 1.5,1 1,1.5 1.5,2 1,1 0)),((1.5 1.5,1 2,0.5 1.5,0 2,1 3,2 2,1.5 1.5)),((3.5 1.5,4 1,3 0,2 1,2.5 1.5,3 1,3.5 1.5)),((3.5 1.5,3 2,2.5 1.5,2 2,3 3,4 2,3.5 1.5)))",
-			union:   "GEOMETRYCOLLECTION(LINESTRING(0 1,0.333333333333333 1.66666666666667),POLYGON((1 0,0 1,0.5 1.5,1 1,1.5 1.5,2 1,1 0)),POLYGON((1.5 1.5,1 2,0.5 1.5,0.333333333333333 1.66666666666667,0 2,1 3,2 2,1.5 1.5)),POLYGON((3.5 1.5,4 1,3 0,2 1,2.5 1.5,3 1,3.5 1.5)),POLYGON((3.5 1.5,3 2,2.5 1.5,2 2,3 3,4 2,3.5 1.5)))",
-			inter:   "GEOMETRYCOLLECTION(POINT(0 1),LINESTRING(0.333333333333333 1.66666666666667,1 3))",
-			fwdDiff: "LINESTRING(0 1,0.333333333333333 1.66666666666667)",
-			revDiff: "MULTIPOLYGON(((1 0,0 1,0.5 1.5,1 1,1.5 1.5,2 1,1 0)),((1.5 1.5,1 2,0.5 1.5,0.333333333333333 1.66666666666667,0 2,1 3,2 2,1.5 1.5)),((3.5 1.5,4 1,3 0,2 1,2.5 1.5,3 1,3.5 1.5)),((3.5 1.5,3 2,2.5 1.5,2 2,3 3,4 2,3.5 1.5)))",
-			symDiff: "GEOMETRYCOLLECTION(LINESTRING(0 1,0.333333333333333 1.66666666666667),POLYGON((1 0,0 1,0.5 1.5,1 1,1.5 1.5,2 1,1 0)),POLYGON((1.5 1.5,1 2,0.5 1.5,0.333333333333333 1.66666666666667,0 2,1 3,2 2,1.5 1.5)),POLYGON((3.5 1.5,4 1,3 0,2 1,2.5 1.5,3 1,3.5 1.5)),POLYGON((3.5 1.5,3 2,2.5 1.5,2 2,3 3,4 2,3.5 1.5)))",
 		},
 		{
 			input1:  "POINT(5 5)",
@@ -790,6 +781,11 @@ func TestBinaryOp(t *testing.T) {
 			input1: "LINESTRING(1 2.1,2.1 1)",
 			input2: "POLYGON((0 0,0 10,10 10,10 0,0 0),(1.5 1.5,8.5 1.5,8.5 8.5,1.5 8.5,1.5 1.5))",
 			inter:  "MULTILINESTRING((1 2.1,1.5 1.6),(1.6 1.5,2.1 1))",
+		},
+		{
+			input1: "LINESTRING(1 2,2 3)",
+			input2: "MULTIPOLYGON(((1 1,1 0,0 0,0 1,1 1)),((1 2,2 2,2 3,1 3,1 2)))",
+			union:  "MULTIPOLYGON(((1 1,1 0,0 0,0 1,1 1)),((1 2,2 2,2 3,1 3,1 2)))",
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/geom/dcel_ghosts.go
+++ b/geom/dcel_ghosts.go
@@ -1,0 +1,152 @@
+package geom
+
+import "fmt"
+
+func connectGeometry(g Geometry) MultiLineString {
+	var ghostLSs []LineString
+	var seenFirst bool
+	var first XY
+	addComponent := func(pt Point) {
+		xy, ok := pt.XY()
+		if !ok {
+			return
+		}
+		if seenFirst {
+			if first != xy {
+				seq := NewSequence([]float64{first.X, first.Y, xy.X, xy.Y}, DimXY)
+				ghostLS, err := NewLineString(seq)
+				if err != nil {
+					// Can't happen, since first and pt are not the same.
+					panic(fmt.Sprintf("could not construct LineString: %v", err))
+				}
+				ghostLSs = append(ghostLSs, ghostLS)
+			}
+		} else {
+			seenFirst = true
+			first = xy
+		}
+	}
+
+	switch g.Type() {
+	case TypePoint:
+		// A single Point is already trivially connected.
+	case TypeMultiPoint:
+		mp := g.AsMultiPoint()
+		n := mp.NumPoints()
+		for i := 0; i < n; i++ {
+			addComponent(mp.PointN(i))
+		}
+	case TypeLineString:
+		// LineStrings are already connected.
+	case TypeMultiLineString:
+		mls := g.AsMultiLineString()
+		n := mls.NumLineStrings()
+		for i := 0; i < n; i++ {
+			ls := mls.LineStringN(i)
+			addComponent(ls.StartPoint())
+		}
+	case TypePolygon:
+		poly := g.AsPolygon()
+		addComponent(poly.ExteriorRing().StartPoint())
+		n := poly.NumInteriorRings()
+		for i := 0; i < n; i++ {
+			addComponent(poly.InteriorRingN(i).StartPoint())
+		}
+	case TypeMultiPolygon:
+		mp := g.AsMultiPolygon()
+		n := mp.NumPolygons()
+		for i := 0; i < n; i++ {
+			poly := mp.PolygonN(i)
+			addComponent(poly.ExteriorRing().StartPoint())
+			m := poly.NumInteriorRings()
+			for j := 0; j < m; j++ {
+				addComponent(poly.InteriorRingN(j).StartPoint())
+			}
+		}
+	case TypeGeometryCollection:
+		gc := g.AsGeometryCollection()
+		n := gc.NumGeometries()
+		for i := 0; i < n; i++ {
+			addComponent(pointOnGeometry(gc.GeometryN(i)))
+		}
+	default:
+		panic(fmt.Sprintf("unknown geometry type: %v", g.Type()))
+	}
+
+	return NewMultiLineStringFromLineStrings(ghostLSs)
+}
+
+func connectGeometries(g1, g2 Geometry) LineString {
+	pt1 := pointOnGeometry(g1)
+	pt2 := pointOnGeometry(g2)
+
+	xy1, ok1 := pt1.XY()
+	xy2, ok2 := pt2.XY()
+	if !ok1 || !ok2 || xy1 == xy2 {
+		return LineString{}
+	}
+
+	coords := []float64{xy1.X, xy1.Y, xy2.X, xy2.Y}
+	ls, err := NewLineString(NewSequence(coords, DimXY))
+	if err != nil {
+		// Can't happen, since we have already checked that xy1 != xy2.
+		panic(fmt.Sprintf("could not create lines string: %v", err))
+	}
+	return ls
+}
+
+func pointOnGeometry(g Geometry) Point {
+	switch g.Type() {
+	case TypePoint:
+		return g.AsPoint()
+	case TypeMultiPoint:
+		mp := g.AsMultiPoint()
+		n := mp.NumPoints()
+		for i := 0; i < n; i++ {
+			pt := mp.PointN(i)
+			if !pt.IsEmpty() {
+				return pt
+			}
+		}
+		return Point{}
+	case TypeLineString:
+		return g.AsLineString().StartPoint()
+	case TypeMultiLineString:
+		mls := g.AsMultiLineString()
+		n := mls.NumLineStrings()
+		for i := 0; i < n; i++ {
+			pt := mls.LineStringN(i).StartPoint()
+			if !pt.IsEmpty() {
+				return pt
+			}
+		}
+		return Point{}
+	case TypePolygon:
+		return pointOnGeometry(g.Boundary())
+	case TypeMultiPolygon:
+		return pointOnGeometry(g.Boundary())
+	case TypeGeometryCollection:
+		gc := g.AsGeometryCollection()
+		n := gc.NumGeometries()
+		for i := 0; i < n; i++ {
+			pt := pointOnGeometry(gc.GeometryN(i))
+			if !pt.IsEmpty() {
+				return pt
+			}
+		}
+		return Point{}
+	default:
+		panic(fmt.Sprintf("unknown geometry type: %v", g.Type()))
+	}
+}
+
+func mergeMultiLineStrings(mlss []MultiLineString) MultiLineString {
+	var lss []LineString
+	for _, mls := range mlss {
+		n := mls.NumLineStrings()
+		for i := 0; i < n; i++ {
+			lss = append(lss, mls.LineStringN(i))
+		}
+	}
+	return NewMultiLineStringFromLineStrings(lss)
+}

--- a/geom/dcel_overlay.go
+++ b/geom/dcel_overlay.go
@@ -1,17 +1,15 @@
 package geom
 
 import (
-	"errors"
-	"fmt"
 	"math"
 	"sort"
 )
 
 func (d *doublyConnectedEdgeList) overlay(other *doublyConnectedEdgeList) error {
 	d.overlayVertices(other)
-	faceLabels := d.overlayEdges(other)
+	d.overlayEdges(other)
 	d.fixVertices()
-	if err := d.reAssignFaces(faceLabels); err != nil {
+	if err := d.reAssignFaces(); err != nil {
 		return err
 	}
 	d.fixLabels()
@@ -27,38 +25,16 @@ func (d *doublyConnectedEdgeList) overlayVertices(other *doublyConnectedEdgeList
 			d.vertices[xy] = otherVert
 		}
 	}
-	for _, face := range other.faces {
-		if cmp := face.outerComponent; cmp != nil {
-			d.overlayVerticesInComponent(cmp)
-		}
-		for _, cmp := range face.innerComponents {
-			d.overlayVerticesInComponent(cmp)
-		}
-	}
-}
-
-func (d *doublyConnectedEdgeList) overlayVerticesInComponent(start *halfEdgeRecord) {
-	forEachEdge(start, func(e *halfEdgeRecord) {
+	for _, e := range other.halfEdges {
 		if existing, ok := d.vertices[e.origin.coords]; ok {
 			e.origin = existing
 		} else {
 			d.vertices[e.origin.coords] = e.origin
 		}
-	})
-}
-
-func forEachEdge(start *halfEdgeRecord, fn func(*halfEdgeRecord)) {
-	e := start
-	for {
-		fn(e)
-		e = e.next
-		if e == start {
-			break
-		}
 	}
 }
 
-func (d *doublyConnectedEdgeList) overlayEdges(other *doublyConnectedEdgeList) map[line]uint8 {
+func (d *doublyConnectedEdgeList) overlayEdges(other *doublyConnectedEdgeList) {
 	// Clear incidents lists, since we're going to re-compute them.
 	for _, vert := range d.vertices {
 		vert.incidents = nil
@@ -68,43 +44,24 @@ func (d *doublyConnectedEdgeList) overlayEdges(other *doublyConnectedEdgeList) m
 	}
 
 	edgeRecords := make(map[line]*halfEdgeRecord)
-	faceLabels := make(map[line]uint8)
 	for _, e := range d.halfEdges {
 		ln := line{e.origin.coords, e.next.origin.coords}
 		edgeRecords[ln] = e
 		e.origin.incidents = append(e.origin.incidents, e)
-		faceLabels[ln] = e.incident.label
 	}
 
-	for _, face := range other.faces {
-		if cmp := face.outerComponent; cmp != nil {
-			d.overlayEdgesInComponent(cmp, edgeRecords, faceLabels)
-		}
-		for _, cmp := range face.innerComponents {
-			d.overlayEdgesInComponent(cmp, edgeRecords, faceLabels)
-		}
-	}
-	return faceLabels
-}
-
-func (d *doublyConnectedEdgeList) overlayEdgesInComponent(start *halfEdgeRecord, edgeRecords map[line]*halfEdgeRecord, faceLabels map[line]uint8) {
-	forEachEdge(start, func(e *halfEdgeRecord) {
+	for _, e := range other.halfEdges {
 		ln := line{e.origin.coords, e.next.origin.coords}
-
-		label, ok := faceLabels[ln]
-		if !ok {
-			d.halfEdges = append(d.halfEdges, e)
-		}
-		label |= e.incident.label
-		faceLabels[ln] = label
-
 		if existing, ok := edgeRecords[ln]; ok {
-			existing.label |= e.label
+			existing.edgeLabel |= e.edgeLabel
+			existing.faceLabel |= e.faceLabel
 		} else {
 			edgeRecords[ln] = e
+			e.origin = d.vertices[ln.a]
 			e.origin.incidents = append(e.origin.incidents, e)
+			d.halfEdges = append(d.halfEdges, e)
 		}
-	})
+	}
 }
 
 func (d *doublyConnectedEdgeList) fixVertices() {
@@ -138,78 +95,34 @@ func (d *doublyConnectedEdgeList) fixVertex(v *vertexRecord) {
 
 // reAssignFaces clears the DCEL face list and creates new faces based on the
 // half edge loops.
-func (d *doublyConnectedEdgeList) reAssignFaces(faceLabels map[line]uint8) error {
-	// Find all boundary cycles, and categorise them as either outer components
-	// or inner components.
-	var innerComponents, outerComponents []*halfEdgeRecord
+func (d *doublyConnectedEdgeList) reAssignFaces() error {
+	// Find all cycles.
+	var cycles []*halfEdgeRecord
 	seen := make(map[*halfEdgeRecord]bool)
 	for _, e := range d.halfEdges {
 		if seen[e] {
 			continue
 		}
-		leftmostLowest := edgeLoopLeftmostLowest(e)
-		if edgeLoopIsOuterComponent(e) {
-			outerComponents = append(outerComponents, leftmostLowest)
-		} else {
-			innerComponents = append(innerComponents, leftmostLowest)
-		}
 		forEachEdge(e, func(e *halfEdgeRecord) {
 			seen[e] = true
 		})
-	}
-
-	// Group together boundary cycles that are for the same face.
-	var graph disjointEdgeSet
-	for _, e := range innerComponents {
-		graph.addSingleton(e)
-	}
-	for _, e := range outerComponents {
-		graph.addSingleton(e)
-	}
-	graph.addSingleton(nil) // nil represents the outer component of the infinite face
-
-	for _, leftmostLowest := range innerComponents {
-		nextLeft := d.findNextDownEdgeToTheLeft(leftmostLowest.origin.coords)
-		if nextLeft != nil {
-			// When there is no next left edge, then this indicates that the
-			// current component is the inner component of the infinite face.
-			// In this case, we *don't* want to find the lowest (or leftmost
-			// for tie) edge, since there is no actual loop.
-			nextLeft = edgeLoopLeftmostLowest(nextLeft)
-		}
-		if err := graph.union(leftmostLowest, nextLeft); err != nil {
-			return err
-		}
+		cycles = append(cycles, e)
 	}
 
 	// Construct new faces.
 	d.faces = nil
-	for _, set := range graph.sets {
-		f := new(faceRecord)
+	for _, cycle := range cycles {
+		f := &faceRecord{
+			cycle: cycle,
+			label: 0, // populated below
+		}
 		d.faces = append(d.faces, f)
-		for _, e := range set {
-			if e == nil || edgeLoopIsOuterComponent(e) {
-				if f.outerComponent != nil {
-					return errors.New("double outer component")
-				}
-				f.outerComponent = e
-			} else {
-				f.innerComponents = append(f.innerComponents, e)
-			}
-			if e != nil {
-				forEachEdge(e, func(e *halfEdgeRecord) {
-					ln := line{e.origin.coords, e.next.origin.coords}
-					f.label |= faceLabels[ln]
-					e.incident = f
-				})
-			}
-		}
-		if f.outerComponent == nil {
-			// The outer face never has geometries present on it, so we can
-			// just mark it's label as being populated now.
-			f.label |= populatedMask
-		}
+		forEachEdge(cycle, func(e *halfEdgeRecord) {
+			f.label |= e.faceLabel
+			e.incident = f
+		})
 	}
+
 	for _, face := range d.faces {
 		d.completePartialFaceLabel(face)
 	}
@@ -224,6 +137,9 @@ func (d *doublyConnectedEdgeList) reAssignFaces(faceLabels map[line]uint8) error
 func (d *doublyConnectedEdgeList) completePartialFaceLabel(face *faceRecord) {
 	labelIsComplete := func() bool {
 		return (face.label & populatedMask) == populatedMask
+	}
+	if labelIsComplete() {
+		return
 	}
 	expanded := make(map[*faceRecord]bool)
 	stack := []*faceRecord{face}
@@ -242,27 +158,26 @@ func (d *doublyConnectedEdgeList) completePartialFaceLabel(face *faceRecord) {
 			}
 		}
 	}
+
+	// It's possible that we're still missing part of the face label. This
+	// could happen if one of the inputs is a Point/MultiPoint input because
+	// its associated ghost lines would not add to the label pool. We can
+	// safely fill in the presence bits for this case.
+	face.label |= populatedMask
 }
 
 // adjacentFaces finds all of the faces that adjacent to f.
 func adjacentFaces(f *faceRecord) []*faceRecord {
-	set := make(map[*faceRecord]struct{})
-	if cmp := f.outerComponent; cmp != nil {
-		forEachEdge(cmp, func(e *halfEdgeRecord) {
-			set[e.twin.incident] = struct{}{}
-		})
-	}
-	for _, cmp := range f.innerComponents {
-		forEachEdge(cmp, func(e *halfEdgeRecord) {
-			set[e.twin.incident] = struct{}{}
-		})
-	}
-
-	faces := make([]*faceRecord, 0, len(set))
-	for face := range set {
-		faces = append(faces, face)
-	}
-	return faces
+	var adjacent []*faceRecord
+	set := make(map[*faceRecord]bool)
+	forEachEdge(f.cycle, func(e *halfEdgeRecord) {
+		adj := e.twin.incident
+		if !set[adj] {
+			set[adj] = true
+			adjacent = append(adjacent, adj)
+		}
+	})
+	return adjacent
 }
 
 // completeLabel copies any missing portion (part A or part B) of the label
@@ -277,228 +192,21 @@ func completeLabel(recipient, donor uint8) uint8 {
 	return recipient
 }
 
-// edgeLoopLeftmostLowest finds the edge in the cycle whose origin is the
-// leftmost (or lowest for a tie) point in the loop. If there is a tie (i.e.
-// two edges in the cycle with the same origin), then it uses the edge
-// destination to choose between them.
-func edgeLoopLeftmostLowest(start *halfEdgeRecord) *halfEdgeRecord {
-	var best *halfEdgeRecord
-	forEachEdge(start, func(e *halfEdgeRecord) {
-		if best == nil ||
-			e.origin.coords.Less(best.origin.coords) ||
-			e.origin.coords == best.origin.coords && e.twin.origin.coords.Less(best.twin.origin.coords) {
-			best = e
-		}
-	})
-	return best
-}
-
-// edgeLoopIsOuterComponent checks to see if an edge loop is an outer edge loop
-// or an inner edge loop. It does this by checking its orientation via the
-// Shoelace Formula.
-func edgeLoopIsOuterComponent(start *halfEdgeRecord) bool {
-	// Check to see if the loop is degenerate (i.e. doesn't enclose any area).
-	// Degenerate loops must always be inner components. We can't just use the
-	// shoelace formula and check for an area of zero due to numerical
-	// precision issues. Instead, we keep track of which twin edges we see
-	// during edge cycle iteration -- if we never see a twin again then we can
-	// be sure the cycle isn't degenerate.
-	twins := make(map[*halfEdgeRecord]struct{})
-	forEachEdge(start, func(e *halfEdgeRecord) {
-		if _, ok := twins[e]; ok {
-			delete(twins, e)
-		} else {
-			twins[e.twin] = struct{}{}
-		}
-	})
-	if len(twins) == 0 {
-		return false // degenerate
-	}
-
-	// Check the area of the loop using the shoelace formula. The sign of the
-	// loop area implies an orientation, which in turn implies whether the loop
-	// is an inner or outer component.
-	var sum float64
-	forEachEdge(start, func(e *halfEdgeRecord) {
-		pt0 := e.origin.coords
-		pt1 := e.next.origin.coords
-		sum += (pt1.X + pt0.X) * (pt1.Y - pt0.Y)
-	})
-	return sum > 0
-}
-
-func (d *doublyConnectedEdgeList) findNextDownEdgeToTheLeft(pt XY) *halfEdgeRecord {
-	var acc nextDownEdgeToTheLeftAccumulator
-	var bestEdge *halfEdgeRecord
-	for _, e := range d.halfEdges {
-		ln := line{e.origin.coords, e.twin.origin.coords}
-		if acc.accumulate(ln, pt) {
-			bestEdge = e
-		}
-	}
-	return bestEdge
-}
-
-type nextDownEdgeToTheLeftAccumulator struct {
-	bestLine line
-	bestDist float64
-	tieBreak float64
-}
-
-func (a *nextDownEdgeToTheLeftAccumulator) accumulate(ln line, pt XY) bool {
-	origin := ln.a
-	destin := ln.b
-	if !(destin.Y <= pt.Y && pt.Y <= origin.Y) {
-		// We only want to consider edges that go "down" (or horizontal)
-		// and overlap vertically with pt.
-		return false
-	}
-	if origin.Y == destin.Y && origin.X < destin.X {
-		// For horizontal lines, we only want to consider edges that go
-		// from the right to the left.
-		return false
-	}
-
-	// Calculate distance.
-	dist := signedHorizontalDistanceBetweenXYAndLine(pt, ln)
-	if dist <= 0 {
-		// Edge is on the wrong side of pt (we only want edges to the left).
-		return false
-	}
-
-	// Calculate tie-break.
-	unitAwayFromHit := XY{1, 0}
-	hit := XY{pt.X - dist, pt.Y}
-	var other XY
-	if hit.distanceTo(origin) > hit.distanceTo(destin) {
-		other = origin
-	} else {
-		other = destin
-	}
-	edgeUnit := other.Sub(hit).Unit()
-	tieBreak := unitAwayFromHit.Dot(edgeUnit)
-
-	// Replace if best.
-	if a.bestLine == (line{}) || dist < a.bestDist || (dist == a.bestDist && tieBreak > a.tieBreak) {
-		a.bestLine = ln
-		a.bestDist = dist
-		a.tieBreak = tieBreak
-		return true
-	}
-	return false
-}
-
-func signedHorizontalDistanceBetweenXYAndLine(xy XY, ln line) float64 {
-	// TODO: This may not be robust in cases of an *almost* horizontal line.
-	// Need to have a think about a better approach here.
-	if ln.b.Y == ln.a.Y {
-		return xy.X - math.Max(ln.a.X, ln.b.X)
-	}
-	rat := (xy.Y - ln.a.Y) / (ln.b.Y - ln.a.Y)
-	x := (1-rat)*ln.a.X + rat*ln.b.X
-	dist := xy.X - x
-	return dist
-}
-
-// disjointEdgeSet is a disjoint set data structure where each element in the
-// set is a *halfEdgeRecord (see
-// https://en.wikipedia.org/wiki/Disjoint-set_data_structure).
-//
-// TODO: the implementation here is naive/brute-force. There are well known
-// better disjoint edge set algorithms.
-type disjointEdgeSet struct {
-	sets [][]*halfEdgeRecord
-}
-
-// addSingleton adds a new set containing just e to the disjoint edge set.
-func (s *disjointEdgeSet) addSingleton(e *halfEdgeRecord) {
-	s.sets = append(s.sets, []*halfEdgeRecord{e})
-}
-
-// union unions together the distinct sets containing e1 and e2. It *shouldn't*
-// ever return an error (however we want to be cautious not to panic).
-func (s *disjointEdgeSet) union(e1, e2 *halfEdgeRecord) error {
-	idx1, idx2 := -1, -1
-	for i, set := range s.sets {
-		for _, e := range set {
-			if e == e1 {
-				if idx1 != -1 {
-					return fmt.Errorf("idx1 already set: %d", idx1)
-				}
-				idx1 = i
-			}
-			if e == e2 {
-				if idx2 != -1 {
-					return fmt.Errorf("idx2 already set: %d", idx2)
-				}
-				idx2 = i
-			}
-		}
-	}
-	if idx1 == -1 || idx2 == -1 || idx1 == idx2 {
-		return fmt.Errorf("e1: %p e2: %p state: %v indexes: %d %d", e1, e2, s.sets, idx1, idx2)
-	}
-
-	set1 := s.sets[idx1]
-	set2 := s.sets[idx2]
-	n := len(s.sets)
-	s.sets[idx1], s.sets[n-1] = s.sets[n-1], s.sets[idx1]
-	if idx2 == n-1 {
-		idx2 = idx1
-	}
-	s.sets[idx2], s.sets[n-2] = s.sets[n-2], s.sets[idx2]
-	s.sets = s.sets[:n-2]
-	s.sets = append(s.sets, append(set1, set2...))
-	return nil
-}
-
 // fixLabels updates edge and vertex labels after performing an overlay.
 func (d *doublyConnectedEdgeList) fixLabels() {
 	for _, e := range d.halfEdges {
-		// Add edge presence if the two faces adjacent to the edge are both
-		// present. The edge is part of that geometry (because it's "within"
-		// it), even if it's not explicitly part of its boundary.
-		face1 := e.incident.label
-		face2 := e.twin.incident.label
-		e.label |= face1 & face2 & inSetMask
+		// Copy labels from incident faces into edge since the edge represents
+		// the (closed) border of the face.
+		e.edgeLabel |= e.incident.label | e.twin.incident.label
 
 		// If we haven't seen an edge label yet for one of the two input
 		// geometries, we can assume that we'll never see it. So we mark off
 		// that side as having the bit populated.
-		e.label |= populatedMask
+		e.edgeLabel |= populatedMask
 
 		// Copy edge labels onto the labels of adjacent vertices. This is
 		// because the vertices represent the endpoints of the edges, and
 		// should have at least those bits set.
-		e.origin.label |= e.label | e.prev.label
-	}
-
-	var infFace *faceRecord
-	for _, f := range d.faces {
-		if f.outerComponent == nil {
-			infFace = f
-			break
-		}
-	}
-
-	// If there are any vertices that don't have populated labels, it's because
-	// they are isolated (i.e. in the middle of a face). We need to work out
-	// which face they are part of.
-	for _, vert := range d.vertices {
-		xy := vert.coords
-		if (vert.label & populatedMask) == populatedMask {
-			continue
-		}
-		var face *faceRecord
-		e := d.findNextDownEdgeToTheLeft(xy)
-		if e == nil {
-			// There was no next edge to the left, so the face we're interested
-			// in is the infinite face.
-			face = infFace
-		} else {
-			face = e.incident
-		}
-		vert.label = completeLabel(vert.label, face.label)
-		face.internalVertices = append(face.internalVertices, vert)
+		e.origin.label |= e.edgeLabel | e.prev.edgeLabel
 	}
 }

--- a/geom/dcel_re_noding_test.go
+++ b/geom/dcel_re_noding_test.go
@@ -52,7 +52,7 @@ func TestReNode(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			gotA, gotB, err := reNodeGeometries(inA, inB)
+			gotA, gotB, _, err := reNodeGeometries(inA, inB, MultiLineString{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/geom/dcel_test.go
+++ b/geom/dcel_test.go
@@ -10,23 +10,23 @@ type DCELSpec struct {
 	NumVerts int
 	NumEdges int
 	NumFaces int
-	Faces    []FaceSpec
-	Edges    []EdgeLabelSpec
 	Vertices []VertexSpec
+	Edges    []EdgeLabelSpec
+	Faces    []FaceSpec
 }
 
 type FaceSpec struct {
 	// Origin and destination of an edge that is incident to the face.
-	EdgeOrigin      XY
-	EdgeDestin      XY
-	OuterComponent  []XY
-	InnerComponents [][]XY
-	Label           uint8
+	EdgeOrigin XY
+	EdgeDestin XY
+	Cycle      []XY
+	Label      uint8
 }
 
 type EdgeLabelSpec struct {
-	Label uint8
-	Edges []XY
+	EdgeLabel uint8
+	FaceLabel uint8
+	Edges     []XY
 }
 
 type VertexSpec struct {
@@ -49,70 +49,11 @@ func CheckDCEL(t *testing.T, dcel *doublyConnectedEdgeList, spec DCELSpec) {
 		t.Fatalf("NumFaces doesn't match len(spec.Faces): %d vs %d", spec.NumFaces, len(spec.Faces))
 	}
 
-	for _, vr := range dcel.vertices {
-		bruteForceEdgeSet := make(map[*halfEdgeRecord]struct{})
-		for _, er := range dcel.halfEdges {
-			if er.origin.coords == vr.coords {
-				bruteForceEdgeSet[er] = struct{}{}
-			}
-		}
-		incidentsSet := make(map[*halfEdgeRecord]struct{})
-		for _, e := range vr.incidents {
-			incidentsSet[e] = struct{}{}
-		}
-		if !reflect.DeepEqual(bruteForceEdgeSet, incidentsSet) {
-			t.Fatalf("vertex record at %v doesn't have correct incidents: "+
-				"bruteForceEdgeSet=%v incidentsSet=%v", vr.coords, bruteForceEdgeSet, incidentsSet)
-		}
-	}
-
-	for i, want := range spec.Faces {
-		t.Run(fmt.Sprintf("f%d", i), func(t *testing.T) {
-			got := findEdge(t, dcel, want.EdgeOrigin, want.EdgeDestin).incident
-
-			if len(want.OuterComponent) == 0 {
-				if got.outerComponent != nil {
-					t.Fatal("want no outer component but outer component is not nil")
-				}
-			} else {
-				if len(want.OuterComponent) != 0 && got.outerComponent == nil {
-					t.Fatal("want outer component but outer component is nil")
-				}
-				CheckComponent(t, got, got.outerComponent, want.OuterComponent)
-			}
-
-			if len(got.innerComponents) != len(want.InnerComponents) {
-				t.Fatalf("len want inners not equal to actual inners: %d vs %d",
-					len(want.InnerComponents), len(got.innerComponents))
-			}
-			for i, wantInner := range want.InnerComponents {
-				CheckComponent(t, got, got.innerComponents[i], wantInner)
-			}
-			if want.Label != got.label {
-				t.Errorf("label doesn't match: want=%b got=%b", want.Label, got.label)
-			}
-		})
-	}
-
-	t.Run("edge_labels", func(t *testing.T) {
-		for _, want := range spec.Edges {
-			for i := 0; i+1 < len(want.Edges); i++ {
-				u := want.Edges[i]
-				v := want.Edges[i+1]
-				e := findEdge(t, dcel, u, v)
-				if e.label != want.Label {
-					t.Errorf("incorrect label for edge %v -> %v: "+
-						"want=%b got=%b", u, v, want.Label, e.label)
-				}
-				if e.twin.label != want.Label {
-					t.Errorf("incorrect label for edge %v -> %v: "+
-						"want=%b got=%b", v, u, want.Label, e.twin.label)
-				}
-			}
-		}
-	})
-
 	t.Run("vertex_labels", func(t *testing.T) {
+		unchecked := make(map[*vertexRecord]bool)
+		for _, vert := range dcel.vertices {
+			unchecked[vert] = true
+		}
 		for _, want := range spec.Vertices {
 			for _, wantXY := range want.Vertices {
 				vert, ok := dcel.vertices[wantXY]
@@ -123,9 +64,74 @@ func CheckDCEL(t *testing.T, dcel *doublyConnectedEdgeList, spec DCELSpec) {
 				if vert.label != want.Label {
 					t.Errorf("vertex label mismatch for %v: want=%b got=%b", wantXY, want.Label, vert.label)
 				}
+				delete(unchecked, vert)
+			}
+		}
+		if len(unchecked) > 0 {
+			for vert := range unchecked {
+				t.Logf("unchecked vertex: %v", vert)
+			}
+			t.Errorf("some vertex labels not checked: %d", len(unchecked))
+		}
+	})
+
+	t.Run("vertex_incidents", func(t *testing.T) {
+		for _, vr := range dcel.vertices {
+			bruteForceEdgeSet := make(map[*halfEdgeRecord]struct{})
+			for _, er := range dcel.halfEdges {
+				if er.origin.coords == vr.coords {
+					bruteForceEdgeSet[er] = struct{}{}
+				}
+			}
+			incidentsSet := make(map[*halfEdgeRecord]struct{})
+			for _, e := range vr.incidents {
+				incidentsSet[e] = struct{}{}
+			}
+			if !reflect.DeepEqual(bruteForceEdgeSet, incidentsSet) {
+				t.Fatalf("vertex record at %v doesn't have correct incidents: "+
+					"bruteForceEdgeSet=%v incidentsSet=%v", vr.coords, bruteForceEdgeSet, incidentsSet)
 			}
 		}
 	})
+
+	t.Run("edge_labels", func(t *testing.T) {
+		unchecked := make(map[*halfEdgeRecord]bool)
+		for _, e := range dcel.halfEdges {
+			unchecked[e] = true
+		}
+		for _, want := range spec.Edges {
+			for i := 0; i+1 < len(want.Edges); i++ {
+				u := want.Edges[i]
+				v := want.Edges[i+1]
+				e := findEdge(t, dcel, u, v)
+				delete(unchecked, e)
+				if e.edgeLabel != want.EdgeLabel {
+					t.Errorf("incorrect edge label for edge %v -> %v: "+
+						"want=%b got=%b", u, v, want.EdgeLabel, e.edgeLabel)
+				}
+				if e.faceLabel != want.FaceLabel {
+					t.Errorf("incorrect face label for edge %v -> %v: "+
+						"want=%b got=%b", u, v, want.FaceLabel, e.faceLabel)
+				}
+			}
+		}
+		if len(unchecked) > 0 {
+			for e := range unchecked {
+				t.Logf("unchecked edge: %v", e)
+			}
+			t.Errorf("some edge labels not checked: %d", len(unchecked))
+		}
+	})
+
+	for i, want := range spec.Faces {
+		t.Run(fmt.Sprintf("face_%d", i), func(t *testing.T) {
+			got := findEdge(t, dcel, want.EdgeOrigin, want.EdgeDestin).incident
+			CheckComponent(t, got, got.cycle, want.Cycle)
+			if want.Label != got.label {
+				t.Errorf("face label doesn't match: want=%b got=%b", want.Label, got.label)
+			}
+		})
+	}
 }
 
 func findEdge(t *testing.T, dcel *doublyConnectedEdgeList, origin, dest XY) *halfEdgeRecord {
@@ -138,6 +144,7 @@ func findEdge(t *testing.T, dcel *doublyConnectedEdgeList, origin, dest XY) *hal
 	return nil
 }
 
+// TODO: rename to CheckCycle
 func CheckComponent(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []XY) {
 	// Check component matches forward order when following 'next' pointer.
 	e := start
@@ -165,7 +172,7 @@ func CheckComponent(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []X
 	got = nil
 	for {
 		i++
-		if i == 20 {
+		if i == 100 {
 			t.Fatal("inf loop")
 		}
 
@@ -276,33 +283,24 @@ func TestGraphTriangle(t *testing.T) {
 	CheckDCEL(t, dcel, DCELSpec{
 		NumVerts: 3,
 		NumEdges: 6,
-		NumFaces: 2,
-		Faces: []FaceSpec{
-			{
-				// f0
-				EdgeOrigin:      v2,
-				EdgeDestin:      v1,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v2, v1, v0}},
-				Label:           inputAPopulated,
-			},
-			{
-				// f1
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v2},
-				InnerComponents: [][]XY{},
-				Label:           inputAMask,
-			},
-		},
-		Edges: []EdgeLabelSpec{{
-			Label: inputAPopulated | inputAInSet,
-			Edges: []XY{v0, v1, v2},
-		}},
+		NumFaces: 0,
 		Vertices: []VertexSpec{{
 			Label:    inputAPopulated | inputAInSet,
 			Vertices: []XY{v0, v1, v2},
 		}},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v0, v1, v2, v0},
+			},
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v0, v2, v1, v0},
+			},
+		},
+		Faces: nil,
 	})
 }
 
@@ -347,41 +345,44 @@ func TestGraphWithHoles(t *testing.T) {
 	CheckDCEL(t, dcel, DCELSpec{
 		NumVerts: 12,
 		NumEdges: 24,
-		NumFaces: 4,
-		Faces: []FaceSpec{
+		NumFaces: 0,
+		Vertices: []VertexSpec{{
+			Label:    inputBPopulated | inputBInSet,
+			Vertices: []XY{v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11},
+		}},
+		Edges: []EdgeLabelSpec{
 			{
-				// f0
-				EdgeOrigin:      v3,
-				EdgeDestin:      v2,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v3, v2, v1, v0}},
-				Label:           inputBPopulated,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v0, v1, v2, v3, v0},
 			},
 			{
-				// f1
-				EdgeOrigin:      v2,
-				EdgeDestin:      v3,
-				OuterComponent:  []XY{v2, v3, v0, v1},
-				InnerComponents: [][]XY{{v7, v4, v5, v6}, {v11, v8, v9, v10}},
-				Label:           inputBPopulated | inputBInSet,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v0, v3, v2, v1, v0},
 			},
 			{
-				// f2
-				EdgeOrigin:      v4,
-				EdgeDestin:      v7,
-				OuterComponent:  []XY{v4, v7, v6, v5},
-				InnerComponents: nil,
-				Label:           inputBPopulated,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v4, v5, v6, v7, v4},
 			},
 			{
-				// f3
-				EdgeOrigin:      v8,
-				EdgeDestin:      v11,
-				OuterComponent:  []XY{v8, v11, v10, v9},
-				InnerComponents: nil,
-				Label:           inputBPopulated,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v4, v7, v6, v5, v4},
+			},
+			{
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v8, v9, v10, v11, v8},
+			},
+			{
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v8, v11, v10, v9, v8},
 			},
 		},
+		Faces: nil,
 	})
 }
 
@@ -413,33 +414,34 @@ func TestGraphWithMultiPolygon(t *testing.T) {
 	CheckDCEL(t, dcel, DCELSpec{
 		NumVerts: 8,
 		NumEdges: 16,
-		NumFaces: 3,
-		Faces: []FaceSpec{
+		NumFaces: 0,
+		Vertices: []VertexSpec{{
+			Label:    inputBPopulated | inputBInSet,
+			Vertices: []XY{v0, v1, v2, v3, v4, v5, v6, v7},
+		}},
+		Edges: []EdgeLabelSpec{
 			{
-				// f0
-				EdgeOrigin:      v7,
-				EdgeDestin:      v6,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v3, v2, v1, v0}, {v7, v6, v5, v4}},
-				Label:           inputBPopulated,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v0, v1, v2, v3, v0},
 			},
 			{
-				// f1
-				EdgeOrigin:      v6,
-				EdgeDestin:      v7,
-				OuterComponent:  []XY{v6, v7, v4, v5},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputBInSet,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v0, v3, v2, v1, v0},
 			},
 			{
-				// f2
-				EdgeOrigin:      v2,
-				EdgeDestin:      v3,
-				OuterComponent:  []XY{v2, v3, v0, v1},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputBInSet,
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v4, v5, v6, v7, v4},
+			},
+			{
+				EdgeLabel: inputBPopulated | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v4, v7, v6, v5, v4},
 			},
 		},
+		Faces: nil,
 	})
 }
 
@@ -448,7 +450,7 @@ func TestGraphMultiLineString(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel, err := newDCELFromGeometry(mls, inputAMask)
+	dcel, err := newDCELFromGeometry(mls, MultiLineString{}, inputAMask)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,28 +477,24 @@ func TestGraphMultiLineString(t *testing.T) {
 	CheckDCEL(t, dcel, DCELSpec{
 		NumVerts: 6,
 		NumEdges: 8,
-		NumFaces: 1,
-		Faces: []FaceSpec{{
-			EdgeOrigin:      v0,
-			EdgeDestin:      v1,
-			OuterComponent:  nil,
-			InnerComponents: [][]XY{{v0, v1}, {v1, v2}, {v5, v4}, {v4, v3}},
-			Label:           inputAPopulated,
-		}},
-		Edges: []EdgeLabelSpec{
-			{
-				Label: inputAPopulated | inputAInSet,
-				Edges: []XY{v0, v1, v2},
-			},
-			{
-				Label: inputAPopulated | inputAInSet,
-				Edges: []XY{v3, v4, v5},
-			},
-		},
+		NumFaces: 0,
 		Vertices: []VertexSpec{{
 			Label:    inputAPopulated | inputAInSet,
 			Vertices: []XY{v0, v1, v2, v3, v4, v5},
 		}},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v0, v1, v2, v1, v0},
+			},
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v3, v4, v5, v4, v3},
+			},
+		},
+		Faces: nil,
 	})
 }
 
@@ -505,7 +503,7 @@ func TestGraphSelfOverlappingLineString(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel, err := newDCELFromGeometry(ls, inputAMask)
+	dcel, err := newDCELFromGeometry(ls, MultiLineString{}, inputAMask)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,28 +526,70 @@ func TestGraphSelfOverlappingLineString(t *testing.T) {
 	CheckDCEL(t, dcel, DCELSpec{
 		NumVerts: 5,
 		NumEdges: 10,
-		NumFaces: 1, // just the infinite face
-		Faces: []FaceSpec{{
-			EdgeOrigin:      v0,
-			EdgeDestin:      v1,
-			OuterComponent:  nil,
-			InnerComponents: [][]XY{{v0, v1}, {v1, v2}, {v3, v2}, {v1, v3}, {v2, v4}},
-			Label:           inputAPopulated,
-		}},
-		Edges: []EdgeLabelSpec{
-			{
-				Label: inputAPopulated | inputAInSet,
-				Edges: []XY{v0, v1, v3, v2},
-			},
-			{
-				Label: inputAPopulated | inputAInSet,
-				Edges: []XY{v1, v2, v4},
-			},
-		},
+		NumFaces: 0,
 		Vertices: []VertexSpec{{
 			Label:    inputAPopulated | inputAInSet,
 			Vertices: []XY{v0, v1, v2, v3, v4},
 		}},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v0, v1, v3, v2, v3, v1, v0},
+			},
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v1, v2, v4, v2, v1},
+			},
+		},
+		Faces: nil,
+	})
+}
+
+func TestGraphGhostDeduplication(t *testing.T) {
+	ls, err := UnmarshalWKT("LINESTRING(0 0,1 0)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ghost contains duplicated lines. This could happen in the scenario where
+	// one of the inputs is a multipolygon and the ghost joins the rings, but
+	// then the line joining the two input geometries is the same line segment.
+	ghost, err := UnmarshalWKT("MULTILINESTRING((0 0,0 1,0 0))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dcel, err := newDCELFromGeometry(ls, ghost.AsMultiLineString(), inputAMask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v0 := XY{0, 0}
+	v1 := XY{1, 0}
+	v2 := XY{0, 1}
+
+	CheckDCEL(t, dcel, DCELSpec{
+		NumVerts: 3,
+		NumEdges: 4,
+		NumFaces: 0,
+		Vertices: []VertexSpec{
+			{Label: inputAPopulated | inputAInSet, Vertices: []XY{v0, v1}},
+			{Label: 0, Vertices: []XY{v2}},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: inputAPopulated | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v0, v1, v0},
+			},
+			{
+				EdgeLabel: inputAPopulated,
+				FaceLabel: 0,
+				Edges:     []XY{v0, v2, v0},
+			},
+		},
 	})
 }
 
@@ -562,16 +602,16 @@ func TestGraphOverlayDisjoint(t *testing.T) {
 	/*
 	                v7------v6
 	                |        |
-	                |   f2   |
+	                |   f3   |
 	                |        |
 	                |        |
-	                v4------v5
-
+	               ,v4------v5
+	             ,`
 	   v3------v2
-	   |        |
-	   |   f1   |       f0
-	   |        |
-	   |        |
+	   |     ,` |
+	   |f2  `   |       f0
+	   |  ,` f1 |
+	   | ,      |
 	   v0------v1
 
 	*/
@@ -587,32 +627,78 @@ func TestGraphOverlayDisjoint(t *testing.T) {
 
 	CheckDCEL(t, overlay, DCELSpec{
 		NumVerts: 8,
-		NumEdges: 16,
-		NumFaces: 3,
+		NumEdges: 20,
+		NumFaces: 4,
+		Vertices: []VertexSpec{
+			{
+				Label:    populatedMask | inputAInSet,
+				Vertices: []XY{v0, v1, v2, v3},
+			},
+			{
+				Label:    populatedMask | inputBInSet,
+				Vertices: []XY{v4, v5, v6, v7},
+			},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v0, v1, v2, v3, v0},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v4, v5, v6, v7, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v0, v3, v2, v1, v0},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v4, v7, v6, v5, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: 0,
+				Edges:     []XY{v0, v2, v0},
+			},
+			{
+				EdgeLabel: populatedMask,
+				FaceLabel: 0,
+				Edges:     []XY{v2, v4, v2},
+			},
+		},
 		Faces: []FaceSpec{
 			{
 				// f0
-				EdgeOrigin:      v2,
-				EdgeDestin:      v1,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v6, v5, v4, v7}, {v2, v1, v0, v3}},
-				Label:           populatedMask,
+				EdgeOrigin: v2,
+				EdgeDestin: v1,
+				Cycle:      []XY{v2, v1, v0, v3, v2, v4, v7, v6, v5, v4},
+				Label:      populatedMask,
 			},
 			{
 				// f1
-				EdgeOrigin:      v1,
-				EdgeDestin:      v2,
-				OuterComponent:  []XY{v2, v3, v0, v1},
-				InnerComponents: nil,
-				Label:           populatedMask | inputAInSet,
+				EdgeOrigin: v1,
+				EdgeDestin: v2,
+				Cycle:      []XY{v2, v0, v1},
+				Label:      populatedMask | inputAInSet,
 			},
 			{
 				// f2
-				EdgeOrigin:      v5,
-				EdgeDestin:      v6,
-				OuterComponent:  []XY{v5, v6, v7, v4},
-				InnerComponents: nil,
-				Label:           populatedMask | inputBInSet,
+				EdgeOrigin: v2,
+				EdgeDestin: v3,
+				Cycle:      []XY{v2, v3, v0},
+				Label:      populatedMask | inputAInSet,
+			},
+			{
+				// f3
+				EdgeOrigin: v5,
+				EdgeDestin: v6,
+				Cycle:      []XY{v5, v6, v7, v4},
+				Label:      populatedMask | inputBInSet,
 			},
 		},
 	})
@@ -634,10 +720,10 @@ func TestGraphOverlayIntersecting(t *testing.T) {
 	     /    /  \    \
 	    /    / f3 \    \
 	   v5--v4------v2--v6
-	       /        \
-	      /    f1    \    f0
-	     /            \
-	    /              \
+	   |   /        \
+	   |f4/    f1    \    f0
+	   | /            \
+	   |/              \
 	   v0--------------v1
 
 	*/
@@ -653,56 +739,8 @@ func TestGraphOverlayIntersecting(t *testing.T) {
 
 	CheckDCEL(t, overlay, DCELSpec{
 		NumVerts: 8,
-		NumEdges: 20,
-		NumFaces: 4,
-		Faces: []FaceSpec{
-			{
-				// f0
-				EdgeOrigin:      v7,
-				EdgeDestin:      v6,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v7, v6, v2, v1, v0, v4, v5}},
-				Label:           populatedMask,
-			},
-			{
-				// f1
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v2, v4},
-				InnerComponents: nil,
-				Label:           populatedMask | inputAInSet,
-			},
-			{
-				// f2
-				EdgeOrigin:      v6,
-				EdgeDestin:      v7,
-				OuterComponent:  []XY{v6, v7, v5, v4, v3, v2},
-				InnerComponents: nil,
-				Label:           populatedMask | inputBInSet,
-			},
-			{
-				// f3
-				EdgeOrigin:      v4,
-				EdgeDestin:      v2,
-				OuterComponent:  []XY{v4, v2, v3},
-				InnerComponents: nil,
-				Label:           populatedMask | inputAInSet | inputBInSet,
-			},
-		},
-		Edges: []EdgeLabelSpec{
-			{
-				Label: populatedMask | inputAInSet,
-				Edges: []XY{v4, v0, v1, v2},
-			},
-			{
-				Label: populatedMask | inputBInSet,
-				Edges: []XY{v4, v5, v7, v6, v2},
-			},
-			{
-				Label: populatedMask | inSetMask,
-				Edges: []XY{v4, v3, v2, v4},
-			},
-		},
+		NumEdges: 22,
+		NumFaces: 5,
 		Vertices: []VertexSpec{
 			{
 				Label:    populatedMask | inputAInSet,
@@ -715,6 +753,90 @@ func TestGraphOverlayIntersecting(t *testing.T) {
 			{
 				Label:    populatedMask | inSetMask,
 				Vertices: []XY{v2, v3, v4},
+			},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v4, v0, v1, v2},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v2, v1, v0, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v2, v6, v7, v5, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v4, v5, v7, v6, v2},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v2, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v4, v2},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v4, v3, v2},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v2, v3, v4},
+			},
+			{
+				EdgeLabel: populatedMask,
+				FaceLabel: 0,
+				Edges:     []XY{v0, v5, v0},
+			},
+		},
+		Faces: []FaceSpec{
+			{
+				// f0
+				EdgeOrigin: v7,
+				EdgeDestin: v6,
+				Cycle:      []XY{v7, v6, v2, v1, v0, v5},
+				Label:      populatedMask,
+			},
+			{
+				// f1
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v2, v4},
+				Label:      populatedMask | inputAInSet,
+			},
+			{
+				// f2
+				EdgeOrigin: v6,
+				EdgeDestin: v7,
+				Cycle:      []XY{v6, v7, v5, v4, v3, v2},
+				Label:      populatedMask | inputBInSet,
+			},
+			{
+				// f3
+				EdgeOrigin: v4,
+				EdgeDestin: v2,
+				Cycle:      []XY{v4, v2, v3},
+				Label:      populatedMask | inputAInSet | inputBInSet,
+			},
+			{
+				// f4
+				EdgeOrigin: v0,
+				EdgeDestin: v4,
+				Cycle:      []XY{v0, v4, v5},
+				Label:      populatedMask,
 			},
 		},
 	})
@@ -734,8 +856,8 @@ func TestGraphOverlayInside(t *testing.T) {
 	   |     | f2  |     |
 	   |     |     |     |
 	   |    v4-----v5    |  f0
-	   |                 |
-	   |       f1        |
+	   |  ,`             |
+	   |,`     f1        |
 	  v0-----------------v1
 
 	*/
@@ -751,32 +873,66 @@ func TestGraphOverlayInside(t *testing.T) {
 
 	CheckDCEL(t, overlay, DCELSpec{
 		NumVerts: 8,
-		NumEdges: 16,
+		NumEdges: 18,
 		NumFaces: 3,
+		Vertices: []VertexSpec{
+			{
+				Label:    populatedMask | inputAInSet,
+				Vertices: []XY{v0, v1, v2, v3},
+			},
+			{
+				Label:    populatedMask | inSetMask,
+				Vertices: []XY{v4, v5, v6, v7},
+			},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v0, v3, v2, v1, v0},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v0, v1, v2, v3, v0},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v4, v7, v6, v5, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v4, v5, v6, v7, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: 0,
+				Edges:     []XY{v0, v4, v0},
+			},
+		},
 		Faces: []FaceSpec{
 			{
 				// f0
-				EdgeOrigin:      v2,
-				EdgeDestin:      v1,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v2, v1, v0, v3}},
-				Label:           populatedMask,
+				EdgeOrigin: v2,
+				EdgeDestin: v1,
+				Cycle:      []XY{v2, v1, v0, v3},
+				Label:      populatedMask,
 			},
 			{
 				// f1
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v2, v3},
-				InnerComponents: [][]XY{{v4, v7, v6, v5}},
-				Label:           populatedMask | inputAInSet,
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v2, v3, v0, v4, v7, v6, v5, v4},
+				Label:      populatedMask | inputAInSet,
 			},
 			{
 				// f2
-				EdgeOrigin:      v4,
-				EdgeDestin:      v5,
-				OuterComponent:  []XY{v4, v5, v6, v7},
-				InnerComponents: nil,
-				Label:           populatedMask | inputAInSet | inputBInSet,
+				EdgeOrigin: v4,
+				EdgeDestin: v5,
+				Cycle:      []XY{v4, v5, v6, v7},
+				Label:      populatedMask | inputAInSet | inputBInSet,
 			},
 		},
 	})
@@ -793,18 +949,18 @@ func TestGraphOverlayReproduceHorizontalHoleLinkageBug(t *testing.T) {
 	   | f2  |
 	   |     |
 	  v13---v14
-
-
-	  v12---------v11
-	   |  f4       |
-	   |           |
+	   | `,
+	   |f9 `,
+	  v12---v19---v11
+	   |  f4   `,f8|
+	   |         `,|
 	   |    v4----v18----v3
-	   |     | f5  |     |    f0
-	   |     |     |     |
-	  v9----v17---v10    |    v8-----v7
-	         |           |     | f1  |
-	         |  f3       |     |     |
-	   o    v1-----------v2   v5-----v6
+	   |     | f5  | `,f7|    f0
+	   |     |     |   `,|
+	  v9----v17---v10   v20   v8-----v7
+	         |           | `,  | f1  |
+	         |  f3       |f6 `,|     |
+	   o    v1-----------v2---v5-----v6
 	*/
 
 	v1 := XY{1, 0}
@@ -825,63 +981,183 @@ func TestGraphOverlayReproduceHorizontalHoleLinkageBug(t *testing.T) {
 	v16 := XY{0, 5}
 	v17 := XY{1, 1}
 	v18 := XY{2, 2}
+	v19 := XY{1, 3}
+	v20 := XY{3, 1}
 
 	CheckDCEL(t, overlay, DCELSpec{
-		NumVerts: 18,
-		NumEdges: 40,
-		NumFaces: 6,
+		NumVerts: 20,
+		NumEdges: 56,
+		NumFaces: 10,
+		Vertices: []VertexSpec{
+			{
+				Label:    populatedMask | inputAInSet,
+				Vertices: []XY{v1, v3, v20, v2, v8, v5, v7, v6},
+			},
+			{
+				Label:    populatedMask | inputBInSet,
+				Vertices: []XY{v9, v12, v19, v11, v13, v14, v16, v15},
+			},
+			{
+				Label:    populatedMask | inSetMask,
+				Vertices: []XY{v4, v17, v10, v18},
+			},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				EdgeLabel: populatedMask,
+				FaceLabel: 0,
+				Edges:     []XY{v20, v5, v2, v5, v20},
+			},
+			{
+				EdgeLabel: populatedMask,
+				FaceLabel: 0,
+				Edges:     []XY{v12, v13, v19, v13, v12},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v5, v6, v7, v8, v5},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v5, v8, v7, v6, v5},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v13, v14, v15, v16, v13},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v13, v16, v15, v14, v13},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v18, v3, v20, v2, v1, v17},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v17, v9, v12, v19, v11, v18},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v17, v1, v2, v20, v3, v18},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v18, v11, v19, v12, v9, v17},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v18, v10, v17},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v17, v4, v18},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v17, v10, v18},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v18, v4, v17},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: 0,
+				Edges:     []XY{v20, v18, v20},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: 0,
+				Edges:     []XY{v19, v18, v19},
+			},
+		},
 		Faces: []FaceSpec{
 			{
 				// f0
-				EdgeOrigin:     v12,
-				EdgeDestin:     v11,
-				OuterComponent: nil,
-				InnerComponents: [][]XY{
-					{v14, v13, v16, v15},
-					{v6, v5, v8, v7},
-					{v1, v17, v9, v12, v11, v18, v3, v2},
+				EdgeOrigin: v19,
+				EdgeDestin: v11,
+				Cycle: []XY{
+					v19, v11, v18, v3, v20, v5, v8, v7,
+					v6, v5, v2, v1, v17, v9, v12,
+					v13, v16, v15, v14, v13,
 				},
 				Label: inputBPopulated | inputAPopulated,
 			},
 			{
 				// f1
-				EdgeOrigin:      v6,
-				EdgeDestin:      v7,
-				OuterComponent:  []XY{v6, v7, v8, v5},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputAPopulated | inputAInSet,
+				EdgeOrigin: v6,
+				EdgeDestin: v7,
+				Cycle:      []XY{v6, v7, v8, v5},
+				Label:      inputBPopulated | inputAPopulated | inputAInSet,
 			},
 			{
 				// f2
-				EdgeOrigin:      v13,
-				EdgeDestin:      v14,
-				OuterComponent:  []XY{v13, v14, v15, v16},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputAPopulated | inputBInSet,
+				EdgeOrigin: v13,
+				EdgeDestin: v14,
+				Cycle:      []XY{v13, v14, v15, v16},
+				Label:      inputBPopulated | inputAPopulated | inputBInSet,
 			},
 			{
 				// f3
-				EdgeOrigin:      v1,
-				EdgeDestin:      v2,
-				OuterComponent:  []XY{v1, v2, v3, v18, v10, v17},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputAPopulated | inputAInSet,
+				EdgeOrigin: v1,
+				EdgeDestin: v2,
+				Cycle:      []XY{v1, v2, v20, v18, v10, v17},
+				Label:      inputBPopulated | inputAPopulated | inputAInSet,
 			},
 			{
 				// f4
-				EdgeOrigin:      v4,
-				EdgeDestin:      v18,
-				OuterComponent:  []XY{v4, v18, v11, v12, v9, v17},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputAPopulated | inputBInSet,
+				EdgeOrigin: v4,
+				EdgeDestin: v18,
+				Cycle:      []XY{v4, v18, v19, v12, v9, v17},
+				Label:      inputBPopulated | inputAPopulated | inputBInSet,
 			},
 			{
 				// f5
-				EdgeOrigin:      v17,
-				EdgeDestin:      v10,
-				OuterComponent:  []XY{v17, v10, v18, v4},
-				InnerComponents: nil,
-				Label:           inputBPopulated | inputAPopulated | inputBInSet | inputAInSet,
+				EdgeOrigin: v17,
+				EdgeDestin: v10,
+				Cycle:      []XY{v17, v10, v18, v4},
+				Label:      inputBPopulated | inputAPopulated | inputBInSet | inputAInSet,
+			},
+			{
+				// f6
+				EdgeOrigin: v2,
+				EdgeDestin: v5,
+				Cycle:      []XY{v2, v5, v20},
+				Label:      populatedMask,
+			},
+			{
+				// f7
+				EdgeOrigin: v20,
+				EdgeDestin: v3,
+				Cycle:      []XY{v20, v3, v18},
+				Label:      inputBPopulated | inputAPopulated | inputAInSet,
+			},
+			{
+				// f8
+				EdgeOrigin: v18,
+				EdgeDestin: v11,
+				Cycle:      []XY{v18, v11, v19},
+				Label:      inputBPopulated | inputAPopulated | inputBInSet,
+			},
+			{
+				// f9
+				EdgeOrigin: v12,
+				EdgeDestin: v19,
+				Cycle:      []XY{v12, v19, v13},
+				Label:      populatedMask,
 			},
 		},
 	})
@@ -911,41 +1187,61 @@ func TestGraphOverlayFullyOverlappingEdge(t *testing.T) {
 		NumVerts: 6,
 		NumEdges: 14,
 		NumFaces: 3,
-		Faces: []FaceSpec{
-			{
-				EdgeOrigin:      v1,
-				EdgeDestin:      v0,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v0, v5, v4, v3, v2, v1}},
-				Label:           inputAPopulated | inputBPopulated,
-			},
-			{
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v4, v5},
-				InnerComponents: nil,
-				Label:           inputAPopulated | inputBPopulated | inputAInSet,
-			},
-			{
-				EdgeOrigin:      v1,
-				EdgeDestin:      v2,
-				OuterComponent:  []XY{v1, v2, v3, v4},
-				InnerComponents: nil,
-				Label:           inputAPopulated | inputBPopulated | inputBInSet,
-			},
+		Vertices: []VertexSpec{
+			{Vertices: []XY{v0, v5}, Label: populatedMask | inputAInSet},
+			{Vertices: []XY{v1, v4}, Label: populatedMask | inputAInSet | inputBInSet},
+			{Vertices: []XY{v3, v2}, Label: populatedMask | inputBInSet},
 		},
 		Edges: []EdgeLabelSpec{
 			{
-				Label: populatedMask | inputAInSet,
-				Edges: []XY{v1, v0, v5, v4},
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v1, v0, v5, v4},
 			},
 			{
-				Label: populatedMask | inputBInSet,
-				Edges: []XY{v4, v3, v2, v1},
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v4, v5, v0, v1},
 			},
 			{
-				Label: populatedMask | inputAInSet | inputBInSet,
-				Edges: []XY{v1, v4},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v4, v3, v2, v1},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v1, v2, v3, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: populatedMask | inputAInSet,
+				Edges:     []XY{v1, v4},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: populatedMask | inputBInSet,
+				Edges:     []XY{v4, v1},
+			},
+		},
+		Faces: []FaceSpec{
+			{
+				EdgeOrigin: v1,
+				EdgeDestin: v0,
+				Cycle:      []XY{v0, v5, v4, v3, v2, v1},
+				Label:      inputAPopulated | inputBPopulated,
+			},
+			{
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v4, v5},
+				Label:      inputAPopulated | inputBPopulated | inputAInSet,
+			},
+			{
+				EdgeOrigin: v1,
+				EdgeDestin: v2,
+				Cycle:      []XY{v1, v2, v3, v4},
+				Label:      inputAPopulated | inputBPopulated | inputBInSet,
 			},
 		},
 	})
@@ -963,8 +1259,8 @@ func TestGraphOverlayPartiallyOverlappingEdge(t *testing.T) {
 	   | f2   v5-------v4
 	   |       |       |
 	  v0------v1   f1  |
-	           |       |
-	          v2-------v3
+	    `-, f3 |       |
+	       `-,v2-------v3
 	*/
 
 	v0 := XY{0, 1}
@@ -978,43 +1274,78 @@ func TestGraphOverlayPartiallyOverlappingEdge(t *testing.T) {
 
 	CheckDCEL(t, overlay, DCELSpec{
 		NumVerts: 8,
-		NumEdges: 18,
-		NumFaces: 3,
-		Faces: []FaceSpec{
-			{
-				EdgeOrigin:      v1,
-				EdgeDestin:      v0,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v1, v0, v7, v6, v5, v4, v3, v2}},
-				Label:           inputAPopulated | inputBPopulated,
-			},
-			{
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v5, v6, v7},
-				InnerComponents: nil,
-				Label:           inputAPopulated | inputBPopulated | inputAInSet,
-			},
-			{
-				EdgeOrigin:      v1,
-				EdgeDestin:      v2,
-				OuterComponent:  []XY{v1, v2, v3, v4, v5},
-				InnerComponents: nil,
-				Label:           inputAPopulated | inputBPopulated | inputBInSet,
-			},
+		NumEdges: 20,
+		NumFaces: 4,
+		Vertices: []VertexSpec{
+			{Vertices: []XY{v0, v7, v6}, Label: populatedMask | inputAInSet},
+			{Vertices: []XY{v2, v3, v4}, Label: populatedMask | inputBInSet},
+			{Vertices: []XY{v1, v5}, Label: populatedMask | inputAInSet | inputBInSet},
 		},
 		Edges: []EdgeLabelSpec{
 			{
-				Label: populatedMask | inputAInSet,
-				Edges: []XY{v1, v0, v7, v6, v5},
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+				Edges:     []XY{v1, v0, v7, v6, v5},
 			},
 			{
-				Label: populatedMask | inputBInSet,
-				Edges: []XY{v5, v4, v3, v2, v1},
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated | inputAInSet,
+				Edges:     []XY{v5, v6, v7, v0, v1},
 			},
 			{
-				Label: populatedMask | inputAInSet | inputBInSet,
-				Edges: []XY{v1, v5},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+				Edges:     []XY{v5, v4, v3, v2, v1},
+			},
+			{
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+				Edges:     []XY{v1, v2, v3, v4, v5},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: populatedMask | inputAInSet,
+				Edges:     []XY{v1, v5},
+			},
+			{
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: populatedMask | inputBInSet,
+				Edges:     []XY{v5, v1},
+			},
+			{
+				EdgeLabel: populatedMask,
+				FaceLabel: 0,
+				Edges:     []XY{v2, v0, v2},
+			},
+		},
+		Faces: []FaceSpec{
+			{
+				// f0
+				EdgeOrigin: v0,
+				EdgeDestin: v7,
+				Cycle:      []XY{v0, v7, v6, v5, v4, v3, v2},
+				Label:      populatedMask,
+			},
+			{
+				// f1
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v5, v6, v7},
+				Label:      populatedMask | inputAInSet,
+			},
+			{
+				// f2
+				EdgeOrigin: v1,
+				EdgeDestin: v2,
+				Cycle:      []XY{v1, v2, v3, v4, v5},
+				Label:      populatedMask | inputBInSet,
+			},
+			{
+				// f3
+				EdgeOrigin: v2,
+				EdgeDestin: v1,
+				Cycle:      []XY{v2, v1, v0},
+				Label:      populatedMask,
 			},
 		},
 	})
@@ -1043,26 +1374,36 @@ func TestGraphOverlayFullyOverlappingCycle(t *testing.T) {
 		NumVerts: 4,
 		NumEdges: 8,
 		NumFaces: 2,
-		Faces: []FaceSpec{
-			{
-				EdgeOrigin:      v1,
-				EdgeDestin:      v0,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v1, v0, v3, v2}},
-				Label:           inputAPopulated | inputBPopulated,
-			},
-			{
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v2, v3},
-				InnerComponents: nil,
-				Label:           inputAPopulated | inputBPopulated | inputAInSet | inputBInSet,
-			},
-		},
+		Vertices: []VertexSpec{{
+			Label:    populatedMask | inSetMask,
+			Vertices: []XY{v0, v1, v2, v3},
+		}},
 		Edges: []EdgeLabelSpec{
 			{
-				Label: populatedMask | inputAInSet | inputBInSet,
-				Edges: []XY{v0, v1, v2, v3},
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: populatedMask | inSetMask,
+				Edges:     []XY{v0, v1, v2, v3, v0},
+			},
+			{
+				EdgeLabel: populatedMask | inSetMask,
+				FaceLabel: populatedMask,
+				Edges:     []XY{v0, v3, v2, v1, v0},
+			},
+		},
+		Faces: []FaceSpec{
+			{
+				// f0
+				EdgeOrigin: v1,
+				EdgeDestin: v0,
+				Cycle:      []XY{v1, v0, v3, v2},
+				Label:      inputAPopulated | inputBPopulated,
+			},
+			{
+				// f1
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v2, v3},
+				Label:      inputAPopulated | inputBPopulated | inputAInSet | inputBInSet,
 			},
 		},
 	})
@@ -1089,22 +1430,29 @@ func TestGraphOverlayTwoLineStringsIntersectingAtEndpoints(t *testing.T) {
 		NumVerts: 3,
 		NumEdges: 4,
 		NumFaces: 1,
-		Faces: []FaceSpec{{
-			EdgeOrigin:      v0,
-			EdgeDestin:      v1,
-			OuterComponent:  nil,
-			InnerComponents: [][]XY{{v0, v1, v2, v1}},
-			Label:           populatedMask,
-		}},
-		Edges: []EdgeLabelSpec{
-			{Edges: []XY{v1, v2}, Label: populatedMask | inputAInSet},
-			{Edges: []XY{v0, v1}, Label: populatedMask | inputBInSet},
-		},
 		Vertices: []VertexSpec{
 			{Vertices: []XY{v2}, Label: populatedMask | inputAInSet},
 			{Vertices: []XY{v0}, Label: populatedMask | inputBInSet},
 			{Vertices: []XY{v1}, Label: populatedMask | inSetMask},
 		},
+		Edges: []EdgeLabelSpec{
+			{
+				Edges:     []XY{v1, v2, v1},
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+			},
+			{
+				Edges:     []XY{v0, v1, v0},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+			},
+		},
+		Faces: []FaceSpec{{
+			EdgeOrigin: v0,
+			EdgeDestin: v1,
+			Cycle:      []XY{v0, v1, v2, v1},
+			Label:      populatedMask,
+		}},
 	})
 }
 
@@ -1113,6 +1461,14 @@ func TestGraphOverlayReproduceFaceAllocationBug(t *testing.T) {
 		"LINESTRING(0 1,1 0)",
 		"MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 0,2 1,3 1,3 0,2 0)))",
 	)
+
+	/*
+	  v3------v2    v7------v6
+	   |`, f2 |      |      |
+	   |  `,  |  f0  |  f3  |
+	   | f1 `,|      |      |
+	  v0------v1----v4------v5
+	*/
 
 	v0 := XY{0, 0}
 	v1 := XY{1, 0}
@@ -1125,49 +1481,73 @@ func TestGraphOverlayReproduceFaceAllocationBug(t *testing.T) {
 
 	CheckDCEL(t, overlay, DCELSpec{
 		NumVerts: 8,
-		NumEdges: 18,
+		NumEdges: 20,
 		NumFaces: 4,
-		Faces: []FaceSpec{
-			{
-				EdgeOrigin:     v1,
-				EdgeDestin:     v0,
-				OuterComponent: nil,
-				InnerComponents: [][]XY{
-					{v4, v7, v6, v5},
-					{v0, v3, v2, v1},
-				},
-				Label: populatedMask,
-			},
-			{
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  []XY{v0, v1, v3},
-				InnerComponents: nil,
-				Label:           populatedMask | inputBInSet,
-			},
-			{
-				EdgeOrigin:      v1,
-				EdgeDestin:      v2,
-				OuterComponent:  []XY{v1, v2, v3},
-				InnerComponents: nil,
-				Label:           populatedMask | inputBInSet,
-			},
-			{
-				EdgeOrigin:      v4,
-				EdgeDestin:      v5,
-				OuterComponent:  []XY{v4, v5, v6, v7},
-				InnerComponents: nil,
-				Label:           populatedMask | inputBInSet,
-			},
-		},
-		Edges: []EdgeLabelSpec{
-			{Edges: []XY{v1, v3}, Label: populatedMask | inputAInSet | inputBInSet},
-			{Edges: []XY{v0, v1, v2, v3}, Label: populatedMask | inputBInSet},
-			{Edges: []XY{v4, v5, v6, v7}, Label: populatedMask | inputBInSet},
-		},
 		Vertices: []VertexSpec{
 			{Vertices: []XY{v1, v3}, Label: populatedMask | inputAInSet | inputBInSet},
 			{Vertices: []XY{v0, v2, v4, v5, v6, v7}, Label: populatedMask | inputBInSet},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				Edges:     []XY{v1, v3, v1},
+				EdgeLabel: populatedMask | inputAInSet | inputBInSet,
+				FaceLabel: inputAPopulated,
+			},
+			{
+				Edges:     []XY{v0, v1, v2, v3, v0},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+			},
+			{
+				Edges:     []XY{v0, v3, v2, v1, v0},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+			},
+			{
+				Edges:     []XY{v4, v5, v6, v7, v4},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated | inputBInSet,
+			},
+			{
+				Edges:     []XY{v4, v7, v6, v5, v4},
+				EdgeLabel: populatedMask | inputBInSet,
+				FaceLabel: inputBPopulated,
+			},
+			{
+				Edges:     []XY{v1, v4, v1},
+				EdgeLabel: populatedMask,
+				FaceLabel: 0,
+			},
+		},
+		Faces: []FaceSpec{
+			{
+				// f0
+				EdgeOrigin: v1,
+				EdgeDestin: v0,
+				Cycle:      []XY{v1, v0, v3, v2, v1, v4, v7, v6, v5, v4},
+				Label:      populatedMask,
+			},
+			{
+				// f1
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v3},
+				Label:      populatedMask | inputBInSet,
+			},
+			{
+				// f2
+				EdgeOrigin: v1,
+				EdgeDestin: v2,
+				Cycle:      []XY{v1, v2, v3},
+				Label:      populatedMask | inputBInSet,
+			},
+			{
+				// f3
+				EdgeOrigin: v4,
+				EdgeDestin: v5,
+				Cycle:      []XY{v4, v5, v6, v7},
+				Label:      populatedMask | inputBInSet,
+			},
 		},
 	})
 }
@@ -1178,6 +1558,14 @@ func TestGraphOverlayReproducePointOnLineStringPrecisionBug(t *testing.T) {
 		"POINT(0.35355339059327373 0.35355339059327373)",
 	)
 
+	/*
+	      v2
+	      /
+	    v1
+	    /
+	  v0
+	*/
+
 	v0 := XY{0, 0}
 	v1 := XY{0.35355339059327373, 0.35355339059327373}
 	v2 := XY{1, 1}
@@ -1186,21 +1574,24 @@ func TestGraphOverlayReproducePointOnLineStringPrecisionBug(t *testing.T) {
 		NumVerts: 3,
 		NumEdges: 4,
 		NumFaces: 1,
-		Faces: []FaceSpec{
-			{
-				EdgeOrigin:      v0,
-				EdgeDestin:      v1,
-				OuterComponent:  nil,
-				InnerComponents: [][]XY{{v0, v1, v2, v1}},
-				Label:           populatedMask,
-			},
-		},
-		Edges: []EdgeLabelSpec{
-			{Edges: []XY{v0, v1, v2}, Label: populatedMask | inputAInSet},
-		},
 		Vertices: []VertexSpec{
 			{Vertices: []XY{v0, v2}, Label: populatedMask | inputAInSet},
 			{Vertices: []XY{v1}, Label: populatedMask | inputAInSet | inputBInSet},
+		},
+		Edges: []EdgeLabelSpec{
+			{
+				Edges:     []XY{v0, v1, v2, v1, v0},
+				EdgeLabel: populatedMask | inputAInSet,
+				FaceLabel: inputAPopulated,
+			},
+		},
+		Faces: []FaceSpec{
+			{
+				EdgeOrigin: v0,
+				EdgeDestin: v1,
+				Cycle:      []XY{v0, v1, v2, v1},
+				Label:      populatedMask,
+			},
 		},
 	})
 }


### PR DESCRIPTION


## Description

This greatly simplifies the overlay algorithm, in particular with the
"reassign face" step.

It requires a pre-processing stage where ghost edges are created to make
each input geometry fully connected. It also adds a ghost line between
the two geometries.

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) Yes, uses existing tests.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/284

## Benchmark Results

Benchmarks are marginally faster (note that benchmark coverage isn't great so far, and a performance improvement wasn't the intended or expected here).

```
name                    old time/op    new time/op    delta
Intersection/n=10-4        141µs ± 8%     142µs ± 9%    ~     (p=0.780 n=15+14)
Intersection/n=100-4      1.20ms ± 7%    1.10ms ± 4%  -8.15%  (p=0.000 n=15+14)
Intersection/n=1000-4     13.4ms ± 9%    12.2ms ±10%  -9.22%  (p=0.000 n=14+15)
Intersection/n=10000-4     153ms ± 6%     141ms ±11%  -7.52%  (p=0.000 n=14+15)

name                    old alloc/op   new alloc/op   delta
Intersection/n=10-4       56.2kB ± 0%    58.9kB ± 0%  +4.79%  (p=0.000 n=15+15)
Intersection/n=100-4       492kB ± 0%     473kB ± 0%  -3.76%  (p=0.000 n=15+15)
Intersection/n=1000-4     6.05MB ± 0%    5.86MB ± 0%  -3.24%  (p=0.000 n=15+15)
Intersection/n=10000-4    58.9MB ± 0%    56.1MB ± 0%  -4.65%  (p=0.000 n=15+13)

name                    old allocs/op  new allocs/op  delta
Intersection/n=10-4          713 ± 0%       749 ± 0%  +5.09%  (p=0.000 n=15+15)
Intersection/n=100-4       5.22k ± 0%     5.18k ± 0%  -0.83%  (p=0.000 n=15+11)
Intersection/n=1000-4      49.7k ± 0%     49.4k ± 0%  -0.59%  (p=0.000 n=15+15)
Intersection/n=10000-4      494k ± 0%      492k ± 0%  -0.41%  (p=0.000 n=15+15)
```
