### PR TITLE
Fix C Compiler Warning in `geos` package

### DIFF
--- a/geos/helper.c
+++ b/geos/helper.c
@@ -6,7 +6,7 @@
 // something went wrong). The size param is set to the number of bytes in the
 // returned WKB or WKT. The isWKT param is either set to 0 (WKB) or 1 (WKT),
 // indicating the type of marshalling used.
-unsigned char *marshal(
+char *marshal(
 	GEOSContextHandle_t handle,
 	const GEOSGeometry *g,
 	size_t *size,
@@ -21,7 +21,7 @@ unsigned char *marshal(
 	GEOSWKBWriter_destroy_r(handle, wkbWriter);
 	if (wkb) {
 		*isWKT = 0;
-		return wkb;
+		return (char*)wkb;
 	}
 
 	// Try WKT. This should work for all geometries, but will be a bit slower.
@@ -29,7 +29,7 @@ unsigned char *marshal(
 	if (!wktWriter) {
 		return NULL;
 	}
-	unsigned char *wkt = GEOSWKTWriter_write_r(handle, wktWriter, g);
+	char *wkt = GEOSWKTWriter_write_r(handle, wktWriter, g);
 	GEOSWKTWriter_destroy_r(handle, wktWriter);
 	if (wkt) {
 		*size = strlen(wkt);

--- a/geos/libgeos.go
+++ b/geos/libgeos.go
@@ -2,6 +2,7 @@ package geos
 
 /*
 #cgo LDFLAGS: -lgeos_c
+#cgo CFLAGS: -Wall
 #include "geos_c.h"
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +17,7 @@ GEOSContextHandle_t sf_init(void *userdata) {
 	return ctx;
 }
 
-unsigned char *marshal(GEOSContextHandle_t handle, const GEOSGeometry *g, size_t *size, char *isWKT);
+char *marshal(GEOSContextHandle_t handle, const GEOSGeometry *g, size_t *size, char *isWKT);
 
 GEOSGeometry const *noop(GEOSContextHandle_t handle, const GEOSGeometry *g) {
 	return g;


### PR DESCRIPTION
## Description

The underlying problem is that WKTs are `char*` but WKBs are `unsigned char*`. For our purpose it doesn't really matter (since they both convert to the Go `[]byte` type). The fix is to arbitrarily cast `wkb` from `unsigned char*` to `char*`.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/289

## Benchmark Results

- N/A