### PR TITLE
Fix Dockerfile

### DIFF
--- a/geos.Dockerfile
+++ b/geos.Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bullseye
 RUN apt-get -y update && \
-	apt-get install -y 'libgeos-dev=3.8.1-1' 'golang-1.15=1.15.2-1' 'ca-certificates' && \
+	apt-get install -y 'libgeos-dev=3.8.1-1' 'golang-1.15' 'ca-certificates' && \
 	rm -rf /var/lib/apt-lists/*
 ENV PATH=/usr/lib/go-1.15/bin:${PATH}


### PR DESCRIPTION
## Description

Please describe at a high level what the change is and why it is useful or
required.


Remove exact golang-1.15 version from geos.Dockerfile

This is because the exact versions seem to come and go, with historical versions not being kept long term. We're fine with just pointing to 1.15.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A