### PR TITLE
Performance improvement for DCEL re-noding

### DIFF
--- a/geom/alg_binary_op_test.go
+++ b/geom/alg_binary_op_test.go
@@ -800,6 +800,11 @@ func TestBinaryOp(t *testing.T) {
 			input2:  "MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1),(0 1,0.3333333333 0.6666666667,0.5 0.5),(0.5 0.5,1 0))",
 			fwdDiff: "MULTILINESTRING((0 0,0 1),(1 0,0 0))",
 		},
+		{
+			input1: "LINESTRING(1 0,0.5000000000000001 0.5,0 1)",
+			input2: "MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0),(0.5 0.5,1 0.5,1 1.5,0.5 1.5,0.5 0.5)))",
+			union:  "POLYGON((0 0,1 0,2 0,2 2,0 2,0 1,0 0),(0.5000000000000001 0.5,1 0.5,1 1.5,0.5 1.5,0.5000000000000001 0.5))",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g1 := geomFromWKT(t, geomCase.input1)

--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -244,7 +244,7 @@ func reNodeLineString(ls LineString, cut cutSet, nodes nodeSet) (LineString, err
 
 	// Copy over final point.
 	if n > 0 {
-		last := seq.GetXY(n - 1)
+		last := nodes.insertOrGet(seq.GetXY(n - 1))
 		newCoords = append(newCoords, last.X, last.Y)
 	}
 

--- a/geom/dcel_re_noding_test.go
+++ b/geom/dcel_re_noding_test.go
@@ -40,6 +40,12 @@ func TestReNode(t *testing.T) {
 			outputA: "LINESTRING(0 0,1 1,2 2)",
 			outputB: "LINESTRING(0 0,1 1,2 2)",
 		},
+		{
+			inputA:  "LINESTRING(0.5 1,0.5000000000000001 0.5)",
+			inputB:  "LINESTRING(0.5 0,0.5 0.5)",
+			outputA: "LINESTRING(0.5 1,0.5000000000000001 0.5)",
+			outputB: "LINESTRING(0.5 0,0.5000000000000001 0.5)",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			inA, err := UnmarshalWKT(tt.inputA)

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -590,6 +590,11 @@ func checkIntersects(h *Handle, g1, g2 geom.Geometry, log *log.Logger) error {
 		//  f # WRONG!!
 		// (1 row)
 		"LINESTRING(1 0,0.5000000000000001 0.5,0 1)": true,
+
+		// Simplefeatures sometimes gives an incorrect result for this due to
+		// numerical precision issues. Would be solved by
+		// https://github.com/peterstace/simplefeatures/issues/274
+		"LINESTRING(0.5 0,0.5000000000000001 0.5)": true,
 	}
 	if skipList[g1.AsText()] || skipList[g2.AsText()] {
 		// Skipping test because GEOS gives the incorrect result for *some*
@@ -663,6 +668,8 @@ var skipIntersection = map[string]bool{
 	"MULTILINESTRING((0 0,0.5 0.5,1 1,2 2.000000000000001),(1 0,0.5 0.5,0 1,-1 2.000000000000001))": true,
 	"POLYGON((1.5 1,1.353553390593274 0.6464466094067265,1.0000000000000009 0.5,0.646446609406727 0.6464466094067254,0.5 0.9999999999999983,0.6464466094067247 1.3535533905932722,0.9999999999999977 1.5,1.3535533905932717 1.3535533905932757,1.5 1))": true,
 	"POLYGON((1 0,-0.9 -0.2,-1 -0.0000000000000032310891488651735,-0.9 0.2,1 0))": true,
+	"LINESTRING(0.5 0,0.5000000000000001 0.5)":                                    true,
+	"LINESTRING(0.5 1,0.5000000000000001 0.5)":                                    true,
 }
 
 var skipDifference = map[string]bool{
@@ -680,6 +687,8 @@ var skipDifference = map[string]bool{
 	"MULTILINESTRING((0 0,2 2.000000000000001),(1 0,-1 2.000000000000001))":                                                                            true,
 	"MULTILINESTRING((0 0,0.5 0.5,1 1,2 2.000000000000001),(1 0,0.5 0.5,0 1,-1 2.000000000000001))":                                                    true,
 	"MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1),(0 1,0.3333333333 0.6666666667,0.5 0.5),(0.5 0.5,1 0))":                                               true,
+	"LINESTRING(0.5 0,0.5000000000000001 0.5)": true,
+	"LINESTRING(0.5 1,0.5000000000000001 0.5)": true,
 }
 
 var skipSymDiff = map[string]bool{


### PR DESCRIPTION
## Description

This change improves performance for DCEL renode preprocessing.

The main performance improvements are around smarter memory management, reducing GC overhead.

## Check List

Have you:

- Added unit tests? N/A (existing).

- Add cmprefimpl tests? (if appropriate?) N/A (existing).

## Related Issue

N/A

## Benchmark Results

25%-30% speed improvement for the DCEL benchmark (with a significant reduction in allocations).

```
name                                          old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-4                        206ns ±10%     203ns ±18%     ~     (p=0.598 n=14+15)
MarshalWKB/polygon/n=100-4                       605ns ±28%     565ns ±14%     ~     (p=0.222 n=15+13)
MarshalWKB/polygon/n=1000-4                     3.74µs ±17%    4.09µs ±35%     ~     (p=0.193 n=12+14)
MarshalWKB/polygon/n=10000-4                    33.8µs ±52%    33.3µs ±47%     ~     (p=0.786 n=13+15)
UnmarshalWKB/polygon/n=10-4                      317ns ±11%     321ns ±10%     ~     (p=0.517 n=15+13)
UnmarshalWKB/polygon/n=100-4                     793ns ±57%     839ns ±39%     ~     (p=0.155 n=14+15)
UnmarshalWKB/polygon/n=1000-4                   4.79µs ±59%    5.19µs ±53%     ~     (p=0.603 n=14+14)
UnmarshalWKB/polygon/n=10000-4                  45.4µs ±81%    42.7µs ±41%     ~     (p=0.701 n=14+14)
IntersectsLineStringWithLineString/n=10-4       1.97µs ±14%    1.95µs ±20%     ~     (p=0.626 n=15+13)
IntersectsLineStringWithLineString/n=100-4      25.1µs ±12%    27.9µs ±28%     ~     (p=0.202 n=13+14)
IntersectsLineStringWithLineString/n=1000-4      251µs ±15%     238µs ± 3%     ~     (p=0.108 n=15+13)
IntersectsLineStringWithLineString/n=10000-4    3.61ms ±33%    3.58ms ±30%     ~     (p=0.880 n=14+15)
LineStringIsSimpleZigZag/10-4                   2.22µs ±13%    2.13µs ± 8%     ~     (p=0.071 n=15+14)
LineStringIsSimpleZigZag/100-4                  62.2µs ±10%    63.7µs ± 9%     ~     (p=0.316 n=13+15)
LineStringIsSimpleZigZag/1000-4                 1.00ms ±12%    1.01ms ± 9%     ~     (p=0.813 n=15+14)
LineStringIsSimpleZigZag/10000-4                13.1ms ±11%    13.4ms ±10%     ~     (p=0.274 n=13+15)
PolygonSingleRingValidation/n=10-4              2.65µs ±31%    2.47µs ±10%     ~     (p=0.408 n=14+14)
PolygonSingleRingValidation/n=100-4             58.2µs ±12%    58.1µs ±14%     ~     (p=0.981 n=14+13)
PolygonSingleRingValidation/n=1000-4            1.04ms ± 5%    1.05ms ± 9%     ~     (p=0.935 n=15+15)
PolygonSingleRingValidation/n=10000-4           14.0ms ± 5%    14.1ms ± 3%     ~     (p=0.311 n=13+13)
PolygonMultipleRingsValidation/n=4-4            8.98µs ±12%    9.39µs ±24%     ~     (p=0.389 n=15+15)
PolygonMultipleRingsValidation/n=36-4           81.5µs ±12%    79.5µs ± 6%     ~     (p=0.367 n=15+15)
PolygonMultipleRingsValidation/n=400-4          1.09ms ±12%    1.04ms ± 4%     ~     (p=0.102 n=15+14)
PolygonMultipleRingsValidation/n=4096-4         13.1ms ±14%    12.5ms ±13%     ~     (p=0.108 n=15+13)
PolygonZigZagRingsValidation/n=10-4             18.1µs ±17%    18.0µs ±10%     ~     (p=0.806 n=15+15)
PolygonZigZagRingsValidation/n=100-4             258µs ±10%     259µs ± 9%     ~     (p=0.910 n=14+14)
PolygonZigZagRingsValidation/n=1000-4           3.22ms ± 9%    3.18ms ± 2%     ~     (p=0.980 n=14+12)
PolygonZigZagRingsValidation/n=10000-4          40.5ms ± 2%    41.7ms ±10%     ~     (p=0.123 n=12+13)
MultipolygonValidation/n=1-4                     346ns ±12%     355ns ±16%     ~     (p=0.470 n=14+15)
MultipolygonValidation/n=4-4                     885ns ± 9%     897ns ±21%     ~     (p=0.930 n=13+13)
MultipolygonValidation/n=16-4                   5.77µs ±23%    5.53µs ± 8%     ~     (p=0.169 n=14+13)
MultipolygonValidation/n=64-4                   32.9µs ± 7%    33.0µs ± 6%     ~     (p=0.567 n=15+15)
MultipolygonValidation/n=256-4                   193µs ± 3%     200µs ±16%     ~     (p=0.234 n=14+15)
MultipolygonValidation/n=1024-4                  975µs ±14%     970µs ±11%     ~     (p=0.935 n=15+15)
MultiPolygonTwoCircles/n=10-4                   4.73µs ±32%    4.42µs ±11%     ~     (p=0.187 n=15+15)
MultiPolygonTwoCircles/n=100-4                  47.5µs ±10%    46.2µs ± 9%     ~     (p=0.462 n=12+14)
MultiPolygonTwoCircles/n=1000-4                  498µs ± 6%     487µs ± 8%   -2.11%  (p=0.034 n=13+13)
MultiPolygonTwoCircles/n=10000-4                7.04ms ±18%    6.93ms ±14%     ~     (p=0.539 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4        5.29µs ± 4%    5.42µs ±10%     ~     (p=0.387 n=13+15)
MultiPolygonMultipleTouchingPoints/n=10-4       43.4µs ±12%    42.3µs ± 8%     ~     (p=0.285 n=14+14)
MultiPolygonMultipleTouchingPoints/n=100-4       491µs ± 9%     472µs ± 6%     ~     (p=0.065 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-4     5.98ms ±17%    5.68ms ±11%   -5.09%  (p=0.033 n=15+14)
Intersection/n=10-4                              104µs ± 7%      77µs ±12%  -26.07%  (p=0.000 n=13+15)
Intersection/n=100-4                             694µs ±16%     483µs ± 7%  -30.45%  (p=0.000 n=15+14)
Intersection/n=1000-4                           7.08ms ± 9%    4.83ms ± 7%  -31.70%  (p=0.000 n=14+13)
Intersection/n=10000-4                          74.3ms ± 6%    55.0ms ± 3%  -26.00%  (p=0.000 n=14+12)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             48.3µs ± 4%    48.8µs ± 5%     ~     (p=0.356 n=14+13)
Intersection/n=100-4                            95.9µs ± 9%    93.3µs ± 8%     ~     (p=0.056 n=15+15)
Intersection/n=1000-4                            420µs ±13%     400µs ±11%     ~     (p=0.112 n=14+15)
Intersection/n=10000-4                          3.70ms ±10%    3.62ms ±11%     ~     (p=0.345 n=15+15)
NoOp/n=10-4                                     3.86µs ±13%    3.86µs ± 7%     ~     (p=0.769 n=14+14)
NoOp/n=100-4                                    12.5µs ± 8%    12.6µs ± 7%     ~     (p=0.511 n=14+14)
NoOp/n=1000-4                                   89.0µs ±10%    88.0µs ± 5%     ~     (p=0.905 n=15+12)
NoOp/n=10000-4                                   971µs ±22%    1009µs ±25%     ~     (p=0.505 n=15+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                  30.2µs ± 6%    30.7µs ± 5%     ~     (p=0.123 n=14+15)
Delete/n=1000-4                                  713µs ±10%     702µs ± 2%     ~     (p=0.482 n=14+14)
Delete/n=10000-4                                32.5ms ± 5%    33.0ms ± 7%     ~     (p=0.217 n=15+13)
Bulk/n=10-4                                      922ns ±17%     959ns ±15%     ~     (p=0.197 n=15+14)
Bulk/n=100-4                                    15.6µs ±14%    15.8µs ±38%     ~     (p=0.635 n=14+14)
Bulk/n=1000-4                                    221µs ± 6%     219µs ± 6%     ~     (p=0.488 n=14+13)
Bulk/n=10000-4                                  3.05ms ± 6%    3.22ms ±11%   +5.38%  (p=0.008 n=13+15)
Bulk/n=100000-4                                 37.3ms ±15%    36.1ms ± 6%     ~     (p=0.505 n=14+15)
Insert/n=10-4                                   1.58µs ±25%    1.51µs ±22%     ~     (p=0.346 n=14+14)
Insert/n=100-4                                  33.9µs ± 5%    34.0µs ± 9%     ~     (p=0.653 n=15+15)
Insert/n=1000-4                                  554µs ±10%     544µs ± 6%     ~     (p=0.821 n=15+13)
Insert/n=10000-4                                7.81ms ±13%    7.51ms ± 3%     ~     (p=0.065 n=15+13)
Insert/n=100000-4                               94.0ms ± 2%    96.4ms ± 8%     ~     (p=0.093 n=12+15)
RangeSearch/n=10-4                              15.4ns ± 8%    15.0ns ± 2%     ~     (p=0.640 n=15+13)
RangeSearch/n=100-4                             58.3ns ± 1%    58.8ns ± 3%     ~     (p=0.142 n=13+14)
RangeSearch/n=1000-4                             214ns ± 2%     215ns ± 4%     ~     (p=0.364 n=14+14)
RangeSearch/n=10000-4                            763ns ± 8%     754ns ± 5%     ~     (p=0.742 n=15+13)
RangeSearch/n=100000-4                          7.16µs ± 4%    7.22µs ± 6%     ~     (p=0.425 n=14+15)

name                                          old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-4                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                   164kB ± 0%     164kB ± 0%     ~     (p=0.061 n=13+15)
IntersectsLineStringWithLineString/n=10-4       2.44kB ± 0%    2.44kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4      30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4      205kB ± 0%     205kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4    2.63MB ± 0%    2.63MB ± 0%     ~     (p=0.601 n=15+15)
LineStringIsSimpleZigZag/10-4                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                  21.6kB ± 0%    21.6kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                  230kB ± 0%     230kB ± 0%     ~     (p=0.897 n=15+15)
LineStringIsSimpleZigZag/10000-4                2.30MB ± 0%    2.30MB ± 0%     ~     (p=0.422 n=13+15)
PolygonSingleRingValidation/n=10-4              1.47kB ± 0%    1.47kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4             16.2kB ± 0%    16.2kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4             217kB ± 0%     217kB ± 0%     ~     (p=0.282 n=15+15)
PolygonSingleRingValidation/n=10000-4           2.23MB ± 0%    2.23MB ± 0%     ~     (p=0.106 n=12+13)
PolygonMultipleRingsValidation/n=4-4            5.31kB ± 0%    5.31kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4           43.6kB ± 0%    43.6kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           479kB ± 0%     479kB ± 0%     ~     (p=0.291 n=15+15)
PolygonMultipleRingsValidation/n=4096-4         4.92MB ± 0%    4.92MB ± 0%     ~     (p=0.156 n=15+15)
PolygonZigZagRingsValidation/n=10-4             11.1kB ± 0%    11.1kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4             132kB ± 0%     132kB ± 0%   +0.00%  (p=0.011 n=13+15)
PolygonZigZagRingsValidation/n=1000-4           1.02MB ± 0%    1.02MB ± 0%   -0.00%  (p=0.041 n=15+13)
PolygonZigZagRingsValidation/n=10000-4          11.9MB ± 0%    11.9MB ± 0%     ~     (p=0.758 n=15+13)
MultipolygonValidation/n=1-4                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                   3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                   15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                  63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  259kB ± 0%     259kB ± 0%     ~     (p=0.156 n=12+15)
MultiPolygonTwoCircles/n=10-4                   4.98kB ± 0%    4.98kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                  55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                  344kB ± 0%     344kB ± 0%     ~     (p=0.958 n=14+15)
MultiPolygonTwoCircles/n=10000-4                4.60MB ± 0%    4.60MB ± 0%     ~     (p=0.148 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1-4        3.94kB ± 0%    3.94kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4       22.6kB ± 0%    22.6kB ± 0%     ~     (p=0.343 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4       172kB ± 0%     172kB ± 0%     ~     (p=0.676 n=14+13)
MultiPolygonMultipleTouchingPoints/n=1000-4     2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.161 n=15+15)
Intersection/n=10-4                             47.4kB ± 0%    26.5kB ± 0%  -44.19%  (p=0.000 n=15+15)
Intersection/n=100-4                             319kB ± 0%     134kB ± 0%  -57.96%  (p=0.000 n=15+14)
Intersection/n=1000-4                           3.60MB ± 0%    1.70MB ± 0%  -52.73%  (p=0.000 n=15+15)
Intersection/n=10000-4                          36.3MB ± 0%    17.7MB ± 0%  -51.20%  (p=0.000 n=14+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                             1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
Intersection/n=100-4                            6.47kB ± 0%    6.47kB ± 0%   +0.01%  (p=0.011 n=13+15)
Intersection/n=1000-4                           55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
Intersection/n=10000-4                           558kB ± 0%     558kB ± 0%     ~     (p=0.687 n=14+15)
NoOp/n=10-4                                       968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100-4                                    5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                   49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                   492kB ± 0%     492kB ± 0%     ~     (p=0.176 n=15+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                 26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-4                                 412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10-4                                     1.45kB ± 0%    1.45kB ± 0%     ~     (all equal)
Bulk/n=100-4                                    19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-4                                   98.2kB ± 0%    98.2kB ± 0%     ~     (p=0.466 n=15+15)
Bulk/n=10000-4                                  1.57MB ± 0%    1.57MB ± 0%     ~     (p=0.411 n=13+15)
Bulk/n=100000-4                                 20.4MB ± 0%    20.4MB ± 0%     ~     (p=0.417 n=15+14)
Insert/n=10-4                                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-4                                  13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-4                                  132kB ± 0%     132kB ± 0%     ~     (all equal)
Insert/n=10000-4                                1.34MB ± 0%    1.34MB ± 0%     ~     (p=0.053 n=15+15)
Insert/n=100000-4                               13.5MB ± 0%    13.5MB ± 0%     ~     (p=0.191 n=13+12)
RangeSearch/n=10-4                               0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-4                              0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-4                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-4                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-4                           0.00B          0.00B          ~     (all equal)

name                                          old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4         10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4        74.0 ± 0%      74.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4        346 ± 0%       346 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4     5.47k ± 0%     5.47k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                    75.0 ± 0%      75.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                    797 ± 0%       797 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                 8.00k ± 0%     8.00k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                6.00 ± 0%      6.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4               57.0 ± 0%      57.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4               755 ± 0%       755 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4            7.73k ± 0%     7.73k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4              29.0 ± 0%      29.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4              239 ± 0%       239 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4           2.63k ± 0%     2.63k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4          26.9k ± 0%     26.9k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4               40.0 ± 0%      40.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4               378 ± 0%       378 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4            2.66k ± 0%     2.66k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4           32.6k ± 0%     32.6k ± 0%     ~     (p=0.590 n=15+15)
MultipolygonValidation/n=1-4                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                     392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                  1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                     26.0 ± 0%      26.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                     154 ± 0%       154 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                    698 ± 0%       698 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                 10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4          47.0 ± 0%      47.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4          294 ± 0%       294 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4       2.61k ± 0%     2.61k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4      26.7k ± 0%     26.7k ± 0%   -0.00%  (p=0.011 n=14+15)
Intersection/n=10-4                                624 ± 0%       261 ± 0%  -58.17%  (p=0.000 n=15+15)
Intersection/n=100-4                             3.74k ± 0%     0.42k ± 0%  -88.86%  (p=0.000 n=15+12)
Intersection/n=1000-4                            35.0k ± 0%      2.2k ± 0%  -93.77%  (p=0.000 n=15+15)
Intersection/n=10000-4                            348k ± 0%       20k ± 0%  -94.31%  (p=0.000 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                               48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=100-4                              48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                             48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                       33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                      33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                    65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                    480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-4                                 7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-4                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-4                                      70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-4                                      342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-4                                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-4                                  71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-4                                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-4                                    47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-4                                    457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-4                                 4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-4                                46.8k ± 0%     46.8k ± 0%     ~     (all equal)
RangeSearch/n=10-4                                0.00           0.00          ~     (all equal)
RangeSearch/n=100-4                               0.00           0.00          ~     (all equal)
RangeSearch/n=1000-4                              0.00           0.00          ~     (all equal)
RangeSearch/n=10000-4                             0.00           0.00          ~     (all equal)
RangeSearch/n=100000-4                            0.00           0.00          ~     (all equal)
```