### PR TITLE
Conventional WKT Error handling

### DIFF
--- a/geom/wkt_lexer.go
+++ b/geom/wkt_lexer.go
@@ -13,6 +13,7 @@ type wktLexer struct {
 func newWKTLexer(wkt string) wktLexer {
 	var scn scanner.Scanner
 	scn.Init(strings.NewReader(wkt))
+	scn.Mode = scanner.ScanInts | scanner.ScanFloats | scanner.ScanIdents
 	return wktLexer{scn: scn}
 }
 

--- a/geom/wkt_lexer_test.go
+++ b/geom/wkt_lexer_test.go
@@ -23,6 +23,22 @@ func TestWKTLexer(t *testing.T) {
 			"POINT EOF",
 			[]string{"POINT", "<EOF>"},
 		},
+		{
+			`"hello`,
+			[]string{`"`, "hello"},
+		},
+		{
+			`/*hello*/ foo`,
+			[]string{`/`, `*`, `hello`, `*`, `/`, `foo`},
+		},
+		{
+			`3.14`,
+			[]string{`3.14`},
+		},
+		{
+			`3.`,
+			[]string{`3.`},
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			lexer := newWKTLexer(tc.wkt)

--- a/geom/wkt_lexer_test.go
+++ b/geom/wkt_lexer_test.go
@@ -17,10 +17,6 @@ func TestWKTLexer(t *testing.T) {
 			[]string{"POINT", "(", "1", "2", ")"},
 		},
 		{
-			// If for some reason the user puts a literal "EOF" in the input
-			// WKT, it's replaced with an "<EOF>" in the token stream to
-			// differentiate it with "EOF" which is emitted at the end of
-			// stream.
 			"POINT EOF",
 			[]string{"POINT", "EOF"},
 		},

--- a/geom/wkt_lexer_test.go
+++ b/geom/wkt_lexer_test.go
@@ -1,6 +1,7 @@
 package geom
 
 import (
+	"io"
 	"reflect"
 	"strconv"
 	"testing"
@@ -21,7 +22,7 @@ func TestWKTLexer(t *testing.T) {
 			// differentiate it with "EOF" which is emitted at the end of
 			// stream.
 			"POINT EOF",
-			[]string{"POINT", "<EOF>"},
+			[]string{"POINT", "EOF"},
 		},
 		{
 			`"hello`,
@@ -44,9 +45,12 @@ func TestWKTLexer(t *testing.T) {
 			lexer := newWKTLexer(tc.wkt)
 			var got []string
 			for {
-				tok := lexer.next()
-				if tok == "EOF" {
-					break
+				tok, err := lexer.next()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					t.Fatal(err)
 				}
 				got = append(got, tok)
 			}

--- a/geom/wkt_lexer_test.go
+++ b/geom/wkt_lexer_test.go
@@ -1,0 +1,44 @@
+package geom
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestWKTLexer(t *testing.T) {
+	for i, tc := range []struct {
+		wkt  string
+		toks []string
+	}{
+		{
+			"POINT(1 2)",
+			[]string{"POINT", "(", "1", "2", ")"},
+		},
+		{
+			// If for some reason the user puts a literal "EOF" in the input
+			// WKT, it's replaced with an "<EOF>" in the token stream to
+			// differentiate it with "EOF" which is emitted at the end of
+			// stream.
+			"POINT EOF",
+			[]string{"POINT", "<EOF>"},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			lexer := newWKTLexer(tc.wkt)
+			var got []string
+			for {
+				tok := lexer.next()
+				if tok == "EOF" {
+					break
+				}
+				got = append(got, tok)
+			}
+			if !reflect.DeepEqual(got, tc.toks) {
+				t.Logf("want: %v", tc.toks)
+				t.Logf("got:  %v", got)
+				t.Error("mismatch")
+			}
+		})
+	}
+}

--- a/geom/wkt_test.go
+++ b/geom/wkt_test.go
@@ -37,6 +37,7 @@ func TestUnmarshalWKTInvalidGrammar(t *testing.T) {
 		{"left unbalanced point", "point ( 1 2"},
 		{"right unbalanced point", "point 1 2 )"},
 		{"point no parens", "point 1 1"},
+		{"left unbalance multipoint", "MULTIPOINT((0 0 X)"},
 
 		{"mixed empty", "LINESTRING(0 0, EMPTY, 2 2)"},
 		{"foo internal point", "LINESTRING(0 0, foo, 2 2)"},

--- a/geos/libgeos.go
+++ b/geos/libgeos.go
@@ -27,7 +27,6 @@ GEOSGeometry const *noop(GEOSContextHandle_t handle, const GEOSGeometry *g) {
 import "C"
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -625,10 +624,11 @@ func (h *handle) decode(gh *C.GEOSGeometry, opts []geom.ConstructorOption) (geom
 		return geom.Geometry{}, h.err()
 	}
 	defer C.GEOSFree_r(h.context, unsafe.Pointer(serialised))
-	byts := C.GoBytes(unsafe.Pointer(serialised), C.int(size))
 
 	if isWKT != 0 {
-		return geom.UnmarshalWKTFromReader(bytes.NewReader(byts), opts...)
+		wkt := C.GoStringN(serialised, C.int(size))
+		return geom.UnmarshalWKT(wkt, opts...)
 	}
-	return geom.UnmarshalWKB(byts, opts...)
+	wkb := C.GoBytes(unsafe.Pointer(serialised), C.int(size))
+	return geom.UnmarshalWKB(wkb, opts...)
 }


### PR DESCRIPTION
## Description

- Changes WKT parsing to use conventional Go error handling.

- Previously, had used "monad" style error handling. While this was concise, it was error prone to get right and hard to follow the flow.

- This change is a precursor to using standardised error types everywhere (rather than using anonymous error values from `fmt.Errorf`).

## Check List

Have you:

- Added unit tests? N/A, uses existing.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- Relates to https://github.com/peterstace/simplefeatures/issues/56

## Benchmark Results

- N/A, no benchmarks yet for WKT parsing.