### PR TITLE
Benchmark exhibiting O(n^2) polygon validation

### DIFF
--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -2,6 +2,7 @@ package geom_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math"
 	"math/rand"
 	"strconv"
@@ -227,6 +228,22 @@ func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 	}
 }
 
+func BenchmarkPolygonAnnulusValidation(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
+			outer := regularPolygon(XY{}, 1.0, sz/2).ExteriorRing()
+			inner := regularPolygon(XY{}, 0.5, sz/2).ExteriorRing()
+			rings := []LineString{outer, inner}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := NewPolygonFromRings(rings); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkMultipolygonValidation(b *testing.B) {
 	for _, sz := range []int{1, 2, 4, 8, 16, 32} {
 		b.Run(fmt.Sprintf("n=%d", sz*sz), func(b *testing.B) {
@@ -355,5 +372,19 @@ func BenchmarkWKTParsing(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkMultiPolygonValidation(b *testing.B) {
+	wkt, err := ioutil.ReadFile("/home/petsta/boundary_wkt.txt")
+	if err != nil {
+		b.Fatal(err)
+	}
+	wktStr := string(wkt)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := UnmarshalWKT(wktStr); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -2,7 +2,6 @@ package geom_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"strconv"
@@ -372,19 +371,5 @@ func BenchmarkWKTParsing(b *testing.B) {
 				}
 			}
 		})
-	}
-}
-
-func BenchmarkMultiPolygonValidation(b *testing.B) {
-	wkt, err := ioutil.ReadFile("/home/petsta/boundary_wkt.txt")
-	if err != nil {
-		b.Fatal(err)
-	}
-	wktStr := string(wkt)
-
-	for i := 0; i < b.N; i++ {
-		if _, err := UnmarshalWKT(wktStr); err != nil {
-			b.Fatal(err)
-		}
 	}
 }


### PR DESCRIPTION
## Description

Adds a benchmark that shows that polygon validation can take O(n^2) time in some cases.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

Clearly exhibits O(n^2) behaviour:

```
$ go test ./geom -run=\^\$ -bench=BenchmarkPolygonAnnulusValidation
goos: linux
goarch: amd64
pkg: github.com/peterstace/simplefeatures/geom
BenchmarkPolygonAnnulusValidation/n=10            186110              5983 ns/op
BenchmarkPolygonAnnulusValidation/n=100             6235            178734 ns/op
BenchmarkPolygonAnnulusValidation/n=1000             100          10715332 ns/op
BenchmarkPolygonAnnulusValidation/n=10000              2         980167768 ns/op
PASS
ok      github.com/peterstace/simplefeatures/geom       6.330s
```