### PR TITLE
Check single point for ring-in-ring case for Polygon validation

### DIFF
--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -2,6 +2,7 @@ package geom_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math"
 	"math/rand"
 	"strconv"
@@ -355,5 +356,19 @@ func BenchmarkWKTParsing(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkMultiPolygonValidation(b *testing.B) {
+	wkt, err := ioutil.ReadFile("/home/petsta/boundary_wkt.txt")
+	if err != nil {
+		b.Fatal(err)
+	}
+	wktStr := string(wkt)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := UnmarshalWKT(wktStr); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -2,7 +2,6 @@ package geom_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"strconv"
@@ -372,19 +371,5 @@ func BenchmarkWKTParsing(b *testing.B) {
 				}
 			}
 		})
-	}
-}
-
-func BenchmarkMultiPolygonValidation(b *testing.B) {
-	wkt, err := ioutil.ReadFile("/home/petsta/boundary_wkt.txt")
-	if err != nil {
-		b.Fatal(err)
-	}
-	wktStr := string(wkt)
-
-	for i := 0; i < b.N; i++ {
-		if _, err := UnmarshalWKT(wktStr); err != nil {
-			b.Fatal(err)
-		}
 	}
 }

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -125,15 +125,16 @@ func validatePolygon(rings []LineString, opts ctorOptionSet) error {
 		tree.Insert(box, i)
 	}
 
-	// All inner rings must be inside the outer ring.
+	// All inner rings must be inside the outer ring. We can just check an
+	// arbitrary point in each inner ring because we have already made sure
+	// that the rings don't intersect at multiple points.
 	for _, hole := range rings[1:] {
-		holeSeq := hole.Coordinates()
-		holeLen := holeSeq.Length()
-		for i := 0; i < holeLen; i++ {
-			xy := holeSeq.GetXY(i)
-			if relatePointToRing(xy, rings[0]) == exterior {
-				return errors.New("hole must be inside outer ring")
-			}
+		xy, ok := hole.StartPoint().XY()
+		if !ok {
+			continue
+		}
+		if relatePointToRing(xy, rings[0]) == exterior {
+			return errors.New("hole must be inside outer ring")
 		}
 	}
 


### PR DESCRIPTION
## Description

Adds a performance optimisation for Polygon validation. We only need to check a single point to ensure that interior rings are inside exterior rings. This is because we have already ensured that there is at most one intersection point between any interior rings and the exterior ring.

## Check List

Have you:

- Added unit tests? N/A, relies on existing tests.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results
Everything neutral except for:
```
PolygonMultipleRingsValidation/n=4            11.5µs ± 5%     8.5µs ± 4%  -26.11%  (p=0.000 n=14+15)
PolygonMultipleRingsValidation/n=36            104µs ± 2%      80µs ± 4%  -22.71%  (p=0.000 n=13+15)
PolygonMultipleRingsValidation/n=400          1.39ms ± 3%    1.12ms ± 6%  -19.08%  (p=0.000 n=14+13)
PolygonMultipleRingsValidation/n=4096         16.9ms ± 3%    14.0ms ± 4%  -17.20%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10             22.6µs ± 3%    18.6µs ± 3%  -17.83%  (p=0.000 n=14+14)
PolygonZigZagRingsValidation/n=100             333µs ± 3%     297µs ± 3%  -10.87%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000           4.37ms ± 5%    3.99ms ± 2%   -8.72%  (p=0.000 n=15+12)
PolygonZigZagRingsValidation/n=10000          57.6ms ± 3%    53.9ms ± 3%   -6.48%  (p=0.000 n=13+15)
PolygonAnnulusValidation/n=10                 5.63µs ± 4%    4.55µs ± 2%  -19.11%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=100                 174µs ± 3%      77µs ± 2%  -55.77%  (p=0.000 n=13+14)
PolygonAnnulusValidation/n=1000               10.7ms ± 4%     1.4ms ± 4%  -86.61%  (p=0.000 n=14+15)
PolygonAnnulusValidation/n=10000               928ms ± 1%      21ms ± 1%  -97.72%  (p=0.000 n=14+13)
```