### PR TITLE
Optimise LineString's IsSimple

### DIFF
--- a/geom/type_sequence.go
+++ b/geom/type_sequence.go
@@ -163,3 +163,32 @@ func firstAndLastLines(seq Sequence) (int, int, bool) {
 	}
 	return first, last, first != -1 && last != -1
 }
+
+// previousLine finds the index of the line segment previous to line segment i.
+// This may not be i-1 in the case where there are duplicate points. If there
+// is no previous line, then false will be returned.
+func previousLine(seq Sequence, i int) (int, bool) {
+	i--
+	for i >= 0 {
+		if _, ok := getLine(seq, i); ok {
+			return i, true
+		}
+		i--
+	}
+	return 0, false
+}
+
+// nextLine finds the index of the line segment after line segment i.  This may
+// not be i+1 in the case where there are duplicate points. If there is no next
+// line, then false will be returned.
+func nextLine(seq Sequence, i int) (int, bool) {
+	n := seq.Length()
+	i++
+	for i < n {
+		if _, ok := getLine(seq, i); ok {
+			return i, true
+		}
+		i++
+	}
+	return 0, false
+}


### PR DESCRIPTION
## Description

Rather than loading the RTree as we go, we can bulk load it right at the start. This reduces the amount of internal rebalancing that the RTree has to perform, at the expense of slightly more complicated index tracking.

## Check List

Have you:

- Added unit tests? Relies on existing.

- Add cmprefimpl tests? (if appropriate?) Relies on existing.

## Related Issue

N/A

## Benchmark Results
```
COMPARISON
name                                        old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10                        223ns ± 6%     221ns ± 2%     ~     (p=0.403 n=14+13)
MarshalWKB/polygon/n=100                       436ns ± 5%     432ns ± 4%     ~     (p=0.325 n=14+15)
MarshalWKB/polygon/n=1000                     2.39µs ± 3%    2.41µs ± 5%     ~     (p=0.281 n=15+15)
MarshalWKB/polygon/n=10000                    20.4µs ± 6%    20.6µs ± 4%     ~     (p=0.331 n=14+15)
UnmarshalWKB/polygon/n=10                      393ns ± 3%     398ns ± 5%     ~     (p=0.141 n=14+15)
UnmarshalWKB/polygon/n=100                     611ns ± 5%     607ns ± 3%     ~     (p=0.557 n=14+13)
UnmarshalWKB/polygon/n=1000                   2.82µs ± 5%    2.81µs ± 3%     ~     (p=0.974 n=15+14)
UnmarshalWKB/polygon/n=10000                  28.1µs ± 5%    27.9µs ± 6%     ~     (p=0.451 n=15+14)
IntersectsLineStringWithLineString/n=10       2.10µs ± 2%    2.13µs ± 4%   +1.61%  (p=0.029 n=12+15)
IntersectsLineStringWithLineString/n=100      29.5µs ± 3%    29.8µs ± 4%     ~     (p=0.270 n=14+15)
IntersectsLineStringWithLineString/n=1000      305µs ± 2%     304µs ± 5%     ~     (p=0.467 n=15+13)
IntersectsLineStringWithLineString/n=10000    3.92ms ± 3%    3.97ms ± 4%     ~     (p=0.057 n=13+13)
LineStringIsSimpleZigZag/10                   2.69µs ± 4%    2.76µs ± 3%   +2.75%  (p=0.000 n=15+14)
LineStringIsSimpleZigZag/100                  80.7µs ± 2%    44.5µs ± 2%  -44.87%  (p=0.000 n=13+14)
LineStringIsSimpleZigZag/1000                 1.31ms ± 3%    0.50ms ± 5%  -61.40%  (p=0.000 n=13+14)
LineStringIsSimpleZigZag/10000                18.6ms ± 1%     7.1ms ± 2%  -62.07%  (p=0.000 n=12+13)
PolygonSingleRingValidation/n=10              3.07µs ± 3%    3.54µs ± 2%  +15.56%  (p=0.000 n=14+13)
PolygonSingleRingValidation/n=100             74.3µs ± 2%    50.1µs ± 4%  -32.59%  (p=0.000 n=14+14)
PolygonSingleRingValidation/n=1000            1.39ms ± 5%    0.58ms ± 2%  -57.85%  (p=0.000 n=14+13)
PolygonSingleRingValidation/n=10000           19.4ms ± 2%     7.6ms ± 4%  -60.67%  (p=0.000 n=15+14)
PolygonMultipleRingsValidation/n=4            8.52µs ± 4%   10.60µs ± 1%  +24.39%  (p=0.000 n=15+12)
PolygonMultipleRingsValidation/n=36           81.7µs ± 5%    95.1µs ± 5%  +16.41%  (p=0.000 n=14+14)
PolygonMultipleRingsValidation/n=400          1.12ms ± 4%    1.27ms ± 4%  +13.76%  (p=0.000 n=15+14)
PolygonMultipleRingsValidation/n=4096         14.0ms ± 5%    16.0ms ± 4%  +14.87%  (p=0.000 n=15+14)
PolygonZigZagRingsValidation/n=10             18.8µs ± 5%    19.6µs ± 1%   +4.27%  (p=0.000 n=15+14)
PolygonZigZagRingsValidation/n=100             297µs ± 3%     234µs ± 5%  -21.06%  (p=0.000 n=14+14)
PolygonZigZagRingsValidation/n=1000           4.05ms ± 5%    2.62ms ± 6%  -35.32%  (p=0.000 n=15+14)
PolygonZigZagRingsValidation/n=10000          54.2ms ± 3%    34.2ms ± 6%  -36.89%  (p=0.000 n=13+14)
PolygonAnnulusValidation/n=10                 4.51µs ± 4%    5.42µs ± 7%  +20.15%  (p=0.000 n=14+13)
PolygonAnnulusValidation/n=100                77.2µs ± 3%    53.2µs ± 5%  -31.08%  (p=0.000 n=14+14)
PolygonAnnulusValidation/n=1000               1.41ms ± 2%    0.81ms ± 2%  -42.70%  (p=0.000 n=13+12)
PolygonAnnulusValidation/n=10000              21.1ms ± 4%     9.1ms ± 4%  -56.80%  (p=0.000 n=14+13)
MultipolygonValidation/n=1                     420ns ± 2%     413ns ± 2%   -1.59%  (p=0.001 n=14+13)
MultipolygonValidation/n=4                    1.14µs ± 2%    1.15µs ± 6%     ~     (p=0.858 n=13+14)
MultipolygonValidation/n=16                   7.03µs ± 1%    7.07µs ± 3%     ~     (p=0.369 n=13+14)
MultipolygonValidation/n=64                   42.6µs ± 3%    42.5µs ± 2%     ~     (p=0.769 n=14+14)
MultipolygonValidation/n=256                   259µs ± 4%     256µs ± 2%   -1.20%  (p=0.043 n=14+13)
MultipolygonValidation/n=1024                 1.30ms ± 6%    1.29ms ± 3%     ~     (p=0.964 n=13+15)
MultiPolygonTwoCircles/n=10                   5.24µs ± 2%    5.29µs ± 6%     ~     (p=0.540 n=15+14)
MultiPolygonTwoCircles/n=100                  59.3µs ± 3%    58.6µs ± 2%   -1.09%  (p=0.025 n=15+13)
MultiPolygonTwoCircles/n=1000                  623µs ± 3%     625µs ± 4%     ~     (p=0.983 n=15+14)
MultiPolygonTwoCircles/n=10000                9.63ms ± 5%    9.67ms ± 3%     ~     (p=0.595 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1        6.84µs ± 4%    6.75µs ± 1%   -1.39%  (p=0.041 n=14+14)
MultiPolygonMultipleTouchingPoints/n=10       55.0µs ± 2%    57.4µs ± 2%   +4.32%  (p=0.000 n=13+15)
MultiPolygonMultipleTouchingPoints/n=100       622µs ± 3%     620µs ± 2%     ~     (p=0.595 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000     7.74ms ± 4%    7.69ms ± 3%     ~     (p=0.505 n=14+15)
Intersection/n=10                              103µs ± 3%     103µs ± 3%     ~     (p=0.497 n=15+14)
Intersection/n=100                             652µs ± 4%     632µs ± 2%   -2.97%  (p=0.000 n=14+14)
Intersection/n=1000                           6.46ms ± 3%    6.04ms ± 3%   -6.52%  (p=0.000 n=15+12)
Intersection/n=10000                          73.8ms ± 3%    67.0ms ± 3%   -9.24%  (p=0.000 n=15+13)
WKTParsing/point                              1.96µs ± 2%    1.98µs ± 5%     ~     (p=0.409 n=13+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10                             63.4µs ± 5%    62.8µs ± 3%     ~     (p=0.205 n=13+12)
Intersection/n=100                             123µs ± 4%     122µs ± 4%     ~     (p=0.571 n=14+14)
Intersection/n=1000                            562µs ± 8%     569µs ±10%     ~     (p=0.920 n=13+13)
Intersection/n=10000                          4.64ms ± 6%    4.72ms ± 8%     ~     (p=0.223 n=13+13)
NoOp/n=10                                     4.92µs ± 4%    4.88µs ± 7%     ~     (p=0.281 n=13+13)
NoOp/n=100                                    16.4µs ± 7%    16.4µs ± 5%     ~     (p=0.793 n=13+14)
NoOp/n=1000                                    119µs ± 5%     120µs ± 7%     ~     (p=0.616 n=13+14)
NoOp/n=10000                                  1.15ms ± 7%    1.15ms ± 4%     ~     (p=0.977 n=12+12)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100                                  39.7µs ± 6%    39.5µs ± 3%     ~     (p=0.840 n=13+13)
Delete/n=1000                                  905µs ± 3%     900µs ± 4%     ~     (p=0.302 n=14+13)
Delete/n=10000                                40.0ms ± 4%    39.9ms ± 3%     ~     (p=0.720 n=13+14)
Bulk/n=10                                      990ns ± 7%     981ns ± 3%     ~     (p=0.591 n=14+13)
Bulk/n=100                                    17.1µs ± 3%    17.2µs ±10%     ~     (p=0.946 n=14+14)
Bulk/n=1000                                    270µs ± 2%     270µs ± 4%     ~     (p=0.685 n=13+14)
Bulk/n=10000                                  3.93ms ± 5%    3.92ms ± 4%     ~     (p=0.720 n=13+14)
Bulk/n=100000                                 56.2ms ± 5%    55.3ms ± 7%     ~     (p=0.098 n=15+15)
Insert/n=10                                   1.75µs ± 1%    1.76µs ± 5%     ~     (p=0.307 n=13+14)
Insert/n=100                                  43.9µs ± 2%    44.0µs ± 2%     ~     (p=0.992 n=15+14)
Insert/n=1000                                  725µs ± 2%     726µs ± 4%     ~     (p=0.880 n=15+14)
Insert/n=10000                                10.8ms ± 2%    10.8ms ± 5%     ~     (p=0.905 n=13+14)
Insert/n=100000                                138ms ± 4%     137ms ± 4%     ~     (p=0.488 n=14+13)
RangeSearch/n=10                              19.9ns ± 1%    20.0ns ± 3%     ~     (p=0.169 n=14+13)
RangeSearch/n=100                             80.5ns ± 3%    80.5ns ± 3%     ~     (p=0.783 n=14+13)
RangeSearch/n=1000                             295ns ± 2%     299ns ± 7%     ~     (p=0.297 n=13+15)
RangeSearch/n=10000                           1.03µs ± 3%    1.03µs ± 3%     ~     (p=0.574 n=14+13)
RangeSearch/n=100000                          10.2µs ± 2%    10.5µs ± 6%   +3.02%  (p=0.014 n=14+15)

name                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10                         232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100                      1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000                     16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000                     164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10                       284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100                    1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000                   16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000                   164kB ± 0%     164kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10       2.41kB ± 0%    2.41kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100      30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000      205kB ± 0%     205kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000    2.63MB ± 0%    2.63MB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10                   1.44kB ± 0%    1.83kB ± 0%  +27.22%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/100                  21.6kB ± 0%    24.0kB ± 0%  +11.00%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/1000                  230kB ± 0%     139kB ± 0%  -39.37%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10000                2.30MB ± 0%    1.97MB ± 0%  -14.30%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10              1.47kB ± 0%    2.18kB ± 0%  +48.37%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=100             16.2kB ± 0%    24.3kB ± 0%  +50.35%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=1000             217kB ± 0%     139kB ± 0%  -35.77%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10000           2.23MB ± 0%    1.97MB ± 0%  -11.27%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4            5.31kB ± 0%    6.15kB ± 0%  +15.81%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=36           43.6kB ± 0%    49.8kB ± 0%  +14.25%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=400           479kB ± 0%     547kB ± 0%  +14.06%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4096         4.92MB ± 0%    5.61MB ± 0%  +14.00%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10             11.1kB ± 0%    12.3kB ± 0%  +10.28%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100             132kB ± 0%     135kB ± 0%   +2.43%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000           1.02MB ± 0%    0.83MB ± 0%  -18.55%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000          11.9MB ± 0%    11.2MB ± 0%   -6.13%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=10                 3.48kB ± 0%    3.91kB ± 0%  +12.41%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=100                29.3kB ± 0%    28.2kB ± 0%   -3.66%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=1000                358kB ± 0%     379kB ± 0%   +5.81%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=10000              3.72MB ± 0%    3.89MB ± 0%   +4.47%  (p=0.000 n=15+15)
MultipolygonValidation/n=1                      385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4                      676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16                   3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64                   15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256                  63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024                  259kB ± 0%     259kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10                   4.98kB ± 0%    4.98kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100                  55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000                  344kB ± 0%     344kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000                4.60MB ± 0%    4.60MB ± 0%     ~     (p=0.891 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1        3.94kB ± 0%    3.94kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10       22.6kB ± 0%    22.6kB ± 0%     ~     (p=0.440 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100       172kB ± 0%     172kB ± 0%   +0.01%  (p=0.047 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000     2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.113 n=15+15)
Intersection/n=10                             26.5kB ± 0%    27.2kB ± 0%   +2.67%  (p=0.000 n=15+15)
Intersection/n=100                             134kB ± 0%     140kB ± 0%   +4.20%  (p=0.000 n=15+15)
Intersection/n=1000                           1.70MB ± 0%    1.69MB ± 0%   -0.80%  (p=0.000 n=15+15)
Intersection/n=10000                          17.7MB ± 0%    17.8MB ± 0%   +0.32%  (p=0.000 n=15+15)
WKTParsing/point                              1.81kB ± 0%    1.81kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10                             1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
Intersection/n=100                            6.47kB ± 0%    6.47kB ± 0%     ~     (all equal)
Intersection/n=1000                           55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
Intersection/n=10000                           558kB ± 0%     558kB ± 0%     ~     (all equal)
NoOp/n=10                                       968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100                                    5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000                                   49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000                                   492kB ± 0%     492kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100                                    712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000                                 26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000                                 412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10                                     1.45kB ± 0%    1.45kB ± 0%     ~     (all equal)
Bulk/n=100                                    19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000                                   98.2kB ± 0%    98.2kB ± 0%     ~     (all equal)
Bulk/n=10000                                  1.57MB ± 0%    1.57MB ± 0%     ~     (all equal)
Bulk/n=100000                                 20.4MB ± 0%    20.4MB ± 0%     ~     (all equal)
Insert/n=10                                   1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100                                  13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000                                  132kB ± 0%     132kB ± 0%     ~     (all equal)
Insert/n=10000                                1.34MB ± 0%    1.34MB ± 0%     ~     (all equal)
Insert/n=100000                               13.5MB ± 0%    13.5MB ± 0%     ~     (all equal)
RangeSearch/n=10                               0.00B          0.00B          ~     (all equal)
RangeSearch/n=100                              0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000                           0.00B          0.00B          ~     (all equal)

name                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100                        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10         9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100        73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000        345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000     5.46k ± 0%     5.46k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10                     5.00 ± 0%      7.00 ± 0%  +40.00%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/100                    75.0 ± 0%      71.0 ± 0%   -5.33%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/1000                    797 ± 0%       343 ± 0%  -56.96%  (p=0.000 n=15+15)
LineStringIsSimpleZigZag/10000                 8.00k ± 0%     5.46k ± 0%  -31.70%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10                6.00 ± 0%      9.00 ± 0%  +50.00%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=100               57.0 ± 0%      73.0 ± 0%  +28.07%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=1000               755 ± 0%       345 ± 0%  -54.30%  (p=0.000 n=15+15)
PolygonSingleRingValidation/n=10000            7.73k ± 0%     5.46k ± 0%  -29.28%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4              29.0 ± 0%      39.0 ± 0%  +34.48%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=36              239 ± 0%       313 ± 0%  +30.96%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=400           2.63k ± 0%     3.43k ± 0%  +30.51%  (p=0.000 n=15+15)
PolygonMultipleRingsValidation/n=4096          26.9k ± 0%     35.1k ± 0%  +30.41%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10               40.0 ± 0%      46.0 ± 0%  +15.00%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100               378 ± 0%       366 ± 0%   -3.17%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000            2.66k ± 0%     1.73k ± 0%  -35.11%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000           32.6k ± 0%     27.3k ± 0%  -16.29%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=10                   15.0 ± 0%      19.0 ± 0%  +26.67%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=100                  87.0 ± 0%      73.0 ± 0%  -16.09%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=1000                1.06k ± 0%     1.00k ± 0%   -6.21%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=10000               11.1k ± 0%     10.2k ± 0%   -7.58%  (p=0.000 n=15+15)
MultipolygonValidation/n=1                      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4                      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16                     27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256                     392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024                  1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10                     26.0 ± 0%      26.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100                     154 ± 0%       154 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000                    698 ± 0%       698 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000                 10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1          47.0 ± 0%      47.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10          294 ± 0%       294 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100       2.61k ± 0%     2.61k ± 0%     ~     (p=0.051 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000      26.7k ± 0%     26.7k ± 0%     ~     (p=0.111 n=15+15)
Intersection/n=10                                261 ± 0%       264 ± 0%   +1.15%  (p=0.000 n=15+15)
Intersection/n=100                               417 ± 0%       428 ± 0%   +2.54%  (p=0.000 n=15+12)
Intersection/n=1000                            2.18k ± 0%     2.04k ± 0%   -6.42%  (p=0.000 n=15+15)
Intersection/n=10000                           19.8k ± 0%     19.0k ± 0%   -3.74%  (p=0.000 n=14+15)
WKTParsing/point                                21.0 ± 0%      21.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10                               48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=100                              48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=1000                             48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=10000                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10                                       33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100                                      33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100                                    65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000                                    480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000                                 7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100                                      70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000                                      342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000                                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000                                  71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10                                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100                                    47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000                                    457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000                                 4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000                                46.8k ± 0%     46.8k ± 0%     ~     (all equal)
RangeSearch/n=10                                0.00           0.00          ~     (all equal)
RangeSearch/n=100                               0.00           0.00          ~     (all equal)
RangeSearch/n=1000                              0.00           0.00          ~     (all equal)
RangeSearch/n=10000                             0.00           0.00          ~     (all equal)
RangeSearch/n=100000                            0.00           0.00          ~     (all equal)

```