### PR TITLE
Better MultiPoint/MultiPoint intersects algorithm

### DIFF
--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -298,11 +298,18 @@ func hasIntersectionPointWithLineString(pt Point, ls LineString) bool {
 }
 
 func hasIntersectionMultiPointWithMultiPoint(mp1, mp2 MultiPoint) bool {
-	// To do: improve the speed efficiency, it's currently O(n1*n2)
-	for i := 0; i < mp1.NumPoints(); i++ {
-		pt := mp1.PointN(i)
-		if hasIntersectionPointWithMultiPoint(pt, mp2) {
-			return true // Point and MultiPoint both have dimension 0
+	mp1N := mp1.NumPoints()
+	set := make(map[XY]bool, mp1N)
+	for i := 0; i < mp1N; i++ {
+		if xy, ok := mp1.PointN(i).XY(); ok {
+			set[xy] = true
+		}
+	}
+
+	mp2N := mp2.NumPoints()
+	for i := 0; i < mp2N; i++ {
+		if xy, ok := mp2.PointN(i).XY(); ok && set[xy] {
+			return true
 		}
 	}
 	return false

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -99,6 +99,27 @@ func BenchmarkIntersectsLineStringWithLineString(b *testing.B) {
 	}
 }
 
+func BenchmarkIntersectsMultiPointWithMultiPoint(b *testing.B) {
+	for _, sz := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("n=%d", 4*sz), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(0))
+			var coordsA, coordsB []float64
+			for i := 0; i < sz; i++ {
+				coordsA = append(coordsA, rnd.Float64(), rnd.Float64())
+				coordsB = append(coordsB, rnd.Float64(), rnd.Float64())
+			}
+			mpA := NewMultiPoint(NewSequence(coordsA, DimXY)).AsGeometry()
+			mpB := NewMultiPoint(NewSequence(coordsB, DimXY)).AsGeometry()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if Intersects(mpA, mpB) {
+					b.Fatal("shouldn't have intersected")
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkLineStringIsSimpleZigZag(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(sz), func(b *testing.B) {

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -101,7 +101,7 @@ func BenchmarkIntersectsLineStringWithLineString(b *testing.B) {
 
 func BenchmarkIntersectsMultiPointWithMultiPoint(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("n=%d", 4*sz), func(b *testing.B) {
+		b.Run(fmt.Sprintf("n=%d", 2*sz), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
 			var coordsA, coordsB []float64
 			for i := 0; i < sz; i++ {


### PR DESCRIPTION
## Description

Improves the MultiPoint/MultiPoint intersects algorithm from O(n^2) to O(n).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/249

## Benchmark Results


```
IntersectsMultiPointWithMultiPoint/n=40       4.59µs ± 5%      1.89µs ± 2%  -58.90%  (p=0.000 n=15+14)
IntersectsMultiPointWithMultiPoint/n=400       408µs ± 1%        20µs ± 3%  -95.15%  (p=0.000 n=13+15)
IntersectsMultiPointWithMultiPoint/n=4000     40.3ms ± 3%       0.2ms ± 2%  -99.51%  (p=0.000 n=15+13)
IntersectsMultiPointWithMultiPoint/n=40000     3.97s ± 1%       0.00s ± 7%  -99.95%  (p=0.000 n=12+15)

name                                        old alloc/op   new alloc/op     delta
IntersectsMultiPointWithMultiPoint/n=40        0.00B          324.33B ± 0%    +Inf%  (p=0.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=400       0.00B         3082.27B ± 0%    +Inf%  (p=0.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=4000      0.00B        49305.53B ± 0%    +Inf%  (p=0.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=40000     0.00B       338629.47B ± 0%    +Inf%  (p=0.000 n=15+15)

name                                        old allocs/op  new allocs/op    delta
IntersectsMultiPointWithMultiPoint/n=40         0.00             1.00 ± 0%    +Inf%  (p=0.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=400        0.00             7.00 ± 0%    +Inf%  (p=0.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=4000       0.00             6.00 ± 0%    +Inf%  (p=0.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=40000      0.00            11.00 ± 0%    +Inf%  (p=0.000 n=15+15)
```