### PR TITLE
Add RTree Nearest Method

### DIFF
--- a/rtree/nearest.go
+++ b/rtree/nearest.go
@@ -2,6 +2,23 @@ package rtree
 
 import "container/heap"
 
+// Nearest finds the record in the RTree that is the closest to the input box
+// as measured by the Euclidean metric. Note that there may be multiple records
+// that are equidistant from the input box, in which case one is chosen
+// arbitrarily. If the RTree is empty, then false is returned.
+func (t *RTree) Nearest(box Box) (int, bool) {
+	var (
+		recordID int
+		found    bool
+	)
+	t.PrioritySearch(box, func(rid int) error {
+		recordID = rid
+		found = true
+		return Stop
+	})
+	return recordID, found
+}
+
 // PrioritySearch iterates over the records in the RTree in priority order of
 // distance from the input box (shortest distanace first using the Euclidean
 // metric).  The callback is called for every element iterated over. If an


### PR DESCRIPTION
## Description

I keep seeing a repeated pattern where we just want the single nearest record.
This is simple to do using PrioritySearch, but it requires a few lines of
boilerplate. The new method basically just encapsulates that boilerplate and
makes the RTree API a bit easier to use.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/242

## Benchmark Results

N/A