### PR TITLE
Reorder inputs for Distance and Intersects

### DIFF
--- a/geom/alg_distance.go
+++ b/geom/alg_distance.go
@@ -28,12 +28,16 @@ func Distance(g1, g2 Geometry) (float64, bool) {
 	//    geometry. We can stop searching if the bounding box in the RTree is
 	//    further away than the best distance so far.
 
-	// TODO: Swap g1 and g2 so that the indexed geometry is the "smaller" one.
-	// This is a performance optimization, so would need a benchmark to
-	// justify.
-
 	xys1, lns1 := extractXYsAndLines(g1)
 	xys2, lns2 := extractXYsAndLines(g2)
+
+	// Swap order so that the larger geometry goes into the RTree.
+	if len(xys1)+len(lns1) > len(xys2)+len(lns2) {
+		xys1, xys2 = xys2, xys1
+		lns1, lns2 = lns2, lns1
+		g1, g2 = g2, g1
+	}
+
 	tr := loadTree(xys2, lns2)
 	minDist := math.Inf(+1)
 

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -198,7 +198,10 @@ func hasIntersectionBetweenLines(
 ) (
 	bool, mlsWithMLSIntersectsExtension,
 ) {
-	// TODO: Should we conditionally reorder lines1 and lines2?
+	// Put the larger out of the two inputs into the RTree.
+	if len(lines1) > len(lines2) {
+		lines1, lines2 = lines2, lines1
+	}
 
 	bulk := make([]rtree.BulkItem, len(lines1))
 	for i, ln := range lines1 {

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -394,3 +394,37 @@ func BenchmarkWKTParsing(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkDistancePolygonToPolygonOrdering(b *testing.B) {
+	for _, sz := range []int{100, 1000} {
+		for _, swap := range []bool{false, true} {
+			b.Run(fmt.Sprintf("n=%d_swap=%t", sz, swap), func(b *testing.B) {
+				p1 := regularPolygon(geom.XY{0, 0}, 1.0, sz/10).AsGeometry()
+				p2 := regularPolygon(geom.XY{3, 0}, 1.0, sz).AsGeometry()
+				if swap {
+					p1, p2 = p2, p1
+				}
+				for i := 0; i < b.N; i++ {
+					Distance(p1, p2)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkIntersectionPolygonWithPolygonOrdering(b *testing.B) {
+	for _, sz := range []int{100, 1000} {
+		for _, swap := range []bool{false, true} {
+			b.Run(fmt.Sprintf("n=%d_swap=%t", sz, swap), func(b *testing.B) {
+				p1 := regularPolygon(geom.XY{0, 0}, 1.0, sz/10).AsGeometry()
+				p2 := regularPolygon(geom.XY{1, 0}, 1.0, sz).AsGeometry()
+				if swap {
+					p1, p2 = p2, p1
+				}
+				for i := 0; i < b.N; i++ {
+					Distance(p1, p2)
+				}
+			})
+		}
+	}
+}

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -594,7 +594,8 @@ func checkIntersects(h *Handle, g1, g2 geom.Geometry, log *log.Logger) error {
 		// Simplefeatures sometimes gives an incorrect result for this due to
 		// numerical precision issues. Would be solved by
 		// https://github.com/peterstace/simplefeatures/issues/274
-		"LINESTRING(0.5 0,0.5000000000000001 0.5)": true,
+		"LINESTRING(0.5 0,0.5000000000000001 0.5)":                              true,
+		"MULTILINESTRING((0 0,2 2.000000000000001),(1 0,-1 2.000000000000001))": true,
 	}
 	if skipList[g1.AsText()] || skipList[g2.AsText()] {
 		// Skipping test because GEOS gives the incorrect result for *some*


### PR DESCRIPTION
## Description

Conditionally reorders the inputs to Distance and Intersects so that the more complex geometry ends up in the acceleration structure.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/252

## Benchmark Results

```
COMPARISON
name                                                      old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10                                      228ns ± 4%     228ns ± 5%     ~     (p=0.444 n=13+15)
MarshalWKB/polygon/n=100                                     449ns ± 6%     445ns ± 4%     ~     (p=0.474 n=13+15)
MarshalWKB/polygon/n=1000                                   2.48µs ± 8%    2.43µs ± 4%     ~     (p=0.205 n=15+15)
MarshalWKB/polygon/n=10000                                  21.0µs ± 5%    21.2µs ± 7%     ~     (p=0.413 n=13+15)
UnmarshalWKB/polygon/n=10                                    402ns ± 3%     408ns ± 4%     ~     (p=0.336 n=11+14)
UnmarshalWKB/polygon/n=100                                   623ns ± 6%     623ns ± 6%     ~     (p=0.865 n=14+14)
UnmarshalWKB/polygon/n=1000                                 2.86µs ± 4%    2.88µs ± 6%     ~     (p=0.830 n=14+13)
UnmarshalWKB/polygon/n=10000                                28.5µs ± 5%    28.7µs ±11%     ~     (p=0.685 n=14+13)
IntersectsLineStringWithLineString/n=10                     2.17µs ± 2%    2.20µs ±10%     ~     (p=0.518 n=12+14)
IntersectsLineStringWithLineString/n=100                    30.7µs ± 6%    29.9µs ± 3%   -2.54%  (p=0.017 n=14+12)
IntersectsLineStringWithLineString/n=1000                    316µs ± 4%     310µs ± 4%   -1.81%  (p=0.014 n=15+14)
IntersectsLineStringWithLineString/n=10000                  4.22ms ±16%    4.02ms ± 7%   -4.71%  (p=0.005 n=14+14)
IntersectsMultiPointWithMultiPoint/n=20                     1.84µs ± 3%    1.85µs ± 4%     ~     (p=0.587 n=13+13)
IntersectsMultiPointWithMultiPoint/n=200                    19.6µs ± 3%    19.6µs ± 3%     ~     (p=0.946 n=14+14)
IntersectsMultiPointWithMultiPoint/n=2000                    192µs ± 1%     194µs ± 4%     ~     (p=0.747 n=14+15)
IntersectsMultiPointWithMultiPoint/n=20000                  2.12ms ± 8%    2.09ms ± 5%     ~     (p=0.250 n=15+15)
LineStringIsSimpleZigZag/10                                 2.87µs ± 4%    2.85µs ±11%     ~     (p=0.106 n=15+13)
LineStringIsSimpleZigZag/100                                46.1µs ± 9%    46.4µs ± 4%     ~     (p=0.201 n=14+15)
LineStringIsSimpleZigZag/1000                                516µs ± 6%     513µs ± 3%     ~     (p=0.650 n=15+13)
LineStringIsSimpleZigZag/10000                              7.18ms ± 3%    7.27ms ± 4%     ~     (p=0.294 n=13+15)
PolygonSingleRingValidation/n=10                            3.67µs ± 4%    3.69µs ± 4%     ~     (p=0.243 n=13+13)
PolygonSingleRingValidation/n=100                           52.2µs ± 9%    51.3µs ± 3%     ~     (p=0.430 n=14+13)
PolygonSingleRingValidation/n=1000                           602µs ± 8%     589µs ± 1%   -2.04%  (p=0.011 n=14+12)
PolygonSingleRingValidation/n=10000                         7.80ms ± 5%    7.73ms ± 4%     ~     (p=0.285 n=14+14)
PolygonMultipleRingsValidation/n=4                          10.9µs ± 4%    10.9µs ± 4%     ~     (p=0.846 n=13+15)
PolygonMultipleRingsValidation/n=36                         97.0µs ± 5%    97.1µs ± 5%     ~     (p=1.000 n=13+15)
PolygonMultipleRingsValidation/n=400                        1.31ms ± 6%    1.30ms ± 5%     ~     (p=0.094 n=14+14)
PolygonMultipleRingsValidation/n=4096                       16.4ms ± 5%    16.6ms ± 8%     ~     (p=0.567 n=15+15)
PolygonZigZagRingsValidation/n=10                           20.3µs ± 4%    18.1µs ± 2%  -10.65%  (p=0.000 n=14+13)
PolygonZigZagRingsValidation/n=100                           240µs ± 5%     196µs ± 4%  -18.15%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000                         2.66ms ± 4%    2.22ms ± 4%  -16.73%  (p=0.000 n=15+14)
PolygonZigZagRingsValidation/n=10000                        34.3ms ± 4%    27.5ms ± 7%  -19.65%  (p=0.000 n=13+14)
PolygonAnnulusValidation/n=10                               5.49µs ± 1%    5.48µs ± 2%     ~     (p=0.689 n=12+13)
PolygonAnnulusValidation/n=100                              55.3µs ± 8%    54.8µs ± 7%     ~     (p=0.561 n=15+14)
PolygonAnnulusValidation/n=1000                              849µs ± 8%     822µs ± 2%   -3.20%  (p=0.000 n=14+12)
PolygonAnnulusValidation/n=10000                            9.31ms ± 8%    9.28ms ± 3%     ~     (p=0.541 n=14+14)
MultipolygonValidation/n=1                                   437ns ± 4%     424ns ± 2%   -2.92%  (p=0.000 n=15+12)
MultipolygonValidation/n=4                                  1.18µs ± 5%    1.17µs ± 5%     ~     (p=0.190 n=13+13)
MultipolygonValidation/n=16                                 7.32µs ± 5%    7.16µs ± 1%   -2.09%  (p=0.023 n=14+12)
MultipolygonValidation/n=64                                 43.6µs ± 4%    44.1µs ± 4%     ~     (p=0.070 n=14+15)
MultipolygonValidation/n=256                                 260µs ± 3%     264µs ± 4%     ~     (p=0.052 n=13+15)
MultipolygonValidation/n=1024                               1.32ms ± 4%    1.32ms ± 5%     ~     (p=0.561 n=14+15)
MultiPolygonTwoCircles/n=10                                 5.42µs ± 3%    5.46µs ± 9%     ~     (p=0.812 n=13+15)
MultiPolygonTwoCircles/n=100                                60.8µs ± 7%    60.3µs ± 4%     ~     (p=0.813 n=14+15)
MultiPolygonTwoCircles/n=1000                                643µs ± 3%     637µs ± 4%     ~     (p=0.125 n=14+14)
MultiPolygonTwoCircles/n=10000                              9.87ms ±11%    9.78ms ± 8%     ~     (p=0.512 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1                      6.98µs ± 5%    6.99µs ± 5%     ~     (p=0.766 n=13+14)
MultiPolygonMultipleTouchingPoints/n=10                     56.5µs ± 5%    56.6µs ± 5%     ~     (p=0.856 n=13+15)
MultiPolygonMultipleTouchingPoints/n=100                     637µs ± 5%     635µs ± 2%     ~     (p=0.611 n=13+12)
MultiPolygonMultipleTouchingPoints/n=1000                   7.94ms ±13%    7.89ms ± 6%     ~     (p=0.892 n=13+15)
Intersection/n=10                                            105µs ± 3%     106µs ± 3%     ~     (p=0.769 n=12+13)
Intersection/n=100                                           656µs ± 6%     653µs ± 5%     ~     (p=0.983 n=14+15)
Intersection/n=1000                                         6.15ms ± 1%    6.19ms ± 3%     ~     (p=0.560 n=12+14)
Intersection/n=10000                                        67.8ms ± 3%    68.6ms ± 5%     ~     (p=0.302 n=13+14)
WKTParsing/point                                            2.10µs ± 7%    2.12µs ± 5%     ~     (p=0.356 n=14+13)
DistancePolygonToPolygonOrdering/n=100_swap=false            104µs ± 2%     105µs ± 4%   +1.37%  (p=0.043 n=13+14)
DistancePolygonToPolygonOrdering/n=100_swap=true             206µs ± 4%     105µs ± 3%  -49.13%  (p=0.000 n=14+14)
DistancePolygonToPolygonOrdering/n=1000_swap=false          1.79ms ± 3%    1.79ms ± 5%     ~     (p=0.949 n=14+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true           4.82ms ± 5%    1.81ms ± 5%  -62.46%  (p=0.000 n=14+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false     9.88µs ±10%    9.56µs ± 1%   -3.30%  (p=0.000 n=13+12)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true      27.0µs ± 3%     9.5µs ± 3%  -64.78%  (p=0.000 n=13+12)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false     105µs ± 7%     102µs ± 2%   -3.36%  (p=0.001 n=14+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true      281µs ± 2%     103µs ± 3%  -63.26%  (p=0.000 n=12+13)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10                                           65.9µs ± 9%    66.7µs ± 7%     ~     (p=0.345 n=15+15)
Intersection/n=100                                           128µs ±10%     128µs ± 9%     ~     (p=0.880 n=14+15)
Intersection/n=1000                                          581µs ± 7%     582µs ± 6%     ~     (p=0.747 n=14+15)
Intersection/n=10000                                        4.87ms ±10%    4.82ms ± 6%     ~     (p=0.982 n=14+14)
NoOp/n=10                                                   5.17µs ± 9%    5.04µs ± 3%     ~     (p=0.146 n=15+14)
NoOp/n=100                                                  16.9µs ± 6%    16.8µs ± 5%     ~     (p=0.652 n=15+14)
NoOp/n=1000                                                  125µs ±13%     124µs ± 6%     ~     (p=0.914 n=14+15)
NoOp/n=10000                                                1.28ms ±25%    1.19ms ±15%     ~     (p=0.274 n=15+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100                                                40.7µs ± 4%    41.5µs ± 7%     ~     (p=0.146 n=14+15)
Delete/n=1000                                                915µs ± 2%     921µs ± 4%     ~     (p=0.356 n=13+14)
Delete/n=10000                                              40.8ms ± 6%    41.0ms ± 5%     ~     (p=0.354 n=14+15)
Bulk/n=10                                                   1.00µs ± 4%    1.02µs ± 5%     ~     (p=0.181 n=13+14)
Bulk/n=100                                                  17.3µs ± 7%    17.5µs ± 5%     ~     (p=0.252 n=15+14)
Bulk/n=1000                                                  277µs ± 4%     276µs ± 3%     ~     (p=0.717 n=15+13)
Bulk/n=10000                                                4.04ms ± 6%    4.00ms ± 3%     ~     (p=0.451 n=15+14)
Bulk/n=100000                                               57.3ms ± 4%    57.7ms ± 6%     ~     (p=0.775 n=15+15)
Insert/n=10                                                 1.84µs ± 9%    1.84µs ± 6%     ~     (p=0.847 n=14+15)
Insert/n=100                                                44.9µs ± 2%    45.6µs ± 4%   +1.57%  (p=0.013 n=14+15)
Insert/n=1000                                                734µs ± 2%     751µs ± 3%   +2.23%  (p=0.010 n=12+13)
Insert/n=10000                                              11.0ms ± 2%    10.9ms ± 4%     ~     (p=0.172 n=15+14)
Insert/n=100000                                              140ms ± 3%     141ms ± 5%     ~     (p=1.000 n=14+14)
RangeSearch/n=10                                            20.3ns ± 1%    20.4ns ± 3%     ~     (p=0.759 n=10+14)
RangeSearch/n=100                                           82.6ns ± 6%    82.0ns ± 3%     ~     (p=0.434 n=14+14)
RangeSearch/n=1000                                           301ns ± 1%     303ns ± 4%     ~     (p=0.553 n=12+15)
RangeSearch/n=10000                                         1.06µs ± 3%    1.07µs ± 4%     ~     (p=0.078 n=13+14)
RangeSearch/n=100000                                        10.5µs ± 8%    10.6µs ± 9%     ~     (p=0.377 n=14+15)

name                                                      old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000                                   164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000                                 164kB ± 0%     164kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10                     2.41kB ± 0%    2.41kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000                    205kB ± 0%     205kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000                  2.63MB ± 0%    2.63MB ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20                       325B ± 0%      325B ± 0%     ~     (p=1.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=200                    3.08kB ± 0%    3.08kB ± 0%     ~     (p=0.910 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000                   49.3kB ± 0%    49.3kB ± 0%     ~     (p=0.148 n=15+14)
IntersectsMultiPointWithMultiPoint/n=20000                   339kB ± 0%     339kB ± 0%     ~     (p=0.109 n=15+15)
LineStringIsSimpleZigZag/10                                 1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000                                139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000                              1.97MB ± 0%    1.97MB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10                            2.18kB ± 0%    2.18kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100                           24.3kB ± 0%    24.3kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000                           139kB ± 0%     139kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000                         1.97MB ± 0%    1.97MB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4                          6.15kB ± 0%    6.15kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36                         49.8kB ± 0%    49.8kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400                         547kB ± 0%     547kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096                       5.61MB ± 0%    5.61MB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10                           12.3kB ± 0%     9.3kB ± 0%  -23.99%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100                           135kB ± 0%      88kB ± 0%  -34.90%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000                          828kB ± 0%     551kB ± 0%  -33.51%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000                        11.2MB ± 0%     7.2MB ± 0%  -35.30%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=10                               3.91kB ± 0%    3.91kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100                              28.2kB ± 0%    28.2kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000                              379kB ± 0%     379kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000                            3.89MB ± 0%    3.89MB ± 0%     ~     (all equal)
MultipolygonValidation/n=1                                    385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4                                    676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16                                 3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64                                 15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256                                63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024                                259kB ± 0%     259kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10                                 4.98kB ± 0%    4.98kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100                                55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000                                344kB ± 0%     344kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000                              4.60MB ± 0%    4.60MB ± 0%   +0.00%  (p=0.014 n=15+12)
MultiPolygonMultipleTouchingPoints/n=1                      3.94kB ± 0%    3.94kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10                     22.6kB ± 0%    22.6kB ± 0%     ~     (p=1.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100                     172kB ± 0%     172kB ± 0%     ~     (p=0.846 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000                   2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.480 n=15+15)
Intersection/n=10                                           27.2kB ± 0%    27.2kB ± 0%     ~     (p=0.248 n=15+13)
Intersection/n=100                                           140kB ± 0%     140kB ± 0%     ~     (p=0.959 n=15+15)
Intersection/n=1000                                         1.69MB ± 0%    1.69MB ± 0%     ~     (p=0.486 n=15+15)
Intersection/n=10000                                        17.8MB ± 0%    17.8MB ± 0%     ~     (p=0.902 n=15+15)
WKTParsing/point                                            1.93kB ± 0%    1.93kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false           40.7kB ± 0%    40.7kB ± 0%     ~     (p=0.582 n=15+14)
DistancePolygonToPolygonOrdering/n=100_swap=true            65.7kB ± 0%    40.7kB ± 0%  -38.12%  (p=0.000 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=false           369kB ± 0%     369kB ± 0%     ~     (p=0.600 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true            742kB ± 0%     369kB ± 0%  -50.26%  (p=0.000 n=15+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false     5.51kB ± 0%    5.51kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true      27.6kB ± 0%     5.5kB ± 0%  -80.05%  (p=0.000 n=14+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false    60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.200 n=14+14)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true      175kB ± 0%      60kB ± 0%  -65.73%  (p=0.000 n=11+13)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10                                           1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
Intersection/n=100                                          6.47kB ± 0%    6.47kB ± 0%     ~     (all equal)
Intersection/n=1000                                         55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
Intersection/n=10000                                         558kB ± 0%     558kB ± 0%     ~     (all equal)
NoOp/n=10                                                     968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100                                                  5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000                                                 49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000                                                 492kB ± 0%     492kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100                                                  712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000                                               26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000                                               412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10                                                   1.45kB ± 0%    1.45kB ± 0%     ~     (all equal)
Bulk/n=100                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (all equal)
Bulk/n=10000                                                1.57MB ± 0%    1.57MB ± 0%     ~     (all equal)
Bulk/n=100000                                               20.4MB ± 0%    20.4MB ± 0%     ~     (all equal)
Insert/n=10                                                 1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100                                                13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000                                                132kB ± 0%     132kB ± 0%     ~     (all equal)
Insert/n=10000                                              1.34MB ± 0%    1.34MB ± 0%     ~     (all equal)
Insert/n=100000                                             13.5MB ± 0%    13.5MB ± 0%     ~     (all equal)
RangeSearch/n=10                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000                                         0.00B          0.00B          ~     (all equal)

name                                                      old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10                              9.00 ± 0%      9.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100                             73.0 ± 0%      73.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000                             345 ± 0%       345 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000                          5.46k ± 0%     5.46k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4                            39.0 ± 0%      39.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36                            313 ± 0%       313 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400                         3.43k ± 0%     3.43k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096                        35.1k ± 0%     35.1k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10                             46.0 ± 0%      38.0 ± 0%  -17.39%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=100                             366 ± 0%       230 ± 0%  -37.16%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=1000                          1.73k ± 0%     1.05k ± 0%  -39.40%  (p=0.000 n=15+15)
PolygonZigZagRingsValidation/n=10000                         27.3k ± 0%     16.4k ± 0%  -39.96%  (p=0.000 n=15+15)
PolygonAnnulusValidation/n=10                                 19.0 ± 0%      19.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100                                73.0 ± 0%      73.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000                             10.2k ± 0%     10.2k ± 0%     ~     (all equal)
MultipolygonValidation/n=1                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4                                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64                                   99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256                                   392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024                                1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10                                   26.0 ± 0%      26.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100                                   154 ± 0%       154 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000                                  698 ± 0%       698 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000                               10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1                        47.0 ± 0%      47.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10                        294 ± 0%       294 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100                     2.61k ± 0%     2.61k ± 0%     ~     (p=0.183 n=15+11)
MultiPolygonMultipleTouchingPoints/n=1000                    26.7k ± 0%     26.7k ± 0%     ~     (p=0.202 n=14+15)
Intersection/n=10                                              264 ± 0%       264 ± 0%     ~     (all equal)
Intersection/n=100                                             428 ± 0%       428 ± 0%     ~     (p=1.000 n=15+15)
Intersection/n=1000                                          2.04k ± 0%     2.04k ± 0%     ~     (p=0.866 n=15+15)
Intersection/n=10000                                         19.0k ± 0%     19.0k ± 0%     ~     (p=0.830 n=15+15)
WKTParsing/point                                              21.0 ± 0%      21.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true               886 ± 0%       234 ± 0%  -73.59%  (p=0.000 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=false           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true            10.5k ± 0%      2.1k ± 0%  -79.88%  (p=0.000 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true        77.0 ± 0%      13.0 ± 0%  -83.12%  (p=0.000 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true        349 ± 0%        77 ± 0%  -77.94%  (p=0.000 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10                                             48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=100                                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=1000                                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=10000                                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100                                                  65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000                                                  480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000                                               7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100                                                  47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000                                                  457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000                                               4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000                                              46.8k ± 0%     46.8k ± 0%     ~     (all equal)
RangeSearch/n=10                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000                                          0.00           0.00          ~     (all equal)

```