### PR TITLE
Shortcut in `appendNewNode`

### DIFF
--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -38,11 +38,14 @@ func appendNewNodesFromLinePointIntersection(dst []XY, ln line, pt XY, eps float
 // node. But it only does so if the node is *not* already an endpoint of ln
 // (since those nodes already exist).
 func appendNewNode(dst []XY, nodes nodeSet, ln line, xy XY) []XY {
-	xy = nodes.insertOrGet(xy)
-	if xy != ln.a && xy != ln.b && (len(dst) == 0 || xy != dst[len(dst)-1]) {
-		dst = append(dst, xy)
+	if xy == ln.a || xy == ln.b {
+		return dst
 	}
-	return dst
+	xy = nodes.insertOrGet(xy)
+	if xy == ln.a || xy == ln.b {
+		return dst
+	}
+	return append(dst, xy)
 }
 
 // ulpSizeForLine finds the maximum ULP out of the 4 float64s that make a line.

--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -38,9 +38,15 @@ func appendNewNodesFromLinePointIntersection(dst []XY, ln line, pt XY, eps float
 // node. But it only does so if the node is *not* already an endpoint of ln
 // (since those nodes already exist).
 func appendNewNode(dst []XY, nodes nodeSet, ln line, xy XY) []XY {
+	// Because ln is already noded, we can skip the nodes lookup if xy is
+	// _exactly_ on the nodes. This will be the case for adjacent lines, and
+	// provides a significant performance boost.
 	if xy == ln.a || xy == ln.b {
 		return dst
 	}
+
+	// Now we perform the regular noding of xy, and check it against the line
+	// endpoints.
 	xy = nodes.insertOrGet(xy)
 	if xy == ln.a || xy == ln.b {
 		return dst


### PR DESCRIPTION
## Description

Adds a performance optimisation in `appendNewNode`:

- If the point (node) we are adding is one of the endpoints of the line, then we can skip adding the node (since it will already be added). Previously, we snap the point in case it already exists before doing the check.

- _However_, we can do a regular check first, since the endpoints of the line are already snapped.

## Check List

Have you:

- Added unit tests? Yes, existing.

- Add cmprefimpl tests? (if appropriate?) Yes, existing.

## Related Issue

- N/A

## Benchmark Results

~10-20% speed improvement for the intersection benchmark.

```
COMPARISON
name                                                        old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-4                                      293ns ±81%     209ns ±20%     ~     (p=0.071 n=14+14)
MarshalWKB/polygon/n=100-4                                     791ns ±69%     610ns ±35%     ~     (p=0.198 n=14+12)
MarshalWKB/polygon/n=1000-4                                  9.75µs ±117%    5.66µs ±74%     ~     (p=0.183 n=15+12)
MarshalWKB/polygon/n=10000-4                                  42.5µs ±97%    40.7µs ±96%     ~     (p=0.839 n=14+14)
UnmarshalWKB/polygon/n=10-4                                    314ns ± 7%     321ns ± 7%   +2.29%  (p=0.047 n=14+15)
UnmarshalWKB/polygon/n=100-4                                   706ns ±13%     977ns ±98%     ~     (p=0.059 n=13+14)
UnmarshalWKB/polygon/n=1000-4                                 4.28µs ±50%   5.89µs ±133%     ~     (p=0.141 n=13+14)
UnmarshalWKB/polygon/n=10000-4                               56.7µs ±130%    44.0µs ±65%     ~     (p=0.614 n=15+12)
IntersectsLineStringWithLineString/n=10-4                     1.87µs ±13%    1.87µs ± 8%     ~     (p=0.747 n=14+15)
IntersectsLineStringWithLineString/n=100-4                    25.7µs ±13%    25.0µs ± 4%     ~     (p=0.164 n=15+11)
IntersectsLineStringWithLineString/n=1000-4                    246µs ± 5%     247µs ±11%     ~     (p=0.583 n=14+13)
IntersectsLineStringWithLineString/n=10000-4                  3.42ms ±12%    3.42ms ± 7%     ~     (p=0.728 n=13+12)
IntersectsMultiPointWithMultiPoint/n=20-4                     1.32µs ± 5%    1.38µs ±14%   +4.30%  (p=0.007 n=13+15)
IntersectsMultiPointWithMultiPoint/n=200-4                    14.1µs ± 2%    14.2µs ± 8%     ~     (p=0.503 n=12+13)
IntersectsMultiPointWithMultiPoint/n=2000-4                    146µs ±11%     143µs ± 2%     ~     (p=0.687 n=14+11)
IntersectsMultiPointWithMultiPoint/n=20000-4                  1.56ms ± 7%    1.51ms ± 2%   -2.75%  (p=0.012 n=15+12)
LineStringIsSimpleZigZag/10-4                                 2.34µs ±24%    2.31µs ±12%     ~     (p=0.953 n=13+14)
LineStringIsSimpleZigZag/100-4                                35.8µs ±15%    34.8µs ±11%     ~     (p=0.156 n=15+13)
LineStringIsSimpleZigZag/1000-4                                411µs ±18%     404µs ± 9%     ~     (p=0.448 n=13+13)
LineStringIsSimpleZigZag/10000-4                              5.33ms ±17%    5.31ms ±11%     ~     (p=0.635 n=14+14)
PolygonSingleRingValidation/n=10-4                            2.94µs ± 9%    2.92µs ± 5%     ~     (p=0.860 n=12+14)
PolygonSingleRingValidation/n=100-4                           40.2µs ± 7%    39.3µs ± 5%   -2.24%  (p=0.034 n=13+13)
PolygonSingleRingValidation/n=1000-4                           457µs ± 2%     467µs ±10%     ~     (p=0.648 n=12+15)
PolygonSingleRingValidation/n=10000-4                         5.71ms ±17%    5.60ms ±15%     ~     (p=1.000 n=15+14)
PolygonMultipleRingsValidation/n=4-4                          8.28µs ± 4%    8.35µs ± 6%     ~     (p=0.630 n=12+12)
PolygonMultipleRingsValidation/n=36-4                         76.1µs ±10%    77.0µs ± 8%     ~     (p=0.477 n=14+15)
PolygonMultipleRingsValidation/n=400-4                        1.01ms ±12%    1.01ms ±11%     ~     (p=0.685 n=13+14)
PolygonMultipleRingsValidation/n=4096-4                       11.5ms ± 2%    11.6ms ± 4%     ~     (p=0.374 n=12+14)
PolygonZigZagRingsValidation/n=10-4                           14.4µs ±11%    14.2µs ± 7%     ~     (p=0.856 n=15+13)
PolygonZigZagRingsValidation/n=100-4                           158µs ±21%     153µs ±11%     ~     (p=0.511 n=14+14)
PolygonZigZagRingsValidation/n=1000-4                         1.66ms ±10%    1.65ms ± 8%     ~     (p=0.806 n=15+15)
PolygonZigZagRingsValidation/n=10000-4                        25.1ms ±71%    20.6ms ± 3%     ~     (p=0.095 n=14+12)
PolygonAnnulusValidation/n=10-4                               4.41µs ± 9%    4.53µs ±14%     ~     (p=0.089 n=12+13)
PolygonAnnulusValidation/n=100-4                              41.3µs ±11%    41.2µs ± 6%     ~     (p=0.667 n=14+14)
PolygonAnnulusValidation/n=1000-4                              649µs ±10%     659µs ±10%     ~     (p=0.259 n=13+14)
PolygonAnnulusValidation/n=10000-4                            7.49ms ± 5%    7.35ms ± 4%     ~     (p=0.143 n=12+12)
MultipolygonValidation/n=1-4                                   354ns ±10%     343ns ± 5%     ~     (p=0.082 n=13+14)
MultipolygonValidation/n=4-4                                   918ns ±13%     905ns ±10%     ~     (p=0.641 n=13+14)
MultipolygonValidation/n=16-4                                 5.64µs ± 8%   8.41µs ±109%     ~     (p=0.290 n=14+15)
MultipolygonValidation/n=64-4                                 33.3µs ± 8%    34.0µs ± 9%     ~     (p=0.246 n=14+14)
MultipolygonValidation/n=256-4                                 199µs ± 7%     196µs ± 5%     ~     (p=0.550 n=14+13)
MultipolygonValidation/n=1024-4                                971µs ±11%     974µs ± 8%     ~     (p=0.780 n=14+15)
MultiPolygonTwoCircles/n=10-4                                 4.56µs ±10%    4.65µs ±12%     ~     (p=0.616 n=14+13)
MultiPolygonTwoCircles/n=100-4                                49.7µs ±21%    47.5µs ± 7%     ~     (p=0.840 n=13+13)
MultiPolygonTwoCircles/n=1000-4                                490µs ± 4%     510µs ±13%     ~     (p=0.053 n=14+12)
MultiPolygonTwoCircles/n=10000-4                              6.71ms ± 5%    7.21ms ±11%   +7.47%  (p=0.012 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1-4                      5.56µs ±11%    5.35µs ± 3%     ~     (p=0.069 n=14+12)
MultiPolygonMultipleTouchingPoints/n=10-4                     42.4µs ± 5%    42.8µs ± 4%     ~     (p=0.274 n=12+14)
MultiPolygonMultipleTouchingPoints/n=100-4                     479µs ± 4%     479µs ± 3%     ~     (p=0.936 n=13+12)
MultiPolygonMultipleTouchingPoints/n=1000-4                   5.57ms ± 8%    5.61ms ± 7%     ~     (p=0.458 n=14+13)
Intersection/n=10-4                                           77.2µs ± 4%    68.0µs ± 6%  -11.91%  (p=0.000 n=13+14)
Intersection/n=100-4                                           483µs ± 4%     411µs ± 9%  -14.96%  (p=0.000 n=14+15)
Intersection/n=1000-4                                         4.47ms ± 5%    3.81ms ±16%  -14.72%  (p=0.000 n=14+14)
Intersection/n=10000-4                                        50.5ms ±11%    41.1ms ± 6%  -18.67%  (p=0.000 n=13+13)
WKTParsing/point-4                                            1.88µs ±47%    1.73µs ±23%     ~     (p=0.144 n=14+13)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           78.0µs ± 7%    81.6µs ±17%     ~     (p=0.112 n=14+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            77.3µs ± 3%    76.8µs ± 5%     ~     (p=0.569 n=12+14)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4          1.32ms ± 7%    1.29ms ± 7%     ~     (p=0.306 n=14+14)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4           1.30ms ± 7%    1.31ms ± 9%     ~     (p=0.541 n=14+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     7.90µs ±17%    7.69µs ±10%     ~     (p=0.667 n=12+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      7.77µs ±13%    7.51µs ± 3%     ~     (p=0.153 n=13+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    81.7µs ±10%    82.7µs ±10%     ~     (p=0.320 n=13+12)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     83.3µs ±19%    81.8µs ±10%     ~     (p=0.960 n=13+13)
MultiLineStringIsSimpleManyLineStrings/n=100-4                60.9µs ± 9%    62.2µs ±10%     ~     (p=0.331 n=14+15)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                656µs ± 7%     659µs ±17%     ~     (p=0.756 n=13+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                                           51.4µs ± 8%    51.8µs ±11%     ~     (p=0.870 n=15+15)
Intersection/n=100-4                                           100µs ±10%      96µs ± 4%   -3.69%  (p=0.026 n=14+15)
Intersection/n=1000-4                                          424µs ±14%     410µs ±11%     ~     (p=0.270 n=14+15)
Intersection/n=10000-4                                        3.63ms ±15%    3.68ms ±18%     ~     (p=0.821 n=15+13)
NoOp/n=10-4                                                   3.90µs ± 4%    3.93µs ±11%     ~     (p=0.910 n=13+13)
NoOp/n=100-4                                                  12.8µs ±10%    12.6µs ± 4%     ~     (p=0.848 n=14+14)
NoOp/n=1000-4                                                 89.8µs ± 4%    90.7µs ±11%     ~     (p=0.598 n=14+15)
NoOp/n=10000-4                                                 983µs ±32%     991µs ±25%     ~     (p=0.747 n=14+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                30.9µs ± 6%    30.8µs ± 7%     ~     (p=0.713 n=15+15)
Delete/n=1000-4                                                716µs ± 6%     715µs ± 3%     ~     (p=0.905 n=13+14)
Delete/n=10000-4                                              33.4ms ± 9%    32.8ms ± 3%     ~     (p=0.373 n=15+12)
Bulk/n=10-4                                                    951ns ±16%     917ns ±14%     ~     (p=0.355 n=13+13)
Bulk/n=100-4                                                  14.6µs ± 6%    14.6µs ± 8%     ~     (p=0.742 n=13+15)
Bulk/n=1000-4                                                  226µs ± 5%     225µs ± 8%     ~     (p=0.406 n=12+13)
Bulk/n=10000-4                                                3.08ms ± 3%    3.12ms ± 6%     ~     (p=0.101 n=13+13)
Bulk/n=100000-4                                               36.3ms ± 5%    37.3ms ±10%     ~     (p=0.113 n=13+13)
Insert/n=10-4                                                 1.53µs ±16%    1.44µs ± 6%     ~     (p=0.054 n=14+12)
Insert/n=100-4                                                34.0µs ± 7%    34.3µs ± 7%     ~     (p=0.949 n=14+15)
Insert/n=1000-4                                                554µs ± 5%     547µs ± 2%     ~     (p=0.105 n=13+14)
Insert/n=10000-4                                              7.84ms ±10%    7.73ms ±10%     ~     (p=0.280 n=14+13)
Insert/n=100000-4                                             98.7ms ± 9%    98.9ms ±10%     ~     (p=0.874 n=14+14)
RangeSearch/n=10-4                                            15.1ns ± 2%    15.3ns ± 8%     ~     (p=0.639 n=14+14)
RangeSearch/n=100-4                                           59.5ns ± 3%    59.3ns ± 3%     ~     (p=0.394 n=13+14)
RangeSearch/n=1000-4                                           221ns ± 6%     216ns ± 1%     ~     (p=0.053 n=15+13)
RangeSearch/n=10000-4                                          757ns ± 3%     753ns ± 2%     ~     (p=0.381 n=13+14)
RangeSearch/n=100000-4                                        7.57µs ± 8%    7.37µs ± 2%   -2.67%  (p=0.038 n=15+14)

name                                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-4                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                   164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                 164kB ± 0%     164kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4                     2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                    205kB ± 0%     205kB ± 0%     ~     (p=0.962 n=15+15)
IntersectsLineStringWithLineString/n=10000-4                  2.63MB ± 0%    2.63MB ± 0%     ~     (p=0.347 n=15+14)
IntersectsMultiPointWithMultiPoint/n=20-4                       324B ± 0%      324B ± 0%     ~     (p=0.156 n=12+15)
IntersectsMultiPointWithMultiPoint/n=200-4                    3.08kB ± 0%    3.08kB ± 0%   -0.05%  (p=0.012 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000-4                   49.3kB ± 0%    49.3kB ± 0%     ~     (p=0.778 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000-4                   339kB ± 0%     339kB ± 0%     ~     (p=0.262 n=15+15)
LineStringIsSimpleZigZag/10-4                                 1.84kB ± 0%    1.84kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                139kB ± 0%     139kB ± 0%     ~     (p=0.074 n=12+15)
LineStringIsSimpleZigZag/10000-4                              1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.187 n=15+14)
PolygonSingleRingValidation/n=10-4                            2.19kB ± 0%    2.19kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                           24.3kB ± 0%    24.3kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                           140kB ± 0%     140kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4                         1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.195 n=15+14)
PolygonMultipleRingsValidation/n=4-4                          6.22kB ± 0%    6.22kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                         50.4kB ± 0%    50.4kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         553kB ± 0%     553kB ± 0%     ~     (p=0.652 n=15+15)
PolygonMultipleRingsValidation/n=4096-4                       5.67MB ± 0%    5.67MB ± 0%     ~     (p=0.943 n=15+15)
PolygonZigZagRingsValidation/n=10-4                           9.38kB ± 0%    9.38kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                          87.8kB ± 0%    87.8kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          551kB ± 0%     551kB ± 0%     ~     (p=0.115 n=15+15)
PolygonZigZagRingsValidation/n=10000-4                        7.24MB ± 0%    7.24MB ± 0%     ~     (p=0.238 n=14+15)
PolygonAnnulusValidation/n=10-4                               3.94kB ± 0%    3.94kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                              28.3kB ± 0%    28.3kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              379kB ± 0%     379kB ± 0%   +0.00%  (p=0.026 n=15+15)
PolygonAnnulusValidation/n=10000-4                            3.89MB ± 0%    3.89MB ± 0%     ~     (p=0.297 n=15+15)
MultipolygonValidation/n=1-4                                    385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                                    676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                                 3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                 15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                                63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                                259kB ± 0%     259kB ± 0%   -0.00%  (p=0.009 n=15+13)
MultiPolygonTwoCircles/n=10-4                                 4.99kB ± 0%    4.99kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                                55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                                345kB ± 0%     345kB ± 0%     ~     (p=0.809 n=15+14)
MultiPolygonTwoCircles/n=10000-4                              4.60MB ± 0%    4.60MB ± 0%     ~     (p=0.899 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1-4                      3.95kB ± 0%    3.95kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4                     22.6kB ± 0%    22.6kB ± 0%     ~     (p=0.848 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     172kB ± 0%     172kB ± 0%   -0.01%  (p=0.002 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-4                   2.04MB ± 0%    2.04MB ± 0%     ~     (p=1.000 n=15+15)
Intersection/n=10-4                                           27.2kB ± 0%    27.2kB ± 0%     ~     (p=0.244 n=15+15)
Intersection/n=100-4                                           140kB ± 0%     140kB ± 0%     ~     (p=0.624 n=15+15)
Intersection/n=1000-4                                         1.69MB ± 0%    1.69MB ± 0%     ~     (p=0.187 n=15+15)
Intersection/n=10000-4                                        17.8MB ± 0%    17.8MB ± 0%     ~     (p=0.713 n=15+15)
WKTParsing/point-4                                            1.93kB ± 0%    1.93kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           369kB ± 0%     369kB ± 0%     ~     (p=0.197 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            369kB ± 0%     369kB ± 0%     ~     (p=0.148 n=15+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.054 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.532 n=14+13)
MultiLineStringIsSimpleManyLineStrings/n=100-4                59.2kB ± 0%    59.2kB ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                491kB ± 0%     491kB ± 0%     ~     (p=0.652 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                                           1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
Intersection/n=100-4                                          6.47kB ± 0%    6.47kB ± 0%   +0.01%  (p=0.034 n=12+15)
Intersection/n=1000-4                                         55.1kB ± 0%    55.1kB ± 0%     ~     (p=0.074 n=12+15)
Intersection/n=10000-4                                         558kB ± 0%     558kB ± 0%     ~     (p=0.261 n=15+14)
NoOp/n=10-4                                                     968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100-4                                                  5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                                 49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                                 492kB ± 0%     492kB ± 0%     ~     (p=0.894 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                               26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-4                                               412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10-4                                                   1.46kB ± 0%    1.46kB ± 0%     ~     (all equal)
Bulk/n=100-4                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-4                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (p=0.908 n=14+13)
Bulk/n=10000-4                                                1.57MB ± 0%    1.57MB ± 0%     ~     (p=0.610 n=15+14)
Bulk/n=100000-4                                               20.4MB ± 0%    20.4MB ± 0%   -0.00%  (p=0.015 n=14+12)
Insert/n=10-4                                                 1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-4                                                13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-4                                                132kB ± 0%     132kB ± 0%     ~     (p=0.070 n=15+13)
Insert/n=10000-4                                              1.34MB ± 0%    1.34MB ± 0%   +0.00%  (p=0.013 n=14+14)
Insert/n=100000-4                                             13.5MB ± 0%    13.5MB ± 0%     ~     (p=0.125 n=12+12)
RangeSearch/n=10-4                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-4                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-4                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-4                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-4                                         0.00B          0.00B          ~     (all equal)

name                                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
MarshalWKB/polygon/n=10-4                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-4                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-4                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-4                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                              9.00 ± 0%      9.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                             73.0 ± 0%      73.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                             345 ± 0%       345 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4                          5.46k ± 0%     5.46k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4                            39.0 ± 0%      39.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                            313 ± 0%       313 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         3.43k ± 0%     3.43k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4                        35.1k ± 0%     35.1k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4                             38.0 ± 0%      38.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                             230 ± 0%       230 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          1.05k ± 0%     1.05k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4                         16.4k ± 0%     16.4k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10-4                                 19.0 ± 0%      19.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                                73.0 ± 0%      73.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000-4                             10.2k ± 0%     10.2k ± 0%     ~     (all equal)
MultipolygonValidation/n=1-4                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                   99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                                   392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                                1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                                   26.0 ± 0%      26.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                                   154 ± 0%       154 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                                  698 ± 0%       698 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                               10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4                        47.0 ± 0%      47.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4                        294 ± 0%       294 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4                     2.61k ± 0%     2.61k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4                    26.7k ± 0%     26.7k ± 0%     ~     (p=0.766 n=13+13)
Intersection/n=10-4                                              264 ± 0%       264 ± 0%     ~     (all equal)
Intersection/n=100-4                                             428 ± 0%       428 ± 0%     ~     (p=0.342 n=15+14)
Intersection/n=1000-4                                          2.04k ± 0%     2.04k ± 0%     ~     (p=0.208 n=15+15)
Intersection/n=10000-4                                         19.0k ± 0%     19.0k ± 0%     ~     (p=0.862 n=15+15)
WKTParsing/point-4                                              21.0 ± 0%      21.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4               234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            2.10k ± 0%     2.10k ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4       77.0 ± 0%      77.0 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-4                   371 ± 0%       371 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                3.34k ± 0%     3.34k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                                             48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=100-4                                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                                  480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-4                                               7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-4                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-4                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-4                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-4                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-4                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-4                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-4                                                  47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-4                                                  457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-4                                               4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-4                                              46.8k ± 0%     46.8k ± 0%   -0.00%  (p=0.026 n=15+13)
RangeSearch/n=10-4                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100-4                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000-4                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000-4                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000-4                                          0.00           0.00          ~     (all equal)
```