### PR TITLE
Perf improvement: line's envelope method

### DIFF
--- a/geom/line.go
+++ b/geom/line.go
@@ -13,8 +13,8 @@ type line struct {
 }
 
 func (ln line) envelope() Envelope {
-	ln.a.X, ln.b.X = sort2(ln.a.X, ln.b.X)
-	ln.a.Y, ln.b.Y = sort2(ln.a.Y, ln.b.Y)
+	ln.a.X, ln.b.X = sortFloat64Pair(ln.a.X, ln.b.X)
+	ln.a.Y, ln.b.Y = sortFloat64Pair(ln.a.Y, ln.b.Y)
 	return Envelope{ln.a, ln.b}
 }
 

--- a/geom/line.go
+++ b/geom/line.go
@@ -13,8 +13,17 @@ type line struct {
 }
 
 func (ln line) envelope() Envelope {
-	e := NewEnvelope(ln.a)
-	return e.ExtendToIncludePoint(ln.b)
+	e := Envelope{
+		min: ln.a,
+		max: ln.b,
+	}
+	if e.min.X > e.max.X {
+		e.min.X, e.max.X = e.max.X, e.min.X
+	}
+	if e.min.Y > e.max.Y {
+		e.min.Y, e.max.Y = e.max.Y, e.min.Y
+	}
+	return e
 }
 
 func (ln line) reverse() line {

--- a/geom/line.go
+++ b/geom/line.go
@@ -13,17 +13,9 @@ type line struct {
 }
 
 func (ln line) envelope() Envelope {
-	e := Envelope{
-		min: ln.a,
-		max: ln.b,
-	}
-	if e.min.X > e.max.X {
-		e.min.X, e.max.X = e.max.X, e.min.X
-	}
-	if e.min.Y > e.max.Y {
-		e.min.Y, e.max.Y = e.max.Y, e.min.Y
-	}
-	return e
+	ln.a.X, ln.b.X = sort2(ln.a.X, ln.b.X)
+	ln.a.Y, ln.b.Y = sort2(ln.a.Y, ln.b.Y)
+	return Envelope{ln.a, ln.b}
 }
 
 func (ln line) reverse() line {

--- a/geom/perf_internal_test.go
+++ b/geom/perf_internal_test.go
@@ -1,0 +1,23 @@
+package geom
+
+import (
+	"strconv"
+	"testing"
+)
+
+var dummyEnv Envelope
+
+func BenchmarkLineEnvelope(b *testing.B) {
+	for i, ln := range []line{
+		line{XY{0, 0}, XY{1, 1}},
+		line{XY{1, 1}, XY{0, 0}},
+		line{XY{0, 1}, XY{1, 0}},
+		line{XY{1, 0}, XY{0, 1}},
+	} {
+		b.Run(strconv.Itoa(i), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				dummyEnv = ln.envelope()
+			}
+		})
+	}
+}

--- a/geom/util.go
+++ b/geom/util.go
@@ -86,3 +86,26 @@ func reverseXYs(fwd []XY) []XY {
 	}
 	return rev
 }
+
+// fastMin is a faster but not functionally identical version of math.Min.
+func fastMin(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// fastMax is a faster but not functionally identical version of math.Max.
+func fastMax(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func sort2(a, b float64) (float64, float64) {
+	if a > b {
+		return b, a
+	}
+	return a, b
+}

--- a/geom/util.go
+++ b/geom/util.go
@@ -103,7 +103,8 @@ func fastMax(a, b float64) float64 {
 	return b
 }
 
-func sort2(a, b float64) (float64, float64) {
+// sortFloat64Pair returns a and b in sorted order.
+func sortFloat64Pair(a, b float64) (float64, float64) {
 	if a > b {
 		return b, a
 	}


### PR DESCRIPTION
## Description

Improves the performance of line's envelope method. This is a (smallish...) bottleneck in Intersection/Union etc.

## Check List

Have you:

- Added unit tests? N/A, existing.

- Add cmprefimpl tests? (if appropriate?) N/A, existing.

## Related Issue

- N/A

## Benchmark Results

Results are significant for the actual envelope method. I wasn't able to time the impact on Intersection, since the variance is higher than the actual saving. I calculated the saving to be around ~3% though (so the gain is marginal). I figure 3% since the `envelope` method shows up as 3% in the pprof profile, and as can be seen in the benchmarks below, this perf change basically makes the method call free.

```
COMPARISON
name              old time/op    new time/op    delta
LineEnvelope/0-4    19.4ns ±15%     1.6ns ± 7%  -91.67%  (p=0.000 n=14+13)
LineEnvelope/1-4    18.4ns ± 5%     1.1ns ± 9%  -94.28%  (p=0.000 n=12+13)
LineEnvelope/2-4    18.8ns ±17%     1.3ns ±10%  -92.87%  (p=0.000 n=15+14)
LineEnvelope/3-4    18.3ns ±12%     1.2ns ±14%  -93.40%  (p=0.000 n=15+15)

name              old alloc/op   new alloc/op   delta
LineEnvelope/0-4     0.00B          0.00B          ~     (all equal)
LineEnvelope/1-4     0.00B          0.00B          ~     (all equal)
LineEnvelope/2-4     0.00B          0.00B          ~     (all equal)
LineEnvelope/3-4     0.00B          0.00B          ~     (all equal)

name              old allocs/op  new allocs/op  delta
LineEnvelope/0-4      0.00           0.00          ~     (all equal)
LineEnvelope/1-4      0.00           0.00          ~     (all equal)
LineEnvelope/2-4      0.00           0.00          ~     (all equal)
LineEnvelope/3-4      0.00           0.00          ~     (all equal)
```