### PR TITLE
Fast Min/Max

### DIFF
--- a/geom/alg_distance.go
+++ b/geom/alg_distance.go
@@ -66,9 +66,9 @@ func Distance(g1, g2 Geometry) (float64, bool) {
 		// See if the current item in the tree is better than our current best
 		// distance.
 		if recordID > 0 {
-			minDist = math.Min(minDist, xyDist(xyIdx))
+			minDist = fastMin(minDist, xyDist(xyIdx))
 		} else {
-			minDist = math.Min(minDist, lnDist(lnIdx))
+			minDist = fastMin(minDist, lnDist(lnIdx))
 		}
 		return nil
 	}
@@ -179,7 +179,7 @@ func distBetweenLineAndLine(ln1, ln2 line) float64 {
 		distBetweenXYAndLine(ln2.a, ln1),
 		distBetweenXYAndLine(ln2.b, ln1),
 	} {
-		minDist = math.Min(minDist, dist)
+		minDist = fastMin(minDist, dist)
 	}
 	return minDist
 }

--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -49,7 +49,7 @@ func appendNewNode(dst []XY, nodes nodeSet, ln line, xy XY) []XY {
 
 // ulpSizeForLine finds the maximum ULP out of the 4 float64s that make a line.
 func ulpSizeForLine(ln line) float64 {
-	return math.Max(math.Max(math.Max(
+	return fastMax(fastMax(fastMax(
 		ulpSize(ln.a.X),
 		ulpSize(ln.a.Y)),
 		ulpSize(ln.b.X)),
@@ -70,7 +70,7 @@ func reNodeGeometries(g1, g2 Geometry, mls MultiLineString) (Geometry, Geometry,
 	var xyCount int
 	walk(all, func(xy XY) {
 		xyCount++
-		maxULPSize = math.Max(maxULPSize, math.Max(
+		maxULPSize = fastMax(maxULPSize, fastMax(
 			ulpSize(math.Abs(xy.X)),
 			ulpSize(math.Abs(xy.Y)),
 		))

--- a/geom/line.go
+++ b/geom/line.go
@@ -36,11 +36,11 @@ func (ln line) centroid() XY {
 }
 
 func (ln line) minX() float64 {
-	return math.Min(ln.a.X, ln.b.X)
+	return fastMin(ln.a.X, ln.b.X)
 }
 
 func (ln line) maxX() float64 {
-	return math.Max(ln.a.X, ln.b.X)
+	return fastMax(ln.a.X, ln.b.X)
 }
 
 func (ln line) asLineString() LineString {
@@ -138,10 +138,10 @@ func (ln line) intersectLine(other line) lineWithLineIntersection {
 // onSegement checks if point r on the segment formed by p and q.
 // p, q and r should be collinear
 func onSegment(p XY, q XY, r XY) bool {
-	return r.X <= math.Max(p.X, q.X) &&
-		r.X >= math.Min(p.X, q.X) &&
-		r.Y <= math.Max(p.Y, q.Y) &&
-		r.Y >= math.Min(p.Y, q.Y)
+	return r.X <= fastMax(p.X, q.X) &&
+		r.X >= fastMin(p.X, q.X) &&
+		r.Y <= fastMax(p.Y, q.Y) &&
+		r.Y >= fastMin(p.Y, q.Y)
 }
 
 // rightmostThenHighestIndex finds the rightmost-then-highest point

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -97,8 +97,8 @@ func (e Envelope) Max() XY {
 // points in this envelope along with the provided point.
 func (e Envelope) ExtendToIncludePoint(point XY) Envelope {
 	return Envelope{
-		min: XY{math.Min(e.min.X, point.X), math.Min(e.min.Y, point.Y)},
-		max: XY{math.Max(e.max.X, point.X), math.Max(e.max.Y, point.Y)},
+		min: XY{fastMin(e.min.X, point.X), fastMin(e.min.Y, point.Y)},
+		max: XY{fastMax(e.max.X, point.X), fastMax(e.max.Y, point.Y)},
 	}
 }
 
@@ -106,8 +106,8 @@ func (e Envelope) ExtendToIncludePoint(point XY) Envelope {
 // the points in this envelope and another envelope.
 func (e Envelope) ExpandToIncludeEnvelope(other Envelope) Envelope {
 	return Envelope{
-		min: XY{math.Min(e.min.X, other.min.X), math.Min(e.min.Y, other.min.Y)},
-		max: XY{math.Max(e.max.X, other.max.X), math.Max(e.max.Y, other.max.Y)},
+		min: XY{fastMin(e.min.X, other.min.X), fastMin(e.min.Y, other.min.Y)},
+		max: XY{fastMax(e.max.X, other.max.X), fastMax(e.max.Y, other.max.Y)},
 	}
 }
 
@@ -179,8 +179,8 @@ func (e Envelope) ExpandBy(x, y float64) (Envelope, bool) {
 // envelope. If the envelopes intersect with each other, then the returned
 // distance is 0.
 func (e Envelope) Distance(o Envelope) float64 {
-	dx := math.Max(0, math.Max(o.min.X-e.max.X, e.min.X-o.max.X))
-	dy := math.Max(0, math.Max(o.min.Y-e.max.Y, e.min.Y-o.max.Y))
+	dx := fastMax(0, fastMax(o.min.X-e.max.X, e.min.X-o.max.X))
+	dy := fastMax(0, fastMax(o.min.Y-e.max.Y, e.min.Y-o.max.Y))
 	return math.Sqrt(dx*dx + dy*dy)
 }
 

--- a/rtree/box.go
+++ b/rtree/box.go
@@ -1,7 +1,5 @@
 package rtree
 
-import "math"
-
 // Box is an axis-aligned bounding box.
 type Box struct {
 	MinX, MinY, MaxX, MaxY float64
@@ -19,10 +17,10 @@ func calculateBound(n *node) Box {
 // combine gives the smallest bounding box containing both box1 and box2.
 func combine(box1, box2 Box) Box {
 	return Box{
-		MinX: math.Min(box1.MinX, box2.MinX),
-		MinY: math.Min(box1.MinY, box2.MinY),
-		MaxX: math.Max(box1.MaxX, box2.MaxX),
-		MaxY: math.Max(box1.MaxY, box2.MaxY),
+		MinX: fastMin(box1.MinX, box2.MinX),
+		MinY: fastMin(box1.MinY, box2.MinY),
+		MaxX: fastMax(box1.MaxX, box2.MaxX),
+		MaxY: fastMax(box1.MaxY, box2.MaxY),
 	}
 }
 
@@ -43,7 +41,7 @@ func overlap(box1, box2 Box) bool {
 }
 
 func squaredEuclideanDistance(b1, b2 Box) float64 {
-	dx := math.Max(0, math.Max(b1.MinX-b2.MaxX, b2.MinX-b1.MaxX))
-	dy := math.Max(0, math.Max(b1.MinY-b2.MaxY, b2.MinY-b1.MaxY))
+	dx := fastMax(0, fastMax(b1.MinX-b2.MaxX, b2.MinX-b1.MaxX))
+	dy := fastMax(0, fastMax(b1.MinY-b2.MaxY, b2.MinY-b1.MaxY))
 	return dx*dx + dy*dy
 }

--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -191,32 +191,32 @@ func quickPartition(items []BulkItem, k int, horizontal bool) {
 }
 
 func itemsAreHorizontal(items []BulkItem) bool {
-	// quickMin is used rather than Box's combine method to avoid math.Min and
-	// math.Max calls (which are more expensive).
+	// fastMin and fastMax are used rather than Box's combine method to avoid
+	// math.Min and math.Max calls (which are more expensive).
 	minX := items[0].Box.MinX
 	maxX := items[0].Box.MaxX
 	minY := items[0].Box.MinY
 	maxY := items[0].Box.MaxY
 	for _, item := range items[1:] {
 		box := item.Box
-		minX = quickMin(minX, box.MinX)
-		maxX = quickMax(maxX, box.MaxX)
-		minY = quickMin(minY, box.MinY)
-		maxY = quickMax(maxY, box.MaxY)
+		minX = fastMin(minX, box.MinX)
+		maxX = fastMax(maxX, box.MaxX)
+		minY = fastMin(minY, box.MinY)
+		maxY = fastMax(maxY, box.MaxY)
 	}
 	return maxX-minX > maxY-minY
 }
 
-// quickMin is a faster but not functionally identical version of math.Min.
-func quickMin(a, b float64) float64 {
+// fastMin is a faster but not functionally identical version of math.Min.
+func fastMin(a, b float64) float64 {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-// quickMax is a faster but not functionally identical version of math.Max.
-func quickMax(a, b float64) float64 {
+// fastMax is a faster but not functionally identical version of math.Max.
+func fastMax(a, b float64) float64 {
 	if a > b {
 		return a
 	}


### PR DESCRIPTION
## Description

Use fastMin and fastMax throughout the codebase indiscriminately.

The intention was to get Union/Intersection etc to run a bit faster (math.Min and math.Max were combining to 2.5% of the runtime in the CPU profile). This should theoretically have occurred in this PR, but doesn't show up in the benchmark results because the benchmark variance is higher than that.

_However_, significant performance improvements are seen across the board for a lot of other benchmarks, so it's definitely worthwhile.

The only behavioural difference is when `NaN` is involved. However, all bets are off the table anyway if `NaN` becomes involved (so it doesn't really matter if `NaN`s are propagated in the standard floating point way or not).

## Check List

Have you:

- Added unit tests? No, uses existing.

- Add cmprefimpl tests? (if appropriate?) No, uses existing.

## Related Issue

N/A

## Benchmark Results

```
COMPARISON
name                                                        old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                              1.65ns ±12%    1.58ns ± 4%   -4.15%  (p=0.011 n=13+14)
LineEnvelope/1-4                                              1.05ns ± 8%    1.04ns ± 4%     ~     (p=0.308 n=14+14)
LineEnvelope/2-4                                              1.31ns ± 5%    1.31ns ± 9%     ~     (p=0.488 n=15+15)
LineEnvelope/3-4                                              1.19ns ± 6%    1.20ns ± 8%     ~     (p=0.991 n=14+15)
MarshalWKB/polygon/n=10-4                                      199ns ±26%     195ns ±19%     ~     (p=0.493 n=13+14)
MarshalWKB/polygon/n=100-4                                    701ns ±116%     827ns ±49%     ~     (p=0.068 n=13+14)
MarshalWKB/polygon/n=1000-4                                  7.27µs ±151%   6.66µs ±113%     ~     (p=0.928 n=15+13)
MarshalWKB/polygon/n=10000-4                                  37.7µs ±48%   56.5µs ±150%     ~     (p=0.399 n=12+15)
UnmarshalWKB/polygon/n=10-4                                    313ns ±10%     312ns ±12%     ~     (p=0.742 n=15+13)
UnmarshalWKB/polygon/n=100-4                                   755ns ±29%     849ns ±81%     ~     (p=0.553 n=13+13)
UnmarshalWKB/polygon/n=1000-4                                 6.36µs ±93%   7.19µs ±130%     ~     (p=0.652 n=15+14)
UnmarshalWKB/polygon/n=10000-4                               68.1µs ±103%   85.4µs ±116%     ~     (p=0.567 n=15+15)
IntersectsLineStringWithLineString/n=10-4                     1.61µs ±33%    1.44µs ±11%  -11.06%  (p=0.001 n=12+14)
IntersectsLineStringWithLineString/n=100-4                    21.3µs ±20%    21.8µs ±31%     ~     (p=0.860 n=12+14)
IntersectsLineStringWithLineString/n=1000-4                   317µs ±103%    236µs ±118%  -25.39%  (p=0.009 n=14+13)
IntersectsLineStringWithLineString/n=10000-4                  3.23ms ±21%    3.07ms ±13%     ~     (p=0.252 n=15+14)
IntersectsMultiPointWithMultiPoint/n=20-4                     1.31µs ± 8%    1.31µs ± 7%     ~     (p=0.940 n=15+14)
IntersectsMultiPointWithMultiPoint/n=200-4                    14.1µs ±12%    14.2µs ±10%     ~     (p=0.910 n=14+14)
IntersectsMultiPointWithMultiPoint/n=2000-4                    142µs ±11%     139µs ± 4%     ~     (p=0.650 n=14+13)
IntersectsMultiPointWithMultiPoint/n=20000-4                  1.51ms ± 9%    1.53ms ±10%     ~     (p=0.400 n=14+15)
LineStringIsSimpleZigZag/10-4                                 1.92µs ± 9%    1.87µs ± 9%     ~     (p=0.137 n=14+13)
LineStringIsSimpleZigZag/100-4                                31.0µs ± 8%    29.3µs ± 9%   -5.38%  (p=0.001 n=14+12)
LineStringIsSimpleZigZag/1000-4                                378µs ± 6%     370µs ±15%     ~     (p=0.114 n=12+15)
LineStringIsSimpleZigZag/10000-4                              5.08ms ±10%    4.79ms ±11%   -5.69%  (p=0.003 n=14+13)
PolygonSingleRingValidation/n=10-4                            2.59µs ±10%    2.41µs ±21%   -7.18%  (p=0.009 n=13+13)
PolygonSingleRingValidation/n=100-4                           36.1µs ±14%    31.7µs ±13%  -12.23%  (p=0.000 n=12+14)
PolygonSingleRingValidation/n=1000-4                           433µs ±14%     381µs ± 5%  -12.09%  (p=0.000 n=13+13)
PolygonSingleRingValidation/n=10000-4                         5.23ms ± 9%    5.02ms ±11%   -4.13%  (p=0.046 n=13+15)
PolygonMultipleRingsValidation/n=4-4                          6.79µs ± 8%    6.80µs ±16%     ~     (p=0.880 n=15+14)
PolygonMultipleRingsValidation/n=36-4                         64.5µs ± 9%    57.6µs ±11%  -10.62%  (p=0.000 n=13+14)
PolygonMultipleRingsValidation/n=400-4                         868µs ±12%     787µs ±12%   -9.37%  (p=0.001 n=13+14)
PolygonMultipleRingsValidation/n=4096-4                       10.8ms ±16%     9.1ms ±13%  -15.57%  (p=0.000 n=13+14)
PolygonZigZagRingsValidation/n=10-4                           11.8µs ±11%    11.1µs ±21%   -5.84%  (p=0.009 n=14+14)
PolygonZigZagRingsValidation/n=100-4                           134µs ±12%     129µs ±12%     ~     (p=0.058 n=13+15)
PolygonZigZagRingsValidation/n=1000-4                         1.52ms ±10%    1.44ms ±10%   -5.26%  (p=0.008 n=15+15)
PolygonZigZagRingsValidation/n=10000-4                        19.4ms ±10%    19.4ms ±13%     ~     (p=0.742 n=12+14)
PolygonAnnulusValidation/n=10-4                               3.82µs ± 8%    3.70µs ± 8%     ~     (p=0.139 n=13+13)
PolygonAnnulusValidation/n=100-4                              33.8µs ± 5%    32.5µs ±20%   -3.80%  (p=0.014 n=13+14)
PolygonAnnulusValidation/n=1000-4                              595µs ±14%     550µs ±14%   -7.65%  (p=0.001 n=14+14)
PolygonAnnulusValidation/n=10000-4                            7.09ms ±17%    6.47ms ±13%   -8.77%  (p=0.002 n=14+12)
MultipolygonValidation/n=1-4                                   348ns ± 9%     300ns ±14%  -13.77%  (p=0.000 n=14+13)
MultipolygonValidation/n=4-4                                   909ns ± 9%     713ns ±15%  -21.60%  (p=0.000 n=15+12)
MultipolygonValidation/n=16-4                                 5.51µs ± 6%    4.03µs ± 5%  -26.88%  (p=0.000 n=15+12)
MultipolygonValidation/n=64-4                                 33.5µs ±11%    22.6µs ±19%  -32.36%  (p=0.000 n=13+15)
MultipolygonValidation/n=256-4                                 194µs ± 9%     158µs ± 8%  -18.37%  (p=0.000 n=13+14)
MultipolygonValidation/n=1024-4                                976µs ±17%     767µs ±15%  -21.42%  (p=0.000 n=14+15)
MultiPolygonTwoCircles/n=10-4                                 4.10µs ±16%    3.53µs ±26%  -13.97%  (p=0.000 n=12+12)
MultiPolygonTwoCircles/n=100-4                                42.6µs ±15%    36.1µs ±11%  -15.39%  (p=0.000 n=13+14)
MultiPolygonTwoCircles/n=1000-4                                433µs ± 4%     409µs ±16%   -5.71%  (p=0.000 n=13+12)
MultiPolygonTwoCircles/n=10000-4                              6.35ms ±15%    5.79ms ±12%   -8.82%  (p=0.002 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1-4                      4.90µs ±16%    4.59µs ±11%   -6.25%  (p=0.007 n=13+13)
MultiPolygonMultipleTouchingPoints/n=10-4                     39.6µs ± 9%    38.3µs ±25%     ~     (p=0.105 n=14+13)
MultiPolygonMultipleTouchingPoints/n=100-4                     470µs ±16%     422µs ± 3%  -10.14%  (p=0.000 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-4                   5.29ms ± 9%    4.99ms ± 3%   -5.72%  (p=0.000 n=13+14)
Intersection/n=10-4                                           55.6µs ±13%    54.2µs ± 6%     ~     (p=0.220 n=14+13)
Intersection/n=100-4                                           299µs ±12%     295µs ±13%     ~     (p=0.277 n=12+15)
Intersection/n=1000-4                                         2.81ms ± 6%    2.70ms ±14%   -4.08%  (p=0.016 n=13+13)
Intersection/n=10000-4                                        30.4ms ±18%    29.1ms ±20%     ~     (p=0.137 n=13+12)
WKTParsing/point-4                                            1.75µs ±11%    1.76µs ±17%     ~     (p=0.905 n=15+12)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           71.4µs ±14%    49.7µs ±13%  -30.49%  (p=0.000 n=14+13)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            70.5µs ±13%    49.3µs ± 8%  -30.10%  (p=0.000 n=14+15)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4          1.20ms ± 5%    0.75ms ± 5%  -37.08%  (p=0.000 n=13+13)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4           1.24ms ±14%    0.74ms ± 3%  -40.21%  (p=0.000 n=14+12)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     5.59µs ±13%    5.57µs ±12%     ~     (p=0.756 n=14+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      5.63µs ±12%    5.48µs ±10%     ~     (p=0.123 n=13+12)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    73.9µs ±71%    60.2µs ±22%     ~     (p=0.062 n=14+14)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     61.1µs ±27%    58.5µs ±10%     ~     (p=0.259 n=13+14)
MultiLineStringIsSimpleManyLineStrings/n=100-4                55.0µs ±25%    51.7µs ±16%     ~     (p=0.085 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                568µs ±14%     578µs ±22%     ~     (p=0.829 n=15+12)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                                           47.2µs ±10%    46.5µs ± 6%     ~     (p=0.561 n=14+15)
Intersection/n=100-4                                          92.1µs ±13%    94.2µs ± 9%     ~     (p=0.254 n=13+15)
Intersection/n=1000-4                                          391µs ± 7%     394µs ±18%     ~     (p=0.946 n=14+14)
Intersection/n=10000-4                                        3.65ms ±13%    3.44ms ± 5%   -5.66%  (p=0.016 n=13+13)
NoOp/n=10-4                                                   3.80µs ± 3%    3.81µs ± 6%     ~     (p=0.971 n=13+14)
NoOp/n=100-4                                                  12.6µs ±15%    12.7µs ±13%     ~     (p=0.715 n=14+15)
NoOp/n=1000-4                                                 86.9µs ± 5%    90.5µs ±11%   +4.21%  (p=0.041 n=13+15)
NoOp/n=10000-4                                                1.01ms ±34%    0.92ms ±21%     ~     (p=0.156 n=15+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                30.5µs ± 7%    19.7µs ± 4%  -35.61%  (p=0.000 n=14+15)
Delete/n=1000-4                                                697µs ± 3%     651µs ± 6%   -6.53%  (p=0.000 n=12+14)
Delete/n=10000-4                                              31.1ms ± 2%    30.9ms ±10%     ~     (p=0.067 n=12+14)
Bulk/n=10-4                                                   970ns ±106%     818ns ±15%  -15.73%  (p=0.037 n=12+12)
Bulk/n=100-4                                                  16.2µs ±45%    14.2µs ±30%  -12.69%  (p=0.029 n=15+13)
Bulk/n=1000-4                                                  223µs ±12%     222µs ±10%     ~     (p=1.000 n=15+12)
Bulk/n=10000-4                                                3.04ms ± 6%    3.13ms ±12%     ~     (p=0.176 n=14+12)
Bulk/n=100000-4                                               36.3ms ±13%    35.8ms ±10%     ~     (p=0.541 n=14+14)
Insert/n=10-4                                                 1.42µs ±15%    1.18µs ±25%  -17.01%  (p=0.000 n=13+13)
Insert/n=100-4                                                33.0µs ± 7%    20.7µs ±12%  -37.10%  (p=0.000 n=12+15)
Insert/n=1000-4                                                544µs ± 9%     442µs ±10%  -18.71%  (p=0.000 n=14+15)
Insert/n=10000-4                                              7.60ms ± 9%    5.36ms ±10%  -29.45%  (p=0.000 n=15+14)
Insert/n=100000-4                                             92.3ms ± 3%    59.8ms ± 2%  -35.16%  (p=0.000 n=12+12)
RangeSearch/n=10-4                                            15.0ns ± 4%    14.7ns ± 2%   -1.92%  (p=0.020 n=15+13)
RangeSearch/n=100-4                                           58.4ns ± 7%    58.2ns ± 3%     ~     (p=0.777 n=14+14)
RangeSearch/n=1000-4                                           213ns ± 2%     213ns ± 2%     ~     (p=0.759 n=13+14)
RangeSearch/n=10000-4                                          732ns ± 2%     734ns ± 4%     ~     (p=0.898 n=12+12)
RangeSearch/n=100000-4                                        7.19µs ± 6%    7.25µs ± 9%     ~     (p=0.723 n=15+14)

name                                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/1-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/2-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/3-4                                               0.00B          0.00B          ~     (all equal)
MarshalWKB/polygon/n=10-4                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                   164kB ± 0%     164kB ± 0%     ~     (p=1.000 n=15+15)
UnmarshalWKB/polygon/n=10-4                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                 164kB ± 0%     164kB ± 0%     ~     (p=0.056 n=15+12)
IntersectsLineStringWithLineString/n=10-4                     2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                    205kB ± 0%     205kB ± 0%     ~     (p=0.582 n=14+15)
IntersectsLineStringWithLineString/n=10000-4                  2.63MB ± 0%    2.63MB ± 0%   -0.00%  (p=0.012 n=14+14)
IntersectsMultiPointWithMultiPoint/n=20-4                       324B ± 0%      325B ± 0%     ~     (p=1.000 n=15+15)
IntersectsMultiPointWithMultiPoint/n=200-4                    3.08kB ± 0%    3.08kB ± 0%     ~     (p=0.174 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000-4                   49.3kB ± 0%    49.3kB ± 0%     ~     (p=0.592 n=15+14)
IntersectsMultiPointWithMultiPoint/n=20000-4                   339kB ± 0%     339kB ± 0%     ~     (p=0.735 n=15+15)
LineStringIsSimpleZigZag/10-4                                 1.84kB ± 0%    1.84kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                              1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.605 n=14+13)
PolygonSingleRingValidation/n=10-4                            2.19kB ± 0%    2.19kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                           24.3kB ± 0%    24.3kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                           140kB ± 0%     140kB ± 0%     ~     (p=0.833 n=15+15)
PolygonSingleRingValidation/n=10000-4                         1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.671 n=15+15)
PolygonMultipleRingsValidation/n=4-4                          6.22kB ± 0%    6.22kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                         50.4kB ± 0%    50.4kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         553kB ± 0%     553kB ± 0%     ~     (p=0.582 n=14+15)
PolygonMultipleRingsValidation/n=4096-4                       5.67MB ± 0%    5.67MB ± 0%     ~     (p=0.838 n=14+15)
PolygonZigZagRingsValidation/n=10-4                           9.38kB ± 0%    9.38kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                          87.8kB ± 0%    87.8kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          551kB ± 0%     551kB ± 0%     ~     (p=0.572 n=15+15)
PolygonZigZagRingsValidation/n=10000-4                        7.24MB ± 0%    7.24MB ± 0%     ~     (p=0.273 n=14+13)
PolygonAnnulusValidation/n=10-4                               3.94kB ± 0%    3.94kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                              28.3kB ± 0%    28.3kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              379kB ± 0%     379kB ± 0%   +0.00%  (p=0.035 n=14+13)
PolygonAnnulusValidation/n=10000-4                            3.89MB ± 0%    3.89MB ± 0%   -0.00%  (p=0.032 n=15+14)
MultipolygonValidation/n=1-4                                    385B ± 0%      385B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                                    676B ± 0%      676B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                                 3.86kB ± 0%    3.86kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                 15.4kB ± 0%    15.4kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                                63.1kB ± 0%    63.1kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                                259kB ± 0%     259kB ± 0%     ~     (p=0.115 n=14+15)
MultiPolygonTwoCircles/n=10-4                                 4.99kB ± 0%    4.99kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                                55.0kB ± 0%    55.0kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                                345kB ± 0%     345kB ± 0%     ~     (p=0.474 n=15+15)
MultiPolygonTwoCircles/n=10000-4                              4.60MB ± 0%    4.60MB ± 0%     ~     (p=0.586 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4                      3.95kB ± 0%    3.95kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4                     22.6kB ± 0%    22.6kB ± 0%     ~     (p=0.575 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     172kB ± 0%     172kB ± 0%     ~     (p=0.348 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1000-4                   2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.467 n=15+15)
Intersection/n=10-4                                           29.2kB ± 0%    29.2kB ± 0%     ~     (p=0.158 n=13+15)
Intersection/n=100-4                                           155kB ± 0%     155kB ± 0%     ~     (p=0.330 n=15+15)
Intersection/n=1000-4                                         1.88MB ± 0%    1.88MB ± 0%     ~     (p=0.574 n=15+15)
Intersection/n=10000-4                                        19.3MB ± 0%    19.3MB ± 0%     ~     (p=0.967 n=15+15)
WKTParsing/point-4                                            1.93kB ± 0%    1.93kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           369kB ± 0%     369kB ± 0%   -0.02%  (p=0.000 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            369kB ± 0%     369kB ± 0%   -0.02%  (p=0.000 n=14+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.580 n=14+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.680 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=100-4                59.2kB ± 0%    59.2kB ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                491kB ± 0%     491kB ± 0%     ~     (p=0.541 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                                           1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
Intersection/n=100-4                                          6.47kB ± 0%    6.47kB ± 0%   +0.01%  (p=0.011 n=13+15)
Intersection/n=1000-4                                         55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
Intersection/n=10000-4                                         558kB ± 0%     558kB ± 0%     ~     (p=0.465 n=13+15)
NoOp/n=10-4                                                     968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100-4                                                  5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                                 49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                                 492kB ± 0%     492kB ± 0%     ~     (p=0.353 n=15+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                               26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-4                                               412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10-4                                                   1.46kB ± 0%    1.46kB ± 0%     ~     (all equal)
Bulk/n=100-4                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-4                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (p=1.000 n=15+15)
Bulk/n=10000-4                                                1.57MB ± 0%    1.57MB ± 0%     ~     (p=0.975 n=15+15)
Bulk/n=100000-4                                               20.4MB ± 0%    20.4MB ± 0%     ~     (p=0.181 n=14+15)
Insert/n=10-4                                                 1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-4                                                13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-4                                                132kB ± 0%     132kB ± 0%   +0.00%  (p=0.004 n=13+15)
Insert/n=10000-4                                              1.34MB ± 0%    1.34MB ± 0%     ~     (p=0.136 n=14+14)
Insert/n=100000-4                                             13.5MB ± 0%    13.5MB ± 0%   -0.00%  (p=0.002 n=15+12)
RangeSearch/n=10-4                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-4                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-4                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-4                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-4                                         0.00B          0.00B          ~     (all equal)

name                                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/1-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/2-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/3-4                                                0.00           0.00          ~     (all equal)
MarshalWKB/polygon/n=10-4                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-4                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-4                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-4                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                              9.00 ± 0%      9.00 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                             73.0 ± 0%      73.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                             345 ± 0%       345 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4                          5.46k ± 0%     5.46k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4                            39.0 ± 0%      39.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                            313 ± 0%       313 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         3.43k ± 0%     3.43k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4                        35.1k ± 0%     35.1k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4                             38.0 ± 0%      38.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                             230 ± 0%       230 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          1.05k ± 0%     1.05k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4                         16.4k ± 0%     16.4k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10-4                                 19.0 ± 0%      19.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                                73.0 ± 0%      73.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000-4                             10.2k ± 0%     10.2k ± 0%     ~     (all equal)
MultipolygonValidation/n=1-4                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                   99.0 ± 0%      99.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                                   392 ± 0%       392 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                                1.58k ± 0%     1.58k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                                   26.0 ± 0%      26.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                                   154 ± 0%       154 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                                  698 ± 0%       698 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                               10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4                        47.0 ± 0%      47.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4                        294 ± 0%       294 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4                     2.61k ± 0%     2.61k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4                    26.7k ± 0%     26.7k ± 0%     ~     (p=0.339 n=15+15)
Intersection/n=10-4                                              284 ± 0%       284 ± 0%     ~     (all equal)
Intersection/n=100-4                                             457 ± 0%       457 ± 0%     ~     (all equal)
Intersection/n=1000-4                                          2.07k ± 0%     2.07k ± 0%     ~     (p=0.737 n=15+15)
Intersection/n=10000-4                                         19.1k ± 0%     19.1k ± 0%     ~     (p=0.976 n=15+15)
WKTParsing/point-4                                              21.0 ± 0%      21.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4               234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            2.10k ± 0%     2.10k ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4       77.0 ± 0%      77.0 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-4                   371 ± 0%       371 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                3.34k ± 0%     3.34k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
Intersection/n=10-4                                             48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=100-4                                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=1000-4                                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Intersection/n=10000-4                                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                                  480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-4                                               7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-4                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-4                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-4                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-4                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-4                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-4                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-4                                                  47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-4                                                  457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-4                                               4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-4                                              46.8k ± 0%     46.8k ± 0%   -0.00%  (p=0.042 n=15+15)
RangeSearch/n=10-4                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100-4                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000-4                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000-4                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000-4                                          0.00           0.00          ~     (all equal)
```