### PR TITLE
Use size hint for maps in findInteractionPoints

### DIFF
--- a/.ci/run_benchmarks.sh
+++ b/.ci/run_benchmarks.sh
@@ -14,8 +14,8 @@ old="$(mktemp)"
 new="$(mktemp)"
 trap "rm -f $new $old" EXIT
 
-package="./geom"
-bench="Intersection\$"
+package="./..."
+bench="."
 
 for (( i = 0; i < 15; i++ )); do
 	echo
@@ -25,13 +25,13 @@ for (( i = 0; i < 15; i++ )); do
 	echo "OLD"
 	git checkout "$old_git_sha1"
 	echo
-	go test "$package" -test.run='^$' -benchtime=5.0s -benchmem -bench="$bench" | tee -a "$old"
+	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench="$bench" | tee -a "$old"
 
 	echo
 	echo "NEW"
 	git checkout "$new_git_sha1"
 	echo
-	go test "$package" -test.run='^$' -benchtime=5.0s -benchmem -bench="$bench" | tee -a "$new"
+	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench="$bench" | tee -a "$new"
 done
 
 echo

--- a/.ci/run_benchmarks.sh
+++ b/.ci/run_benchmarks.sh
@@ -14,8 +14,8 @@ old="$(mktemp)"
 new="$(mktemp)"
 trap "rm -f $new $old" EXIT
 
-package="./..."
-bench="."
+package="./geom"
+bench="Intersection\$"
 
 for (( i = 0; i < 15; i++ )); do
 	echo
@@ -25,13 +25,13 @@ for (( i = 0; i < 15; i++ )); do
 	echo "OLD"
 	git checkout "$old_git_sha1"
 	echo
-	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench="$bench" | tee -a "$old"
+	go test "$package" -test.run='^$' -benchtime=5.0s -benchmem -bench="$bench" | tee -a "$old"
 
 	echo
 	echo "NEW"
 	git checkout "$new_git_sha1"
 	echo
-	go test "$package" -test.run='^$' -benchtime=0.1s -benchmem -bench="$bench" | tee -a "$new"
+	go test "$package" -test.run='^$' -benchtime=5.0s -benchmem -bench="$bench" | tee -a "$new"
 done
 
 echo

--- a/geom/dcel_interaction_points.go
+++ b/geom/dcel_interaction_points.go
@@ -10,14 +10,18 @@ package geom
 // - Input geometries don't have any repeated coordinates (e.g. in areal rings
 //   or linear elements).
 func findInteractionPoints(gs []Geometry) map[XY]struct{} {
-	interactions := make(map[XY]struct{})
+	var sizeHint int
+	for _, g := range gs {
+		sizeHint += g.controlPoints()
+	}
+	interactions := make(map[XY]struct{}, sizeHint)
 
 	// adjacents tracks the next and previous points relative to a middle point
 	// for linear elements (i.e. the points adjacents to a middle point). It is
 	// used to differentiate the cases where linear elements overlap (in which
 	// case there ISN'T an interaction point) and cases where they are crossing
 	// over each other (in which case there IS an interaction point).
-	adjacents := make(map[XY]xyPair)
+	adjacents := make(map[XY]xyPair, sizeHint)
 
 	for _, g := range gs {
 		addGeometryInteractions(g, adjacents, interactions)

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -680,13 +680,13 @@ func (g Geometry) controlPoints() int {
 	case TypeLineString:
 		return g.AsLineString().Coordinates().Length()
 	case TypePolygon:
-		return g.AsPolygon().Boundary().controlPoints()
+		return g.AsPolygon().controlPoints()
 	case TypeMultiPoint:
 		return g.AsMultiPoint().NumPoints()
 	case TypeMultiLineString:
 		return g.AsMultiLineString().controlPoints()
 	case TypeMultiPolygon:
-		return g.AsMultiPolygon().Boundary().controlPoints()
+		return g.AsMultiPolygon().controlPoints()
 	default:
 		panic("unknown geometry: " + g.gtype.String())
 	}

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -666,3 +666,28 @@ func (g Geometry) forceOrientation(forceCW bool) Geometry {
 		return g
 	}
 }
+
+func (g Geometry) controlPoints() int {
+	switch g.gtype {
+	case TypeGeometryCollection:
+		var sum int
+		for _, g := range g.AsGeometryCollection().geoms {
+			sum += g.controlPoints()
+		}
+		return sum
+	case TypePoint:
+		return 1
+	case TypeLineString:
+		return g.AsLineString().Coordinates().Length()
+	case TypePolygon:
+		return g.AsPolygon().Boundary().controlPoints()
+	case TypeMultiPoint:
+		return g.AsMultiPoint().NumPoints()
+	case TypeMultiLineString:
+		return g.AsMultiLineString().controlPoints()
+	case TypeMultiPolygon:
+		return g.AsMultiPolygon().Boundary().controlPoints()
+	default:
+		panic("unknown geometry: " + g.gtype.String())
+	}
+}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -419,3 +419,11 @@ func (m MultiLineString) PointOnSurface() Point {
 	}
 	return nearest.point
 }
+
+func (m MultiLineString) controlPoints() int {
+	var sum int
+	for _, ls := range m.lines {
+		sum += ls.Coordinates().Length()
+	}
+	return sum
+}

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -436,3 +436,11 @@ func (m MultiPolygon) forceOrientation(forceCW bool) MultiPolygon {
 	}
 	return MultiPolygon{polys, m.ctype}
 }
+
+func (m MultiPolygon) controlPoints() int {
+	var sum int
+	for _, p := range m.polys {
+		sum += p.controlPoints()
+	}
+	return sum
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -517,3 +517,11 @@ func (p Polygon) forceOrientation(forceCW bool) Polygon {
 	}
 	return Polygon{orientedRings, p.ctype}
 }
+
+func (p Polygon) controlPoints() int {
+	var sum int
+	for _, r := range p.rings {
+		sum += r.Coordinates().Length()
+	}
+	return sum
+}


### PR DESCRIPTION
## Description

Initiates the maps in findInteractionPoints with a size hint to reduce allocation and map resize overhead. Only gives a small perf improvement.

## Check List

Have you:

- Added unit tests? N/A, relies on existing.

- Add cmprefimpl tests? (if appropriate?) N/A, relies on existing.

## Related Issue

N/A

## Benchmark Results

```
COMPARISON
name                    old time/op    new time/op    delta
Intersection/n=10-4       54.7µs ± 5%    54.2µs ± 7%    ~     (p=0.170 n=13+15)
Intersection/n=100-4       309µs ±14%     284µs ± 6%  -7.99%  (p=0.001 n=15+14)
Intersection/n=1000-4     2.90ms ± 9%    2.72ms ±13%  -6.03%  (p=0.004 n=14+15)
Intersection/n=10000-4    29.5ms ±14%    28.8ms ±13%    ~     (p=0.512 n=15+15)

name                    old alloc/op   new alloc/op   delta
Intersection/n=10-4       29.2kB ± 0%    30.5kB ± 0%  +4.50%  (p=0.000 n=15+14)
Intersection/n=100-4       155kB ± 0%     145kB ± 0%  -6.28%  (p=0.000 n=15+13)
Intersection/n=1000-4     1.88MB ± 0%    1.71MB ± 0%  -9.00%  (p=0.000 n=15+15)
Intersection/n=10000-4    19.3MB ± 0%    17.9MB ± 0%  -7.13%  (p=0.000 n=15+15)

name                    old allocs/op  new allocs/op  delta
Intersection/n=10-4          284 ± 0%       281 ± 0%  -1.06%  (p=0.000 n=15+15)
Intersection/n=100-4         457 ± 0%       441 ± 0%  -3.50%  (p=0.000 n=15+15)
Intersection/n=1000-4      2.07k ± 0%     1.97k ± 0%  -4.55%  (p=0.000 n=15+15)
Intersection/n=10000-4     19.1k ± 0%     18.5k ± 0%  -3.21%  (p=0.000 n=15+15)
```