### PR TITLE
Static RTree for MultiPolygon Validation

### DIFF
--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -32,10 +32,12 @@ func TestDisableValidation(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			_, err := geom.UnmarshalWKT(wkt)
 			if err == nil {
+				t.Logf("wkt: %v", wkt)
 				t.Fatal("expected validation error unmarshalling wkt")
 			}
 			_, err = geom.UnmarshalWKT(wkt, geom.DisableAllValidations)
 			if err != nil {
+				t.Logf("wkt: %v", wkt)
 				t.Errorf("disabling validations still gave an error: %v", err)
 			}
 		})


### PR DESCRIPTION
## Description

Switches to using a static RTree for MultiPolygon validation.

I'm not expecting a performance change, this is more so that I can remove the Insert and Delete RTree methods.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

There are some mild MultiPolygon perf improvements (unintended).

<details>

<summary>Click to expand</summary>

```
name                                                        old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                              1.62ns ± 6%    1.62ns ± 6%     ~     (p=0.674 n=14+15)
LineEnvelope/1-4                                              1.07ns ± 6%    1.07ns ± 4%     ~     (p=0.757 n=15+14)
LineEnvelope/2-4                                              1.33ns ± 5%    1.33ns ± 3%     ~     (p=0.802 n=15+14)
LineEnvelope/3-4                                              1.19ns ± 5%    1.18ns ± 3%     ~     (p=0.938 n=15+14)
MarshalWKB/polygon/n=10-4                                      191ns ± 9%     187ns ± 7%     ~     (p=0.334 n=14+14)
MarshalWKB/polygon/n=100-4                                     679ns ±92%     590ns ±34%     ~     (p=0.650 n=13+12)
MarshalWKB/polygon/n=1000-4                                   3.96µs ±45%    5.43µs ±81%  +36.99%  (p=0.023 n=12+14)
MarshalWKB/polygon/n=10000-4                                  34.3µs ±42%    47.2µs ±64%     ~     (p=0.155 n=13+14)
UnmarshalWKB/polygon/n=10-4                                    319ns ± 7%     321ns ± 6%     ~     (p=0.524 n=15+12)
UnmarshalWKB/polygon/n=100-4                                   739ns ±38%     729ns ±11%     ~     (p=0.552 n=14+12)
UnmarshalWKB/polygon/n=1000-4                                 4.51µs ±31%   5.94µs ±147%     ~     (p=0.406 n=12+13)
UnmarshalWKB/polygon/n=10000-4                               53.2µs ±144%    52.2µs ±72%     ~     (p=0.847 n=14+15)
IntersectsLineStringWithLineString/n=10-4                     1.51µs ±14%    1.58µs ±25%     ~     (p=0.458 n=13+14)
IntersectsLineStringWithLineString/n=100-4                    21.5µs ± 8%    20.7µs ± 4%     ~     (p=0.107 n=14+11)
IntersectsLineStringWithLineString/n=1000-4                    207µs ± 6%     210µs ±13%     ~     (p=0.701 n=14+14)
IntersectsLineStringWithLineString/n=10000-4                  3.09ms ±11%    2.96ms ± 6%     ~     (p=0.065 n=15+13)
IntersectsMultiPointWithMultiPoint/n=20-4                     1.33µs ± 4%    1.34µs ± 5%     ~     (p=0.381 n=15+13)
IntersectsMultiPointWithMultiPoint/n=200-4                    14.1µs ± 3%    14.0µs ± 3%     ~     (p=0.156 n=15+13)
IntersectsMultiPointWithMultiPoint/n=2000-4                    142µs ± 5%     141µs ± 6%     ~     (p=0.331 n=14+15)
IntersectsMultiPointWithMultiPoint/n=20000-4                  1.50ms ± 3%    1.51ms ± 6%     ~     (p=0.983 n=15+14)
PolygonSingleRingValidation/n=10-4                            2.51µs ± 6%    2.54µs ±22%     ~     (p=0.765 n=14+13)
PolygonSingleRingValidation/n=100-4                           32.0µs ± 8%    34.4µs ±17%   +7.33%  (p=0.005 n=14+13)
PolygonSingleRingValidation/n=1000-4                           390µs ± 2%     397µs ± 6%     ~     (p=0.057 n=13+13)
PolygonSingleRingValidation/n=10000-4                         4.91ms ± 1%    5.01ms ± 8%     ~     (p=0.815 n=9+15)
PolygonMultipleRingsValidation/n=4-4                          6.75µs ± 4%    6.84µs ± 8%     ~     (p=0.347 n=12+14)
PolygonMultipleRingsValidation/n=36-4                         57.0µs ± 8%    56.7µs ± 6%     ~     (p=0.801 n=13+13)
PolygonMultipleRingsValidation/n=400-4                         739µs ± 6%     742µs ± 6%     ~     (p=0.705 n=12+14)
PolygonMultipleRingsValidation/n=4096-4                       9.23ms ±19%    8.65ms ± 4%     ~     (p=0.254 n=15+13)
PolygonZigZagRingsValidation/n=10-4                           11.2µs ± 7%    11.1µs ± 5%     ~     (p=0.839 n=14+14)
PolygonZigZagRingsValidation/n=100-4                           131µs ± 8%     129µs ± 6%     ~     (p=0.389 n=15+15)
PolygonZigZagRingsValidation/n=1000-4                         1.47ms ± 4%    1.47ms ± 3%     ~     (p=0.780 n=15+14)
PolygonZigZagRingsValidation/n=10000-4                        19.7ms ±12%    19.5ms ± 5%     ~     (p=0.880 n=14+15)
PolygonAnnulusValidation/n=10-4                               3.77µs ±12%    3.72µs ± 4%     ~     (p=0.762 n=13+13)
PolygonAnnulusValidation/n=100-4                              33.6µs ±13%    33.0µs ±11%     ~     (p=0.467 n=15+13)
PolygonAnnulusValidation/n=1000-4                              550µs ± 8%     557µs ± 4%     ~     (p=0.227 n=14+14)
PolygonAnnulusValidation/n=10000-4                            6.82ms ±20%    6.50ms ±12%     ~     (p=0.070 n=14+15)
MultipolygonValidation/n=1-4                                  450ns ±144%     400ns ±10%     ~     (p=0.104 n=15+15)
MultipolygonValidation/n=4-4                                   726ns ± 7%     916ns ±12%  +26.27%  (p=0.000 n=14+15)
MultipolygonValidation/n=16-4                                 4.20µs ± 5%    3.74µs ±14%  -10.97%  (p=0.000 n=12+13)
MultipolygonValidation/n=64-4                                 22.6µs ± 5%    16.9µs ±14%  -25.13%  (p=0.000 n=15+15)
MultipolygonValidation/n=256-4                                 164µs ±12%     105µs ± 6%  -35.76%  (p=0.000 n=14+15)
MultipolygonValidation/n=1024-4                                764µs ± 5%     496µs ± 6%  -35.12%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10-4                                6.96µs ±187%    3.90µs ±13%     ~     (p=0.448 n=13+13)
MultiPolygonTwoCircles/n=100-4                                38.5µs ±11%    44.2µs ±55%     ~     (p=0.097 n=13+14)
MultiPolygonTwoCircles/n=1000-4                                408µs ±10%     405µs ± 9%     ~     (p=0.650 n=12+13)
MultiPolygonTwoCircles/n=10000-4                              5.96ms ±17%    5.72ms ± 7%     ~     (p=0.217 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1-4                      4.68µs ± 4%    4.81µs ±20%     ~     (p=0.296 n=14+13)
MultiPolygonMultipleTouchingPoints/n=10-4                     37.3µs ± 7%    37.8µs ± 9%     ~     (p=0.813 n=14+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     446µs ± 9%     445µs ± 6%     ~     (p=0.960 n=13+13)
MultiPolygonMultipleTouchingPoints/n=1000-4                   5.03ms ± 3%    5.33ms ±18%   +5.89%  (p=0.000 n=13+13)
WKTParsing/point-4                                            1.71µs ±13%    1.71µs ±17%     ~     (p=0.659 n=13+14)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           50.5µs ± 3%    53.1µs ±23%     ~     (p=0.548 n=12+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            50.4µs ± 7%    51.2µs ±18%     ~     (p=0.943 n=13+14)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           751µs ± 5%     766µs ± 5%     ~     (p=0.112 n=14+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            750µs ± 4%     760µs ± 7%     ~     (p=0.362 n=13+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     5.49µs ± 8%    5.46µs ± 8%     ~     (p=0.755 n=15+12)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      5.61µs ± 8%    5.40µs ± 7%   -3.79%  (p=0.037 n=15+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    61.8µs ± 9%    59.8µs ± 9%     ~     (p=0.098 n=12+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     62.3µs ±21%    60.1µs ± 8%     ~     (p=0.231 n=14+12)
MultiLineStringIsSimpleManyLineStrings/n=100-4                54.6µs ±16%    52.9µs ± 9%     ~     (p=0.519 n=14+13)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                624µs ±30%     556µs ± 5%  -10.92%  (p=0.019 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-4                          49.0µs ± 9%    49.2µs ± 5%     ~     (p=0.616 n=15+15)
IntersectionWithoutValidation/n=100-4                         94.4µs ± 5%    93.9µs ± 6%     ~     (p=0.747 n=15+14)
IntersectionWithoutValidation/n=1000-4                         410µs ±13%     383µs ±20%   -6.48%  (p=0.026 n=15+14)
IntersectionWithoutValidation/n=10000-4                       3.51ms ±13%    3.56ms ± 7%     ~     (p=0.793 n=14+13)
NoOp/n=10-4                                                   3.83µs ± 6%    3.84µs ± 4%     ~     (p=0.691 n=15+14)
NoOp/n=100-4                                                  12.8µs ±11%    12.6µs ± 7%     ~     (p=0.967 n=15+15)
NoOp/n=1000-4                                                 89.2µs ± 3%    90.2µs ± 8%     ~     (p=0.595 n=15+15)
NoOp/n=10000-4                                                 953µs ±17%     930µs ±21%     ~     (p=0.591 n=14+15)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-4                               2.09µs ± 8%    2.09µs ± 8%     ~     (p=0.802 n=13+14)
LineStringIsSimpleCircle/n=100-4                              31.3µs ±13%    31.2µs ± 9%     ~     (p=0.852 n=13+12)
LineStringIsSimpleCircle/n=1000-4                              379µs ± 3%     373µs ± 3%   -1.60%  (p=0.011 n=14+13)
LineStringIsSimpleCircle/n=10000-4                            4.80ms ± 5%    4.87ms ± 9%     ~     (p=0.603 n=14+14)
LineStringIsSimpleZigZag/10-4                                 1.92µs ± 6%    1.89µs ± 6%     ~     (p=0.331 n=13+14)
LineStringIsSimpleZigZag/100-4                                29.8µs ± 4%    29.7µs ± 5%     ~     (p=0.584 n=12+13)
LineStringIsSimpleZigZag/1000-4                                358µs ± 3%     358µs ± 4%     ~     (p=0.943 n=12+15)
LineStringIsSimpleZigZag/10000-4                              4.91ms ± 4%    4.87ms ± 6%     ~     (p=0.294 n=13+15)
SetOperation/n=4/Go_Intersection-4                            41.1µs ±13%    41.9µs ±10%     ~     (p=0.169 n=13+14)
SetOperation/n=4/Go_Difference-4                              42.6µs ± 7%    41.3µs ± 5%   -2.88%  (p=0.023 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-4                     54.0µs ± 3%    54.7µs ± 7%     ~     (p=0.488 n=13+14)
SetOperation/n=4/Go_Union-4                                   43.1µs ± 4%    43.4µs ± 5%     ~     (p=0.519 n=14+13)
SetOperation/n=4/GEOS_Intersection-4                          49.8µs ± 5%    49.7µs ± 9%     ~     (p=0.652 n=14+15)
SetOperation/n=4/GEOS_Difference-4                            52.2µs ± 5%    51.7µs ± 4%     ~     (p=0.675 n=15+15)
SetOperation/n=4/GEOS_SymmetricDifference-4                   75.0µs ±14%    71.7µs ± 3%     ~     (p=0.080 n=15+13)
SetOperation/n=4/GEOS_Union-4                                 51.9µs ± 6%    51.7µs ± 5%     ~     (p=0.683 n=15+15)
SetOperation/n=8/Go_Intersection-4                            51.1µs ± 9%    51.8µs ±12%     ~     (p=0.717 n=15+13)
SetOperation/n=8/Go_Difference-4                              50.6µs ± 4%    50.8µs ± 5%     ~     (p=0.879 n=15+15)
SetOperation/n=8/Go_SymmetricDifference-4                     67.7µs ± 5%    67.0µs ± 4%     ~     (p=0.239 n=14+13)
SetOperation/n=8/Go_Union-4                                   52.2µs ± 8%    52.3µs ± 7%     ~     (p=0.622 n=12+13)
SetOperation/n=8/GEOS_Intersection-4                          57.4µs ± 4%    57.5µs ± 5%     ~     (p=0.946 n=14+14)
SetOperation/n=8/GEOS_Difference-4                            58.4µs ± 5%    58.3µs ± 5%     ~     (p=0.806 n=15+15)
SetOperation/n=8/GEOS_SymmetricDifference-4                   84.0µs ± 4%    86.3µs ± 5%   +2.71%  (p=0.002 n=13+14)
SetOperation/n=8/GEOS_Union-4                                 59.3µs ± 8%    59.2µs ± 4%     ~     (p=0.867 n=14+13)
SetOperation/n=16/Go_Intersection-4                           70.3µs ±12%    69.8µs ± 8%     ~     (p=0.583 n=13+14)
SetOperation/n=16/Go_Difference-4                             73.6µs ± 6%    72.5µs ±10%     ~     (p=0.217 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-4                     107µs ±11%     103µs ± 4%     ~     (p=0.098 n=15+15)
SetOperation/n=16/Go_Union-4                                  76.8µs ± 3%    76.5µs ± 4%     ~     (p=0.683 n=15+15)
SetOperation/n=16/GEOS_Intersection-4                         63.1µs ± 4%    63.1µs ± 4%     ~     (p=0.905 n=13+14)
SetOperation/n=16/GEOS_Difference-4                           69.1µs ± 4%    69.3µs ± 5%     ~     (p=0.683 n=14+15)
SetOperation/n=16/GEOS_SymmetricDifference-4                   109µs ± 7%     109µs ± 6%     ~     (p=0.902 n=15+15)
SetOperation/n=16/GEOS_Union-4                                71.5µs ± 6%    73.8µs ±10%     ~     (p=0.201 n=14+15)
SetOperation/n=32/Go_Intersection-4                            119µs ± 7%     120µs ± 3%     ~     (p=0.128 n=14+13)
SetOperation/n=32/Go_Difference-4                              124µs ± 8%     124µs ± 3%     ~     (p=0.905 n=14+13)
SetOperation/n=32/Go_SymmetricDifference-4                     174µs ± 8%     175µs ± 7%     ~     (p=0.650 n=15+13)
SetOperation/n=32/Go_Union-4                                   129µs ± 6%     131µs ± 8%     ~     (p=0.511 n=14+14)
SetOperation/n=32/GEOS_Intersection-4                         75.9µs ± 3%    76.1µs ± 5%     ~     (p=0.724 n=13+13)
SetOperation/n=32/GEOS_Difference-4                           83.8µs ± 4%    84.8µs ± 6%     ~     (p=0.285 n=14+14)
SetOperation/n=32/GEOS_SymmetricDifference-4                   145µs ±11%     148µs ± 9%     ~     (p=0.234 n=15+14)
SetOperation/n=32/GEOS_Union-4                                90.2µs ± 4%    92.6µs ±11%     ~     (p=0.217 n=14+15)
SetOperation/n=64/Go_Intersection-4                            202µs ± 8%     200µs ±10%     ~     (p=0.436 n=15+15)
SetOperation/n=64/Go_Difference-4                              216µs ±12%     219µs ± 7%     ~     (p=0.290 n=14+15)
SetOperation/n=64/Go_SymmetricDifference-4                     304µs ± 6%     305µs ± 6%     ~     (p=0.967 n=15+15)
SetOperation/n=64/Go_Union-4                                   229µs ± 8%     225µs ± 5%     ~     (p=0.259 n=13+14)
SetOperation/n=64/GEOS_Intersection-4                          100µs ± 5%      98µs ± 2%     ~     (p=0.103 n=15+12)
SetOperation/n=64/GEOS_Difference-4                            122µs ± 6%     121µs ± 4%     ~     (p=0.425 n=15+14)
SetOperation/n=64/GEOS_SymmetricDifference-4                   223µs ±10%     225µs ±10%     ~     (p=0.635 n=14+14)
SetOperation/n=64/GEOS_Union-4                                 132µs ± 3%     132µs ± 3%     ~     (p=0.914 n=15+14)
SetOperation/n=128/Go_Intersection-4                           367µs ± 4%     382µs ±16%     ~     (p=0.160 n=12+14)
SetOperation/n=128/Go_Difference-4                             386µs ± 6%     397µs ±10%   +2.92%  (p=0.029 n=13+14)
SetOperation/n=128/Go_SymmetricDifference-4                    555µs ±16%     539µs ± 7%     ~     (p=0.804 n=14+14)
SetOperation/n=128/Go_Union-4                                  410µs ± 9%     400µs ± 3%     ~     (p=0.081 n=13+13)
SetOperation/n=128/GEOS_Intersection-4                         150µs ± 3%     151µs ± 5%     ~     (p=0.511 n=14+14)
SetOperation/n=128/GEOS_Difference-4                           179µs ± 8%     180µs ± 7%     ~     (p=0.488 n=14+13)
SetOperation/n=128/GEOS_SymmetricDifference-4                  346µs ± 4%     341µs ± 4%     ~     (p=0.053 n=15+12)
SetOperation/n=128/GEOS_Union-4                                198µs ± 4%     198µs ± 6%     ~     (p=0.806 n=15+15)
SetOperation/n=256/Go_Intersection-4                           662µs ± 7%     671µs ±10%     ~     (p=0.402 n=13+14)
SetOperation/n=256/Go_Difference-4                             748µs ±10%     727µs ± 9%     ~     (p=0.280 n=13+14)
SetOperation/n=256/Go_SymmetricDifference-4                   1.11ms ±21%    1.06ms ± 8%     ~     (p=0.440 n=15+13)
SetOperation/n=256/Go_Union-4                                  803µs ±21%     754µs ± 4%     ~     (p=0.185 n=14+13)
SetOperation/n=256/GEOS_Intersection-4                         226µs ± 6%     222µs ± 3%     ~     (p=0.056 n=14+14)
SetOperation/n=256/GEOS_Difference-4                           297µs ± 5%     291µs ± 1%   -2.06%  (p=0.009 n=14+11)
SetOperation/n=256/GEOS_SymmetricDifference-4                  668µs ±10%     649µs ± 9%     ~     (p=0.128 n=13+14)
SetOperation/n=256/GEOS_Union-4                                334µs ± 5%     330µs ± 7%     ~     (p=0.302 n=13+14)
SetOperation/n=512/Go_Intersection-4                          1.36ms ±10%    1.37ms ±10%     ~     (p=0.571 n=14+14)
SetOperation/n=512/Go_Difference-4                            1.43ms ± 4%    1.46ms ± 9%     ~     (p=0.142 n=13+15)
SetOperation/n=512/Go_SymmetricDifference-4                   2.02ms ± 9%    2.07ms ± 7%     ~     (p=0.118 n=15+13)
SetOperation/n=512/Go_Union-4                                 1.51ms ± 9%    1.52ms ±11%     ~     (p=0.650 n=14+13)
SetOperation/n=512/GEOS_Intersection-4                         403µs ± 5%     397µs ± 5%     ~     (p=0.134 n=14+15)
SetOperation/n=512/GEOS_Difference-4                           527µs ± 4%     532µs ± 5%     ~     (p=0.352 n=14+14)
SetOperation/n=512/GEOS_SymmetricDifference-4                 1.18ms ± 5%    1.17ms ± 3%     ~     (p=0.793 n=14+13)
SetOperation/n=512/GEOS_Union-4                                596µs ± 8%     600µs ± 6%     ~     (p=0.561 n=14+15)
SetOperation/n=1024/Go_Intersection-4                         2.73ms ±25%    2.59ms ± 8%     ~     (p=0.234 n=15+14)
SetOperation/n=1024/Go_Difference-4                           2.84ms ± 6%    2.81ms ± 5%     ~     (p=0.311 n=13+13)
SetOperation/n=1024/Go_SymmetricDifference-4                  4.17ms ± 5%    4.13ms ± 6%     ~     (p=0.603 n=14+14)
SetOperation/n=1024/Go_Union-4                                2.98ms ± 7%    2.95ms ± 5%     ~     (p=0.477 n=15+14)
SetOperation/n=1024/GEOS_Intersection-4                        739µs ± 4%     741µs ± 4%     ~     (p=0.870 n=15+15)
SetOperation/n=1024/GEOS_Difference-4                         1.05ms ± 6%    1.07ms ± 7%     ~     (p=0.164 n=14+14)
SetOperation/n=1024/GEOS_SymmetricDifference-4                2.36ms ± 4%    2.40ms ± 8%     ~     (p=0.205 n=12+13)
SetOperation/n=1024/GEOS_Union-4                              1.23ms ± 5%    1.23ms ± 4%     ~     (p=0.860 n=14+12)
SetOperation/n=2048/Go_Intersection-4                         5.64ms ± 5%    5.60ms ±13%     ~     (p=0.320 n=12+13)
SetOperation/n=2048/Go_Difference-4                           6.19ms ±19%    5.96ms ±11%     ~     (p=0.239 n=14+13)
SetOperation/n=2048/Go_SymmetricDifference-4                  8.49ms ±12%    8.28ms ± 6%     ~     (p=0.274 n=15+13)
SetOperation/n=2048/Go_Union-4                                6.24ms ± 5%    6.63ms ±30%     ~     (p=0.265 n=14+14)
SetOperation/n=2048/GEOS_Intersection-4                       1.48ms ± 6%    1.47ms ± 2%     ~     (p=0.555 n=15+13)
SetOperation/n=2048/GEOS_Difference-4                         1.89ms ± 3%    1.88ms ± 3%     ~     (p=0.503 n=13+12)
SetOperation/n=2048/GEOS_SymmetricDifference-4                4.63ms ±11%    4.62ms ± 7%     ~     (p=0.345 n=15+15)
SetOperation/n=2048/GEOS_Union-4                              2.27ms ± 9%    2.26ms ± 4%     ~     (p=0.533 n=14+15)
SetOperation/n=4096/Go_Intersection-4                         11.6ms ±12%    11.6ms ± 6%     ~     (p=0.943 n=13+14)
SetOperation/n=4096/Go_Difference-4                           13.2ms ±13%    12.2ms ± 6%   -7.39%  (p=0.000 n=14+14)
SetOperation/n=4096/Go_SymmetricDifference-4                  18.2ms ±15%    17.6ms ± 7%     ~     (p=0.141 n=14+13)
SetOperation/n=4096/Go_Union-4                                13.8ms ± 9%    13.6ms ±12%     ~     (p=0.512 n=15+15)
SetOperation/n=4096/GEOS_Intersection-4                       2.75ms ± 6%    2.70ms ± 5%     ~     (p=0.102 n=15+14)
SetOperation/n=4096/GEOS_Difference-4                         4.21ms ±12%    4.14ms ±10%     ~     (p=0.252 n=15+14)
SetOperation/n=4096/GEOS_SymmetricDifference-4                10.2ms ± 7%     9.8ms ± 2%   -3.84%  (p=0.001 n=15+14)
SetOperation/n=4096/GEOS_Union-4                              4.84ms ±14%    4.78ms ± 3%     ~     (p=0.943 n=13+14)
SetOperation/n=8192/Go_Intersection-4                         24.4ms ±10%    24.5ms ±16%     ~     (p=0.982 n=14+14)
SetOperation/n=8192/Go_Difference-4                           25.5ms ± 9%    26.6ms ±11%     ~     (p=0.098 n=15+13)
SetOperation/n=8192/Go_SymmetricDifference-4                  35.6ms ±18%    35.4ms ± 9%     ~     (p=0.914 n=15+14)
SetOperation/n=8192/Go_Union-4                                25.5ms ± 6%    27.3ms ±18%   +6.84%  (p=0.002 n=13+14)
SetOperation/n=8192/GEOS_Intersection-4                       5.69ms ± 4%    5.71ms ± 4%     ~     (p=0.618 n=13+15)
SetOperation/n=8192/GEOS_Difference-4                         8.43ms ±10%    8.34ms ± 9%     ~     (p=0.451 n=14+15)
SetOperation/n=8192/GEOS_SymmetricDifference-4                19.8ms ±10%    19.7ms ± 6%     ~     (p=0.949 n=14+15)
SetOperation/n=8192/GEOS_Union-4                              9.54ms ± 9%    9.50ms ± 3%     ~     (p=0.717 n=15+13)
SetOperation/n=16384/Go_Intersection-4                        46.7ms ±12%    49.4ms ±16%     ~     (p=0.067 n=12+14)
SetOperation/n=16384/Go_Difference-4                          54.8ms ± 5%    55.4ms ±10%     ~     (p=0.905 n=13+14)
SetOperation/n=16384/Go_SymmetricDifference-4                 73.9ms ± 9%    73.5ms ± 8%     ~     (p=0.983 n=15+14)
SetOperation/n=16384/Go_Union-4                               55.6ms ± 4%    57.1ms ± 6%   +2.75%  (p=0.019 n=13+14)
SetOperation/n=16384/GEOS_Intersection-4                      11.8ms ± 7%    11.9ms ± 7%     ~     (p=0.867 n=14+13)
SetOperation/n=16384/GEOS_Difference-4                        17.1ms ± 4%    17.8ms ±15%     ~     (p=0.347 n=12+14)
SetOperation/n=16384/GEOS_SymmetricDifference-4               39.1ms ± 5%    38.9ms ± 3%     ~     (p=0.964 n=15+13)
SetOperation/n=16384/GEOS_Union-4                             20.1ms ± 2%    21.0ms ±10%   +4.34%  (p=0.008 n=12+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                19.9µs ± 8%    19.9µs ± 9%     ~     (p=0.967 n=15+15)
Delete/n=1000-4                                                653µs ± 2%     653µs ± 3%     ~     (p=0.650 n=14+13)
Delete/n=10000-4                                              31.1ms ± 3%    30.7ms ± 4%   -1.45%  (p=0.002 n=13+13)
Bulk/n=10-4                                                   1.21µs ±87%    0.87µs ±18%     ~     (p=0.077 n=14+14)
Bulk/n=100-4                                                  16.6µs ±60%    13.7µs ±16%  -17.23%  (p=0.001 n=13+15)
Bulk/n=1000-4                                                  225µs ± 4%     221µs ± 6%   -1.66%  (p=0.005 n=14+14)
Bulk/n=10000-4                                                3.15ms ± 5%    3.13ms ± 7%     ~     (p=0.150 n=14+14)
Bulk/n=100000-4                                               36.4ms ± 3%    35.9ms ± 3%     ~     (p=0.085 n=14+13)
Insert/n=10-4                                                 1.18µs ± 7%    1.22µs ±15%     ~     (p=0.519 n=13+14)
Insert/n=100-4                                                20.4µs ± 6%    20.8µs ± 6%     ~     (p=0.052 n=13+15)
Insert/n=1000-4                                                438µs ± 2%     447µs ± 8%     ~     (p=0.093 n=12+15)
Insert/n=10000-4                                              5.39ms ± 6%    5.56ms ±14%     ~     (p=0.146 n=15+14)
Insert/n=100000-4                                             60.2ms ± 2%    61.4ms ± 5%   +1.86%  (p=0.047 n=12+15)
RangeSearch/n=10-4                                            15.2ns ± 4%    15.2ns ± 4%     ~     (p=0.704 n=15+14)
RangeSearch/n=100-4                                           59.5ns ± 3%    59.5ns ± 5%     ~     (p=0.430 n=15+15)
RangeSearch/n=1000-4                                           217ns ± 2%     216ns ± 3%     ~     (p=0.522 n=15+14)
RangeSearch/n=10000-4                                          746ns ± 2%     753ns ± 3%     ~     (p=0.239 n=13+15)
RangeSearch/n=100000-4                                        7.37µs ± 6%    7.32µs ± 7%     ~     (p=0.567 n=15+15)

name                                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/1-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/2-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/3-4                                               0.00B          0.00B          ~     (all equal)
MarshalWKB/polygon/n=10-4                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                   164kB ± 0%     164kB ± 0%     ~     (p=0.074 n=12+15)
UnmarshalWKB/polygon/n=10-4                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                 164kB ± 0%     164kB ± 0%     ~     (p=0.462 n=15+15)
IntersectsLineStringWithLineString/n=10-4                     2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                    205kB ± 0%     205kB ± 0%     ~     (p=0.638 n=15+15)
IntersectsLineStringWithLineString/n=10000-4                  2.63MB ± 0%    2.63MB ± 0%     ~     (p=0.870 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20-4                       325B ± 0%      325B ± 0%     ~     (p=0.700 n=15+15)
IntersectsMultiPointWithMultiPoint/n=200-4                    3.08kB ± 0%    3.08kB ± 0%     ~     (p=0.770 n=15+14)
IntersectsMultiPointWithMultiPoint/n=2000-4                   49.3kB ± 0%    49.3kB ± 0%   +0.00%  (p=0.029 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000-4                   339kB ± 0%     339kB ± 0%     ~     (p=0.419 n=15+15)
PolygonSingleRingValidation/n=10-4                            2.29kB ± 0%    2.29kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                           24.4kB ± 0%    24.4kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                           140kB ± 0%     140kB ± 0%     ~     (p=0.963 n=15+15)
PolygonSingleRingValidation/n=10000-4                         1.97MB ± 0%    1.97MB ± 0%   +0.00%  (p=0.041 n=14+15)
PolygonMultipleRingsValidation/n=4-4                          6.61kB ± 0%    6.61kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                         53.2kB ± 0%    53.2kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         597kB ± 0%     597kB ± 0%   +0.00%  (p=0.036 n=15+12)
PolygonMultipleRingsValidation/n=4096-4                       6.28MB ± 0%    6.28MB ± 0%     ~     (p=0.059 n=13+15)
PolygonZigZagRingsValidation/n=10-4                           9.62kB ± 0%    9.62kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                          88.0kB ± 0%    88.0kB ± 0%     ~     (p=0.070 n=15+13)
PolygonZigZagRingsValidation/n=1000-4                          551kB ± 0%     551kB ± 0%     ~     (p=0.758 n=15+13)
PolygonZigZagRingsValidation/n=10000-4                        7.24MB ± 0%    7.24MB ± 0%     ~     (p=0.878 n=15+15)
PolygonAnnulusValidation/n=10-4                               4.10kB ± 0%    4.10kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                              28.4kB ± 0%    28.4kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              379kB ± 0%     379kB ± 0%     ~     (p=0.658 n=15+14)
PolygonAnnulusValidation/n=10000-4                            3.89MB ± 0%    3.89MB ± 0%     ~     (p=0.523 n=14+15)
MultipolygonValidation/n=1-4                                    385B ± 0%      481B ± 0%  +24.94%  (p=0.000 n=15+15)
MultipolygonValidation/n=4-4                                    676B ± 0%      980B ± 0%  +44.97%  (p=0.000 n=15+15)
MultipolygonValidation/n=16-4                                 3.86kB ± 0%    4.16kB ± 0%   +7.88%  (p=0.000 n=15+15)
MultipolygonValidation/n=64-4                                 15.4kB ± 0%    17.0kB ± 0%  +10.27%  (p=0.000 n=15+15)
MultipolygonValidation/n=256-4                                63.1kB ± 0%    67.8kB ± 0%   +7.32%  (p=0.000 n=15+15)
MultipolygonValidation/n=1024-4                                259kB ± 0%     271kB ± 0%   +4.91%  (p=0.000 n=15+12)
MultiPolygonTwoCircles/n=10-4                                 4.99kB ± 0%    5.15kB ± 0%   +3.20%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                                55.0kB ± 0%    55.1kB ± 0%   +0.29%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                                345kB ± 0%     345kB ± 0%   +0.05%  (p=0.000 n=15+14)
MultiPolygonTwoCircles/n=10000-4                              4.60MB ± 0%    4.60MB ± 0%   +0.00%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1-4                      3.95kB ± 0%    4.11kB ± 0%   +4.05%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4                     22.6kB ± 0%    22.7kB ± 0%   +0.71%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     172kB ± 0%     172kB ± 0%   +0.09%  (p=0.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1000-4                   2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.050 n=15+15)
WKTParsing/point-4                                            1.93kB ± 0%    1.93kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           369kB ± 0%     369kB ± 0%   -0.00%  (p=0.014 n=15+14)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            369kB ± 0%     369kB ± 0%     ~     (p=0.432 n=14+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.099 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.884 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=100-4                59.2kB ± 0%    59.2kB ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                491kB ± 0%     491kB ± 0%     ~     (p=0.073 n=15+12)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-4                          1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100-4                         6.47kB ± 0%    6.47kB ± 0%   -0.01%  (p=0.009 n=15+13)
IntersectionWithoutValidation/n=1000-4                        55.1kB ± 0%    55.1kB ± 0%     ~     (p=0.133 n=13+15)
IntersectionWithoutValidation/n=10000-4                        558kB ± 0%     558kB ± 0%     ~     (p=0.898 n=13+15)
NoOp/n=10-4                                                     968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100-4                                                  5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                                 49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                                 492kB ± 0%     492kB ± 0%     ~     (p=0.093 n=15+15)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-4                               1.87kB ± 0%    1.87kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100-4                              24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000-4                              139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000-4                            1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.161 n=14+15)
LineStringIsSimpleZigZag/10-4                                 1.84kB ± 0%    1.84kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                              1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.803 n=14+15)
SetOperation/n=4/Go_Intersection-4                            20.4kB ± 0%    20.6kB ± 0%   +0.94%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference-4                              21.4kB ± 0%    21.6kB ± 0%   +0.88%  (p=0.000 n=14+14)
SetOperation/n=4/Go_SymmetricDifference-4                     29.2kB ± 0%    29.5kB ± 0%   +1.20%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union-4                                   22.1kB ± 0%    22.3kB ± 0%   +0.86%  (p=0.000 n=14+14)
SetOperation/n=4/GEOS_Intersection-4                          1.78kB ± 0%    1.78kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference-4                            2.79kB ± 0%    2.79kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-4                   10.5kB ± 0%    10.7kB ± 0%   +1.52%  (p=0.000 n=15+13)
SetOperation/n=4/GEOS_Union-4                                 3.22kB ± 0%    3.22kB ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection-4                            27.7kB ± 0%    27.9kB ± 0%   +0.69%  (p=0.000 n=15+14)
SetOperation/n=8/Go_Difference-4                              27.8kB ± 0%    28.0kB ± 0%   +0.70%  (p=0.000 n=15+14)
SetOperation/n=8/Go_SymmetricDifference-4                     37.6kB ± 0%    38.0kB ± 0%   +0.92%  (p=0.000 n=15+14)
SetOperation/n=8/Go_Union-4                                   28.0kB ± 0%    28.2kB ± 0%   +0.68%  (p=0.000 n=15+14)
SetOperation/n=8/GEOS_Intersection-4                          3.35kB ± 0%    3.35kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference-4                            3.51kB ± 0%    3.51kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-4                   13.0kB ± 0%    13.2kB ± 0%   +1.23%  (p=0.000 n=15+15)
SetOperation/n=8/GEOS_Union-4                                 3.64kB ± 0%    3.64kB ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection-4                           39.1kB ± 0%    39.3kB ± 0%   +0.49%  (p=0.000 n=15+13)
SetOperation/n=16/Go_Difference-4                             42.3kB ± 0%    42.5kB ± 0%   +0.45%  (p=0.000 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-4                    61.0kB ± 0%    61.4kB ± 0%   +0.57%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Union-4                                  43.8kB ± 0%    43.9kB ± 0%   +0.44%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Intersection-4                         3.90kB ± 0%    3.90kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference-4                           6.70kB ± 0%    6.70kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-4                  25.0kB ± 0%    25.2kB ± 0%   +0.64%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Union-4                                8.30kB ± 0%    8.30kB ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection-4                           72.3kB ± 0%    72.5kB ± 0%   +0.27%  (p=0.000 n=13+15)
SetOperation/n=32/Go_Difference-4                             74.9kB ± 0%    75.1kB ± 0%   +0.26%  (p=0.000 n=15+15)
SetOperation/n=32/Go_SymmetricDifference-4                     105kB ± 0%     105kB ± 0%   +0.34%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Union-4                                  75.3kB ± 0%    75.5kB ± 0%   +0.26%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Intersection-4                         8.87kB ± 0%    8.87kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference-4                           10.7kB ± 0%    10.7kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-4                  39.6kB ± 0%    39.7kB ± 0%   +0.40%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Union-4                                11.5kB ± 0%    11.5kB ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection-4                            122kB ± 0%     122kB ± 0%   +0.15%  (p=0.000 n=15+13)
SetOperation/n=64/Go_Difference-4                              134kB ± 0%     135kB ± 0%   +0.14%  (p=0.000 n=14+15)
SetOperation/n=64/Go_SymmetricDifference-4                     200kB ± 0%     200kB ± 0%   +0.18%  (p=0.000 n=15+14)
SetOperation/n=64/Go_Union-4                                   138kB ± 0%     138kB ± 0%   +0.14%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Intersection-4                         12.6kB ± 0%    12.6kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference-4                           23.5kB ± 0%    23.5kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-4                  87.2kB ± 0%    87.4kB ± 0%   +0.18%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Union-4                                28.0kB ± 0%    28.0kB ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection-4                           249kB ± 0%     249kB ± 0%   +0.08%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Difference-4                             261kB ± 0%     261kB ± 0%   +0.07%  (p=0.000 n=15+15)
SetOperation/n=128/Go_SymmetricDifference-4                    372kB ± 0%     372kB ± 0%   +0.10%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Union-4                                  263kB ± 0%     263kB ± 0%   +0.07%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Intersection-4                        30.3kB ± 0%    30.3kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference-4                          40.0kB ± 0%    40.0kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-4                  147kB ± 0%     147kB ± 0%   +0.11%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Union-4                               43.1kB ± 0%    43.1kB ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection-4                           458kB ± 0%     458kB ± 0%   +0.04%  (p=0.000 n=14+15)
SetOperation/n=256/Go_Difference-4                             507kB ± 0%     507kB ± 0%   +0.04%  (p=0.000 n=15+15)
SetOperation/n=256/Go_SymmetricDifference-4                    762kB ± 0%     762kB ± 0%   +0.05%  (p=0.000 n=15+15)
SetOperation/n=256/Go_Union-4                                  517kB ± 0%     517kB ± 0%   +0.03%  (p=0.000 n=15+15)
SetOperation/n=256/GEOS_Intersection-4                        48.2kB ± 0%    48.2kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference-4                          92.6kB ± 0%    92.6kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-4                  341kB ± 0%     341kB ± 0%   +0.05%  (p=0.000 n=15+15)
SetOperation/n=256/GEOS_Union-4                                106kB ± 0%     106kB ± 0%   +0.00%  (p=0.014 n=12+15)
SetOperation/n=512/Go_Intersection-4                           939kB ± 0%     940kB ± 0%   +0.02%  (p=0.000 n=14+14)
SetOperation/n=512/Go_Difference-4                             987kB ± 0%     987kB ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=512/Go_SymmetricDifference-4                   1.41MB ± 0%    1.41MB ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Union-4                                 1.01MB ± 0%    1.01MB ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=512/GEOS_Intersection-4                         115kB ± 0%     115kB ± 0%     ~     (p=0.056 n=15+12)
SetOperation/n=512/GEOS_Difference-4                           159kB ± 0%     159kB ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=512/GEOS_SymmetricDifference-4                  577kB ± 0%     577kB ± 0%   +0.03%  (p=0.000 n=15+15)
SetOperation/n=512/GEOS_Union-4                                171kB ± 0%     171kB ± 0%     ~     (p=0.605 n=9+15)
SetOperation/n=1024/Go_Intersection-4                         1.74MB ± 0%    1.74MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_Difference-4                           1.93MB ± 0%    1.93MB ± 0%   +0.01%  (p=0.000 n=13+15)
SetOperation/n=1024/Go_SymmetricDifference-4                  2.95MB ± 0%    2.95MB ± 0%   +0.01%  (p=0.000 n=15+14)
SetOperation/n=1024/Go_Union-4                                1.98MB ± 0%    1.98MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/GEOS_Intersection-4                        189kB ± 0%     189kB ± 0%     ~     (p=0.751 n=14+15)
SetOperation/n=1024/GEOS_Difference-4                          370kB ± 0%     370kB ± 0%     ~     (p=0.327 n=15+14)
SetOperation/n=1024/GEOS_SymmetricDifference-4                1.38MB ± 0%    1.38MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/GEOS_Union-4                               415kB ± 0%     415kB ± 0%     ~     (p=0.072 n=15+14)
SetOperation/n=2048/Go_Intersection-4                         3.95MB ± 0%    3.95MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Difference-4                           4.18MB ± 0%    4.18MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference-4                  5.93MB ± 0%    5.93MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Union-4                                4.26MB ± 0%    4.26MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Intersection-4                        460kB ± 0%     460kB ± 0%     ~     (p=0.626 n=15+15)
SetOperation/n=2048/GEOS_Difference-4                          648kB ± 0%     648kB ± 0%     ~     (p=0.991 n=15+15)
SetOperation/n=2048/GEOS_SymmetricDifference-4                2.32MB ± 0%    2.32MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Union-4                               689kB ± 0%     689kB ± 0%     ~     (p=0.228 n=14+15)
SetOperation/n=4096/Go_Intersection-4                         7.42MB ± 0%    7.42MB ± 0%   +0.00%  (p=0.000 n=15+14)
SetOperation/n=4096/Go_Difference-4                           8.14MB ± 0%    8.14MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-4                  12.2MB ± 0%    12.2MB ± 0%   +0.00%  (p=0.000 n=13+15)
SetOperation/n=4096/Go_Union-4                                8.38MB ± 0%    8.38MB ± 0%   +0.00%  (p=0.000 n=14+14)
SetOperation/n=4096/GEOS_Intersection-4                        755kB ± 0%     755kB ± 0%   +0.00%  (p=0.003 n=12+15)
SetOperation/n=4096/GEOS_Difference-4                         1.45MB ± 0%    1.45MB ± 0%     ~     (p=0.990 n=15+15)
SetOperation/n=4096/GEOS_SymmetricDifference-4                5.34MB ± 0%    5.34MB ± 0%   +0.00%  (p=0.000 n=15+14)
SetOperation/n=4096/GEOS_Union-4                              1.63MB ± 0%    1.63MB ± 0%     ~     (p=0.677 n=15+14)
SetOperation/n=8192/Go_Intersection-4                         16.1MB ± 0%    16.1MB ± 0%   +0.00%  (p=0.000 n=15+13)
SetOperation/n=8192/Go_Difference-4                           17.0MB ± 0%    17.0MB ± 0%   +0.00%  (p=0.000 n=14+15)
SetOperation/n=8192/Go_SymmetricDifference-4                  23.9MB ± 0%    23.9MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Union-4                                17.3MB ± 0%    17.3MB ± 0%   +0.00%  (p=0.007 n=15+15)
SetOperation/n=8192/GEOS_Intersection-4                       1.76MB ± 0%    1.76MB ± 0%     ~     (p=0.957 n=14+15)
SetOperation/n=8192/GEOS_Difference-4                         2.47MB ± 0%    2.47MB ± 0%     ~     (p=0.716 n=15+15)
SetOperation/n=8192/GEOS_SymmetricDifference-4                9.01MB ± 0%    9.01MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=8192/GEOS_Union-4                              2.66MB ± 0%    2.66MB ± 0%     ~     (p=0.328 n=15+14)
SetOperation/n=16384/Go_Intersection-4                        30.3MB ± 0%    30.3MB ± 0%   +0.00%  (p=0.000 n=14+15)
SetOperation/n=16384/Go_Difference-4                          33.4MB ± 0%    33.4MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-4                 49.7MB ± 0%    49.7MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Union-4                               34.4MB ± 0%    34.4MB ± 0%   +0.00%  (p=0.014 n=15+15)
SetOperation/n=16384/GEOS_Intersection-4                      2.92MB ± 0%    2.92MB ± 0%     ~     (p=0.943 n=15+15)
SetOperation/n=16384/GEOS_Difference-4                        5.68MB ± 0%    5.68MB ± 0%     ~     (p=0.352 n=15+13)
SetOperation/n=16384/GEOS_SymmetricDifference-4               21.1MB ± 0%    21.1MB ± 0%   +0.00%  (p=0.000 n=15+14)
SetOperation/n=16384/GEOS_Union-4                             6.45MB ± 0%    6.45MB ± 0%     ~     (p=0.645 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                               26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-4                                               412kB ± 0%     412kB ± 0%     ~     (p=1.000 n=15+15)
Bulk/n=10-4                                                   1.46kB ± 0%    1.46kB ± 0%     ~     (all equal)
Bulk/n=100-4                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-4                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (p=0.156 n=12+15)
Bulk/n=10000-4                                                1.57MB ± 0%    1.57MB ± 0%   -0.00%  (p=0.025 n=15+13)
Bulk/n=100000-4                                               20.4MB ± 0%    20.4MB ± 0%     ~     (p=0.071 n=15+12)
Insert/n=10-4                                                 1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-4                                                13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-4                                                132kB ± 0%     132kB ± 0%     ~     (p=0.450 n=15+15)
Insert/n=10000-4                                              1.34MB ± 0%    1.34MB ± 0%     ~     (p=0.688 n=15+15)
Insert/n=100000-4                                             13.5MB ± 0%    13.5MB ± 0%     ~     (p=0.790 n=14+13)
RangeSearch/n=10-4                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-4                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-4                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-4                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-4                                         0.00B          0.00B          ~     (all equal)

name                                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/1-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/2-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/3-4                                                0.00           0.00          ~     (all equal)
MarshalWKB/polygon/n=10-4                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-4                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-4                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-4                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                              12.0 ± 0%      12.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                             76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                             348 ± 0%       348 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4                          5.47k ± 0%     5.47k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4                            42.0 ± 0%      42.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                            316 ± 0%       316 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         3.48k ± 0%     3.48k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4                        36.2k ± 0%     36.2k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-4                             41.0 ± 0%      41.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                             233 ± 0%       233 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          1.05k ± 0%     1.05k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4                         16.4k ± 0%     16.4k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10-4                                 22.0 ± 0%      22.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                                76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000-4                             10.3k ± 0%     10.3k ± 0%     ~     (all equal)
MultipolygonValidation/n=1-4                                    5.00 ± 0%      8.00 ± 0%  +60.00%  (p=0.000 n=15+15)
MultipolygonValidation/n=4-4                                    8.00 ± 0%     11.00 ± 0%  +37.50%  (p=0.000 n=15+15)
MultipolygonValidation/n=16-4                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                   99.0 ± 0%      91.0 ± 0%   -8.08%  (p=0.000 n=15+15)
MultipolygonValidation/n=256-4                                   392 ± 0%       347 ± 0%  -11.48%  (p=0.000 n=15+15)
MultipolygonValidation/n=1024-4                                1.58k ± 0%     1.37k ± 0%  -13.23%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10-4                                   26.0 ± 0%      29.0 ± 0%  +11.54%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=100-4                                   154 ± 0%       157 ± 0%   +1.95%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=1000-4                                  698 ± 0%       701 ± 0%   +0.43%  (p=0.000 n=15+15)
MultiPolygonTwoCircles/n=10000-4                               10.9k ± 0%     10.9k ± 0%   +0.03%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-4                        47.0 ± 0%      50.0 ± 0%   +6.38%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-4                        294 ± 0%       297 ± 0%   +1.02%  (p=0.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     2.61k ± 0%     2.61k ± 0%   +0.11%  (p=0.000 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000-4                    26.7k ± 0%     26.7k ± 0%   +0.01%  (p=0.000 n=15+14)
WKTParsing/point-4                                              21.0 ± 0%      21.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4               234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            2.10k ± 0%     2.10k ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4       77.0 ± 0%      77.0 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-4                   371 ± 0%       371 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                3.34k ± 0%     3.34k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-4                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100-4                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=1000-4                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=10000-4                         48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-4                                 7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100-4                                71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000-4                                343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000-4                             5.46k ± 0%     5.46k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
SetOperation/n=4/Go_Intersection-4                               265 ± 0%       271 ± 0%   +2.26%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference-4                                 269 ± 0%       275 ± 0%   +2.23%  (p=0.000 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-4                        363 ± 0%       372 ± 0%   +2.48%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union-4                                      276 ± 0%       282 ± 0%   +2.17%  (p=0.000 n=15+15)
SetOperation/n=4/GEOS_Intersection-4                            52.0 ± 0%      52.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference-4                              55.0 ± 0%      55.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-4                      144 ± 0%       147 ± 0%   +2.08%  (p=0.000 n=15+15)
SetOperation/n=4/GEOS_Union-4                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection-4                               282 ± 0%       288 ± 0%   +2.13%  (p=0.000 n=15+15)
SetOperation/n=8/Go_Difference-4                                 283 ± 0%       289 ± 0%   +2.12%  (p=0.000 n=15+15)
SetOperation/n=8/Go_SymmetricDifference-4                        383 ± 0%       392 ± 0%   +2.35%  (p=0.000 n=15+15)
SetOperation/n=8/Go_Union-4                                      288 ± 0%       294 ± 0%   +2.08%  (p=0.000 n=15+15)
SetOperation/n=8/GEOS_Intersection-4                            56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference-4                              56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-4                      148 ± 0%       151 ± 0%   +2.03%  (p=0.000 n=15+15)
SetOperation/n=8/GEOS_Union-4                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection-4                              296 ± 0%       302 ± 0%   +2.03%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Difference-4                                306 ± 0%       312 ± 0%   +1.96%  (p=0.000 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-4                       431 ± 0%       440 ± 0%   +2.09%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Union-4                                     315 ± 0%       321 ± 0%   +1.90%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Intersection-4                           56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference-4                             64.0 ± 0%      64.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-4                     181 ± 0%       184 ± 0%   +1.66%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Union-4                                  68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection-4                              348 ± 0%       354 ± 0%   +1.72%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Difference-4                                354 ± 0%       360 ± 0%   +1.69%  (p=0.000 n=15+15)
SetOperation/n=32/Go_SymmetricDifference-4                       503 ± 0%       512 ± 0%   +1.79%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Union-4                                     359 ± 0%       365 ± 0%   +1.67%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Intersection-4                           68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference-4                             72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-4                     212 ± 0%       215 ± 0%   +1.42%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Union-4                                  72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection-4                              390 ± 0%       396 ± 0%   +1.54%  (p=0.000 n=12+13)
SetOperation/n=64/Go_Difference-4                                424 ± 0%       430 ± 0%   +1.42%  (p=0.000 n=15+12)
SetOperation/n=64/Go_SymmetricDifference-4                       671 ± 0%       680 ± 0%   +1.34%  (p=0.000 n=14+13)
SetOperation/n=64/Go_Union-4                                     437 ± 0%       443 ± 0%   +1.37%  (p=0.000 n=12+14)
SetOperation/n=64/GEOS_Intersection-4                           72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference-4                              104 ± 0%       104 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-4                     341 ± 0%       344 ± 0%   +0.88%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Union-4                                   112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection-4                             564 ± 0%       570 ± 0%   +1.06%  (p=0.000 n=14+12)
SetOperation/n=128/Go_Difference-4                               590 ± 0%       596 ± 0%   +0.94%  (p=0.000 n=15+13)
SetOperation/n=128/Go_SymmetricDifference-4                      934 ± 0%       943 ± 0%   +1.01%  (p=0.000 n=13+15)
SetOperation/n=128/Go_Union-4                                    595 ± 0%       601 ± 0%   +1.01%  (p=0.000 n=14+13)
SetOperation/n=128/GEOS_Intersection-4                           112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference-4                             136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-4                    469 ± 0%       472 ± 0%   +0.64%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Union-4                                  136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection-4                             724 ± 0%       730 ± 0%   +0.83%  (p=0.000 n=15+14)
SetOperation/n=256/Go_Difference-4                               854 ± 0%       860 ± 0%   +0.70%  (p=0.000 n=15+15)
SetOperation/n=256/Go_SymmetricDifference-4                    1.58k ± 0%     1.59k ± 0%   +0.57%  (p=0.000 n=15+15)
SetOperation/n=256/Go_Union-4                                    883 ± 0%       889 ± 0%   +0.68%  (p=0.000 n=14+15)
SetOperation/n=256/GEOS_Intersection-4                           136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference-4                             264 ± 0%       264 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-4                    981 ± 0%       984 ± 0%   +0.31%  (p=0.000 n=15+15)
SetOperation/n=256/GEOS_Union-4                                  288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/Go_Intersection-4                           1.40k ± 0%     1.40k ± 0%   +0.43%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Difference-4                             1.50k ± 0%     1.51k ± 0%   +0.40%  (p=0.000 n=15+15)
SetOperation/n=512/Go_SymmetricDifference-4                    2.62k ± 0%     2.62k ± 0%   +0.34%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Union-4                                  1.51k ± 0%     1.51k ± 0%   +0.40%  (p=0.000 n=15+15)
SetOperation/n=512/GEOS_Intersection-4                           288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Difference-4                             392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-4                  1.49k ± 0%     1.50k ± 0%   +0.20%  (p=0.000 n=15+15)
SetOperation/n=512/GEOS_Union-4                                  392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Intersection-4                          2.02k ± 0%     2.03k ± 0%   +0.28%  (p=0.000 n=12+15)
SetOperation/n=1024/Go_Difference-4                            2.54k ± 0%     2.54k ± 0%   +0.22%  (p=0.000 n=14+15)
SetOperation/n=1024/Go_SymmetricDifference-4                   5.19k ± 0%     5.20k ± 0%   +0.17%  (p=0.000 n=13+14)
SetOperation/n=1024/Go_Union-4                                 2.63k ± 0%     2.64k ± 0%   +0.23%  (p=0.000 n=15+15)
SetOperation/n=1024/GEOS_Intersection-4                          392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Difference-4                            904 ± 0%       904 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-4                 3.54k ± 0%     3.54k ± 0%   +0.08%  (p=0.000 n=15+15)
SetOperation/n=1024/GEOS_Union-4                                 992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Intersection-4                          4.69k ± 0%     4.69k ± 0%   +0.13%  (p=0.000 n=14+14)
SetOperation/n=2048/Go_Difference-4                            5.11k ± 0%     5.12k ± 0%   +0.12%  (p=0.000 n=14+15)
SetOperation/n=2048/Go_SymmetricDifference-4                   9.30k ± 0%     9.31k ± 0%   +0.10%  (p=0.000 n=12+12)
SetOperation/n=2048/Go_Union-4                                 5.12k ± 0%     5.12k ± 0%   +0.12%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Intersection-4                          992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Difference-4                          1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-4                 5.59k ± 0%     5.59k ± 0%   +0.05%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Union-4                               1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/Go_Intersection-4                          7.17k ± 0%     7.18k ± 0%   +0.08%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_Difference-4                            9.22k ± 0%     9.23k ± 0%   +0.06%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-4                   19.6k ± 0%     19.6k ± 0%   +0.05%  (p=0.000 n=15+11)
SetOperation/n=4096/Go_Union-4                                 9.57k ± 0%     9.58k ± 0%   +0.06%  (p=0.000 n=15+15)
SetOperation/n=4096/GEOS_Intersection-4                        1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Difference-4                          3.46k ± 0%     3.46k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-4                 13.8k ± 0%     13.8k ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=4096/GEOS_Union-4                               3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/Go_Intersection-4                          17.8k ± 0%     17.8k ± 0%   +0.03%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Difference-4                            19.5k ± 0%     19.5k ± 0%   +0.03%  (p=0.000 n=10+15)
SetOperation/n=8192/Go_SymmetricDifference-4                   36.0k ± 0%     36.0k ± 0%   +0.03%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Union-4                                 19.5k ± 0%     19.5k ± 0%   +0.03%  (p=0.000 n=15+10)
SetOperation/n=8192/GEOS_Intersection-4                        3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Difference-4                          5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-4                 22.0k ± 0%     22.0k ± 0%   +0.01%  (p=0.000 n=13+13)
SetOperation/n=8192/GEOS_Union-4                               5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/Go_Intersection-4                         27.7k ± 0%     27.7k ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Difference-4                           35.9k ± 0%     35.9k ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-4                  76.9k ± 0%     76.9k ± 0%   +0.01%  (p=0.000 n=14+15)
SetOperation/n=16384/Go_Union-4                                37.2k ± 0%     37.3k ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=16384/GEOS_Intersection-4                       5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Difference-4                         13.7k ± 0%     13.7k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-4                54.7k ± 0%     54.7k ± 0%   +0.00%  (p=0.000 n=15+14)
SetOperation/n=16384/GEOS_Union-4                              15.1k ± 0%     15.1k ± 0%     ~     (p=0.070 n=15+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                                  480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-4                                               7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-4                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-4                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-4                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-4                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-4                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-4                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-4                                                  47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-4                                                  457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-4                                               4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-4                                              46.8k ± 0%     46.8k ± 0%     ~     (p=0.084 n=15+14)
RangeSearch/n=10-4                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100-4                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000-4                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000-4                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000-4                                          0.00           0.00          ~     (all equal)

```

</details>