### PR TITLE
Use bools rather than bit fields for DCEL labels

### DIFF
--- a/geom/alg_binary_op.go
+++ b/geom/alg_binary_op.go
@@ -61,7 +61,7 @@ func SymmetricDifference(a, b Geometry) (Geometry, error) {
 	return binaryOp(a, b, selectSymmetricDifference)
 }
 
-func binaryOp(a, b Geometry, include func(uint8) bool) (Geometry, error) {
+func binaryOp(a, b Geometry, include func([2]label) bool) (Geometry, error) {
 	overlay, err := createOverlay(a, b)
 	if err != nil {
 		return Geometry{}, fmt.Errorf("internal error creating overlay: %v", err)
@@ -91,8 +91,8 @@ func createOverlay(a, b Geometry) (*doublyConnectedEdgeList, error) {
 
 	interactionPoints := findInteractionPoints([]Geometry{a, b, ghosts.AsGeometry()})
 
-	dcelA := newDCELFromGeometry(a, ghosts, inputAMask, interactionPoints)
-	dcelB := newDCELFromGeometry(b, ghosts, inputBMask, interactionPoints)
+	dcelA := newDCELFromGeometry(a, ghosts, operandA, interactionPoints)
+	dcelB := newDCELFromGeometry(b, ghosts, operandB, interactionPoints)
 
 	dcelA.overlay(dcelB)
 	return dcelA, nil

--- a/geom/dcel.go
+++ b/geom/dcel.go
@@ -57,7 +57,7 @@ type vertexRecord struct {
 	coords    XY
 	incidents []*halfEdgeRecord
 	labels    [2]label
-	locations [2]hasLocation
+	locations [2]location
 	extracted bool
 }
 
@@ -310,7 +310,7 @@ func newDCELFromMultiPoint(mp MultiPoint, operand operand) *doublyConnectedEdgeL
 				coords:    xy,
 				incidents: nil,
 				labels:    [2]label{},       // set below
-				locations: [2]hasLocation{}, // set below
+				locations: [2]location{}, // set below
 			}
 			dcel.vertices[xy] = record
 		}

--- a/geom/dcel.go
+++ b/geom/dcel.go
@@ -11,8 +11,9 @@ type doublyConnectedEdgeList struct {
 }
 
 type faceRecord struct {
-	cycle *halfEdgeRecord
-	label uint8
+	cycle     *halfEdgeRecord
+	labels    [2]label
+	extracted bool
 }
 
 func (f *faceRecord) String() string {
@@ -28,8 +29,9 @@ type halfEdgeRecord struct {
 	incident     *faceRecord // only populated in the overlay
 	next, prev   *halfEdgeRecord
 	intermediate []XY
-	edgeLabel    uint8
-	faceLabel    uint8
+	edgeLabels   [2]label
+	faceLabels   [2]label
+	extracted    bool
 }
 
 // secondXY gives the second (1-indexed) XY in the edge. This is either the
@@ -54,8 +56,9 @@ func (e *halfEdgeRecord) String() string {
 type vertexRecord struct {
 	coords    XY
 	incidents []*halfEdgeRecord
-	label     uint8
-	locLabel  uint8
+	labels    [2]label
+	locations [2]hasLocation
+	extracted bool
 }
 
 func forEachEdge(start *halfEdgeRecord, fn func(*halfEdgeRecord)) {
@@ -69,38 +72,38 @@ func forEachEdge(start *halfEdgeRecord, fn func(*halfEdgeRecord)) {
 	}
 }
 
-func newDCELFromGeometry(g Geometry, ghosts MultiLineString, mask uint8, interactions map[XY]struct{}) *doublyConnectedEdgeList {
+func newDCELFromGeometry(g Geometry, ghosts MultiLineString, operand operand, interactions map[XY]struct{}) *doublyConnectedEdgeList {
 	var dcel *doublyConnectedEdgeList
 	switch g.Type() {
 	case TypePolygon:
 		poly := g.AsPolygon()
-		dcel = newDCELFromMultiPolygon(poly.AsMultiPolygon(), mask, interactions)
+		dcel = newDCELFromMultiPolygon(poly.AsMultiPolygon(), operand, interactions)
 	case TypeMultiPolygon:
 		mp := g.AsMultiPolygon()
-		dcel = newDCELFromMultiPolygon(mp, mask, interactions)
+		dcel = newDCELFromMultiPolygon(mp, operand, interactions)
 	case TypeLineString:
 		mls := g.AsLineString().AsMultiLineString()
-		dcel = newDCELFromMultiLineString(mls, mask, interactions)
+		dcel = newDCELFromMultiLineString(mls, operand, interactions)
 	case TypeMultiLineString:
 		mls := g.AsMultiLineString()
-		dcel = newDCELFromMultiLineString(mls, mask, interactions)
+		dcel = newDCELFromMultiLineString(mls, operand, interactions)
 	case TypePoint:
 		mp := NewMultiPointFromPoints([]Point{g.AsPoint()})
-		dcel = newDCELFromMultiPoint(mp, mask)
+		dcel = newDCELFromMultiPoint(mp, operand)
 	case TypeMultiPoint:
 		mp := g.AsMultiPoint()
-		dcel = newDCELFromMultiPoint(mp, mask)
+		dcel = newDCELFromMultiPoint(mp, operand)
 	case TypeGeometryCollection:
 		panic("geometry collection not supported")
 	default:
 		panic(fmt.Sprintf("unknown geometry type: %v", g.Type()))
 	}
 
-	dcel.addGhosts(ghosts, mask, interactions)
+	dcel.addGhosts(ghosts, operand, interactions)
 	return dcel
 }
 
-func newDCELFromMultiPolygon(mp MultiPolygon, mask uint8, interactions map[XY]struct{}) *doublyConnectedEdgeList {
+func newDCELFromMultiPolygon(mp MultiPolygon, operand operand, interactions map[XY]struct{}) *doublyConnectedEdgeList {
 	mp = mp.ForceCCW()
 
 	dcel := &doublyConnectedEdgeList{vertices: make(map[XY]*vertexRecord)}
@@ -123,7 +126,13 @@ func newDCELFromMultiPolygon(mp MultiPolygon, mask uint8, interactions map[XY]st
 					continue
 				}
 				if _, ok := dcel.vertices[xy]; !ok {
-					dcel.vertices[xy] = &vertexRecord{xy, nil /* populated later */, mask, mask & locBoundary}
+					vr := &vertexRecord{
+						coords:    xy,
+						incidents: nil, // populated later
+						labels:    newHalfPopulatedLabels(operand, true),
+						locations: newLocationsOnBoundary(operand),
+					}
+					dcel.vertices[xy] = vr
 				}
 			}
 		}
@@ -145,8 +154,8 @@ func newDCELFromMultiPolygon(mp MultiPolygon, mask uint8, interactions map[XY]st
 					next:         nil, // populated later
 					prev:         nil, // populated later
 					intermediate: intermediateFwd,
-					edgeLabel:    mask,
-					faceLabel:    mask,
+					edgeLabels:   newHalfPopulatedLabels(operand, true),
+					faceLabels:   newHalfPopulatedLabels(operand, true),
 				}
 				externalEdge := &halfEdgeRecord{
 					origin:       vertB,
@@ -155,8 +164,8 @@ func newDCELFromMultiPolygon(mp MultiPolygon, mask uint8, interactions map[XY]st
 					next:         nil, // populated later
 					prev:         nil, // populated later
 					intermediate: intermediateRev,
-					edgeLabel:    mask,
-					faceLabel:    mask & populatedMask,
+					edgeLabels:   newHalfPopulatedLabels(operand, true),
+					faceLabels:   newHalfPopulatedLabels(operand, false),
 				}
 				internalEdge.twin = externalEdge
 				vertA.incidents = append(vertA.incidents, internalEdge)
@@ -178,7 +187,7 @@ func newDCELFromMultiPolygon(mp MultiPolygon, mask uint8, interactions map[XY]st
 	return dcel
 }
 
-func newDCELFromMultiLineString(mls MultiLineString, mask uint8, interactions map[XY]struct{}) *doublyConnectedEdgeList {
+func newDCELFromMultiLineString(mls MultiLineString, operand operand, interactions map[XY]struct{}) *doublyConnectedEdgeList {
 	dcel := &doublyConnectedEdgeList{
 		vertices: make(map[XY]*vertexRecord),
 	}
@@ -193,23 +202,43 @@ func newDCELFromMultiLineString(mls MultiLineString, mask uint8, interactions ma
 			if _, ok := interactions[xy]; !ok {
 				continue
 			}
-			loc := locInterior
+
 			if (j == 0 || j == n-1) && !ls.IsClosed() {
-				loc = locBoundary
-			}
-			if v, ok := dcel.vertices[xy]; ok {
-				if loc == locBoundary && (v.locLabel&mask&locBoundary) != 0 {
-					// Handle mod-2 rule (the boundary passes through the point
-					// an even number of times, then it should be treated as an
-					// interior point).
-					v.locLabel &= ^mask
-					v.locLabel |= mask & locInterior
+				// Boundary
+				if v, ok := dcel.vertices[xy]; ok {
+					if v.locations[operand].boundary {
+						// Handle mod-2 rule (the boundary passes through the point
+						// an even number of times, then it should be treated as an
+						// interior point).
+						v.locations[operand].boundary = false
+						v.locations[operand].interior = true
+					} else {
+						v.locations[operand].boundary = true
+					}
 				} else {
-					v.locLabel |= mask & loc
+					dcel.vertices[xy] = &vertexRecord{
+						xy,
+						nil, // populated later
+						newHalfPopulatedLabels(operand, true),
+						newLocationsOnBoundary(operand),
+						false,
+					}
 				}
 			} else {
-				dcel.vertices[xy] = &vertexRecord{xy, nil /* populated later */, mask, mask & loc}
+				// Interior
+				if v, ok := dcel.vertices[xy]; ok {
+					v.locations[operand].interior = true
+				} else {
+					dcel.vertices[xy] = &vertexRecord{
+						xy,
+						nil, // populated later
+						newHalfPopulatedLabels(operand, true),
+						newLocationsOnInterior(operand),
+						false,
+					}
+				}
 			}
+
 		}
 	}
 
@@ -241,8 +270,8 @@ func newDCELFromMultiLineString(mls MultiLineString, mask uint8, interactions ma
 				next:         nil, // set later
 				prev:         nil, // set later
 				intermediate: intermediateFwd,
-				edgeLabel:    mask,
-				faceLabel:    mask & populatedMask,
+				edgeLabels:   newHalfPopulatedLabels(operand, true),
+				faceLabels:   newHalfPopulatedLabels(operand, false),
 			}
 			rev := &halfEdgeRecord{
 				origin:       vDestin,
@@ -251,8 +280,8 @@ func newDCELFromMultiLineString(mls MultiLineString, mask uint8, interactions ma
 				next:         fwd,
 				prev:         fwd,
 				intermediate: intermediateRev,
-				edgeLabel:    mask,
-				faceLabel:    mask & populatedMask,
+				edgeLabels:   newHalfPopulatedLabels(operand, true),
+				faceLabels:   newHalfPopulatedLabels(operand, false),
 			}
 			fwd.twin = rev
 			fwd.next = rev
@@ -267,7 +296,7 @@ func newDCELFromMultiLineString(mls MultiLineString, mask uint8, interactions ma
 	return dcel
 }
 
-func newDCELFromMultiPoint(mp MultiPoint, mask uint8) *doublyConnectedEdgeList {
+func newDCELFromMultiPoint(mp MultiPoint, operand operand) *doublyConnectedEdgeList {
 	dcel := &doublyConnectedEdgeList{vertices: make(map[XY]*vertexRecord)}
 	n := mp.NumPoints()
 	for i := 0; i < n; i++ {
@@ -280,18 +309,18 @@ func newDCELFromMultiPoint(mp MultiPoint, mask uint8) *doublyConnectedEdgeList {
 			record = &vertexRecord{
 				coords:    xy,
 				incidents: nil,
-				label:     0, // set below
-				locLabel:  0, // set below
+				labels:    [2]label{},       // set below
+				locations: [2]hasLocation{}, // set below
 			}
 			dcel.vertices[xy] = record
 		}
-		record.label |= mask
-		record.locLabel |= mask & locInterior
+		record.labels[operand] = label{populated: true, inSet: true}
+		record.locations[operand].interior = true
 	}
 	return dcel
 }
 
-func (d *doublyConnectedEdgeList) addGhosts(mls MultiLineString, mask uint8, interactions map[XY]struct{}) {
+func (d *doublyConnectedEdgeList) addGhosts(mls MultiLineString, operand operand, interactions map[XY]struct{}) {
 	edges := make(edgeSet)
 	for _, e := range d.halfEdges {
 		edges.insertEdge(e)
@@ -306,10 +335,10 @@ func (d *doublyConnectedEdgeList) addGhosts(mls MultiLineString, mask uint8, int
 			intermediateRev := reverseXYs(intermediateFwd)
 
 			if _, ok := d.vertices[startXY]; !ok {
-				d.vertices[startXY] = &vertexRecord{coords: startXY, incidents: nil, label: 0}
+				d.vertices[startXY] = &vertexRecord{coords: startXY, incidents: nil, labels: [2]label{}}
 			}
 			if _, ok := d.vertices[endXY]; !ok {
-				d.vertices[endXY] = &vertexRecord{coords: endXY, incidents: nil, label: 0}
+				d.vertices[endXY] = &vertexRecord{coords: endXY, incidents: nil, labels: [2]label{}}
 			}
 
 			if edges.containsStartIntermediateEnd(startXY, intermediateFwd, endXY) {
@@ -319,12 +348,12 @@ func (d *doublyConnectedEdgeList) addGhosts(mls MultiLineString, mask uint8, int
 			edges.insertStartIntermediateEnd(startXY, intermediateFwd, endXY)
 			edges.insertStartIntermediateEnd(endXY, intermediateRev, startXY)
 
-			d.addGhostLine(startXY, intermediateFwd, intermediateRev, endXY, mask)
+			d.addGhostLine(startXY, intermediateFwd, intermediateRev, endXY, operand)
 		})
 	}
 }
 
-func (d *doublyConnectedEdgeList) addGhostLine(startXY XY, intermediateFwd, intermediateRev []XY, endXY XY, mask uint8) {
+func (d *doublyConnectedEdgeList) addGhostLine(startXY XY, intermediateFwd, intermediateRev []XY, endXY XY, operand operand) {
 	vertA := d.vertices[startXY]
 	vertB := d.vertices[endXY]
 
@@ -335,8 +364,8 @@ func (d *doublyConnectedEdgeList) addGhostLine(startXY XY, intermediateFwd, inte
 		next:         nil, // popluated later
 		prev:         nil, // populated later
 		intermediate: intermediateFwd,
-		edgeLabel:    mask & populatedMask,
-		faceLabel:    0,
+		edgeLabels:   newHalfPopulatedLabels(operand, false),
+		faceLabels:   [2]label{},
 	}
 	e2 := &halfEdgeRecord{
 		origin:       vertB,
@@ -345,8 +374,8 @@ func (d *doublyConnectedEdgeList) addGhostLine(startXY XY, intermediateFwd, inte
 		next:         e1,
 		prev:         e1,
 		intermediate: intermediateRev,
-		edgeLabel:    mask & populatedMask,
-		faceLabel:    0,
+		edgeLabels:   newHalfPopulatedLabels(operand, false),
+		faceLabels:   [2]label{},
 	}
 	e1.twin = e2
 	e1.next = e2

--- a/geom/dcel_extract_intersection_matrix.go
+++ b/geom/dcel_extract_intersection_matrix.go
@@ -21,7 +21,7 @@ func (d *doublyConnectedEdgeList) extractIntersectionMatrix() matrix {
 }
 
 func (f *faceRecord) location(operand operand) imLocation {
-	// TODO: Should we assert isPopulated?
+	assertPresence(f.labels)
 	if !f.labels[operand].inSet {
 		return imExterior
 	}
@@ -29,10 +29,15 @@ func (f *faceRecord) location(operand operand) imLocation {
 }
 
 func (e *halfEdgeRecord) location(operand operand) imLocation {
-	// TODO: Should we assert isPopulated?
+	assertPresence(e.edgeLabels)
+
 	if !e.edgeLabels[operand].inSet {
 		return imExterior
 	}
+
+	assertPresence(e.incident.labels)
+	assertPresence(e.twin.incident.labels)
+
 	face1Present := e.incident.labels[operand].inSet
 	face2Present := e.twin.incident.labels[operand].inSet
 	if face1Present != face2Present {
@@ -42,8 +47,6 @@ func (e *halfEdgeRecord) location(operand operand) imLocation {
 }
 
 func (v *vertexRecord) location(operand operand) imLocation {
-	// TODO: Should we assert isPopulated?
-
 	// NOTE: It's important that we check the Boundary flag before the Interior
 	// flag, since both might be set. In that case, we want to treat the
 	// location as a Boundary, since the boundary is a more specific case.

--- a/geom/dcel_extract_intersection_matrix.go
+++ b/geom/dcel_extract_intersection_matrix.go
@@ -3,50 +3,54 @@ package geom
 func (d *doublyConnectedEdgeList) extractIntersectionMatrix() matrix {
 	im := newMatrix()
 	for _, v := range d.vertices {
-		locA := v.location(inputAMask)
-		locB := v.location(inputBMask)
+		locA := v.location(operandA)
+		locB := v.location(operandB)
 		im.set(locA, locB, '0')
 	}
 	for _, e := range d.halfEdges {
-		locA := e.location(inputAMask)
-		locB := e.location(inputBMask)
+		locA := e.location(operandA)
+		locB := e.location(operandB)
 		im.set(locA, locB, '1')
 	}
 	for _, f := range d.faces {
-		locA := f.location(inputAMask)
-		locB := f.location(inputBMask)
+		locA := f.location(operandA)
+		locB := f.location(operandB)
 		im.set(locA, locB, '2')
 	}
 	return im
 }
 
-func (f *faceRecord) location(sideMask uint8) imLocation {
-	if (f.label & inSetMask & sideMask) == 0 {
+func (f *faceRecord) location(operand operand) imLocation {
+	// TODO: Should we assert isPopulated?
+	if !f.labels[operand].inSet {
 		return imExterior
 	}
 	return imInterior
 }
 
-func (e *halfEdgeRecord) location(sideMask uint8) imLocation {
-	if (e.edgeLabel & inSetMask & sideMask) == 0 {
+func (e *halfEdgeRecord) location(operand operand) imLocation {
+	// TODO: Should we assert isPopulated?
+	if !e.edgeLabels[operand].inSet {
 		return imExterior
 	}
-	face1Present := (e.incident.label & inSetMask & sideMask) != 0
-	face2Present := (e.twin.incident.label & inSetMask & sideMask) != 0
+	face1Present := e.incident.labels[operand].inSet
+	face2Present := e.twin.incident.labels[operand].inSet
 	if face1Present != face2Present {
 		return imBoundary
 	}
 	return imInterior
 }
 
-func (v *vertexRecord) location(sideMask uint8) imLocation {
+func (v *vertexRecord) location(operand operand) imLocation {
+	// TODO: Should we assert isPopulated?
+
 	// NOTE: It's important that we check the Boundary flag before the Interior
 	// flag, since both might be set. In that case, we want to treat the
 	// location as a Boundary, since the boundary is a more specific case.
 	switch {
-	case (v.locLabel & sideMask & locBoundary) != 0:
+	case v.locations[operand].boundary:
 		return imBoundary
-	case (v.locLabel & sideMask & locInterior) != 0:
+	case v.locations[operand].interior:
 		return imInterior
 	default:
 		// We don't know the location of the point. But it must be either
@@ -54,7 +58,7 @@ func (v *vertexRecord) location(sideMask uint8) imLocation {
 		// that. We can just use the location of one of the incident edges,
 		// since that would have the same location.
 		for _, e := range v.incidents {
-			return e.location(sideMask)
+			return e.location(operand)
 		}
 		panic("point has no incidents") // Can't happen, due to ghost edges.
 	}

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -43,26 +43,26 @@ func mergeLabels(dst *[2]label, src [2]label) {
 	dst[1].inSet = dst[1].inSet || src[1].inSet
 }
 
-type hasLocation struct {
+type location struct {
 	interior bool
 	boundary bool
 }
 
-func mergeLocations(dst *[2]hasLocation, src [2]hasLocation) {
+func mergeLocations(dst *[2]location, src [2]location) {
 	dst[0].interior = dst[0].interior || src[0].interior
 	dst[1].interior = dst[1].interior || src[1].interior
 	dst[0].boundary = dst[0].boundary || src[0].boundary
 	dst[1].boundary = dst[1].boundary || src[1].boundary
 }
 
-func newLocationsOnBoundary(operand operand) [2]hasLocation {
-	var locs [2]hasLocation
+func newLocationsOnBoundary(operand operand) [2]location {
+	var locs [2]location
 	locs[operand].boundary = true
 	return locs
 }
 
-func newLocationsOnInterior(operand operand) [2]hasLocation {
-	var locs [2]hasLocation
+func newLocationsOnInterior(operand operand) [2]location {
+	var locs [2]location
 	locs[operand].interior = true
 	return locs
 }

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -2,6 +2,71 @@ package geom
 
 import "fmt"
 
+// operand represents either the first (A) or second (B) geometry in a binary
+// operation (such as Union or Covers).
+type operand int
+
+const (
+	operandA operand = 0
+	operandB operand = 1
+)
+
+type label struct {
+	// Set to true once inSet has a valid value.
+	populated bool
+
+	// Indicates whether the thing being labelled is in a set or not (context
+	// specific to how the label is used).
+	inSet bool
+}
+
+func newHalfPopulatedLabels(operand operand, inSet bool) [2]label {
+	var labels [2]label
+	labels[operand].populated = true
+	labels[operand].inSet = inSet
+	return labels
+}
+
+func newPopulatedLabels(inSet bool) [2]label {
+	var labels [2]label
+	labels[0].populated = true
+	labels[1].populated = true
+	labels[0].inSet = inSet
+	labels[1].inSet = inSet
+	return labels
+}
+
+func mergeLabels(dst *[2]label, src [2]label) {
+	dst[0].populated = dst[0].populated || src[0].populated
+	dst[1].populated = dst[1].populated || src[1].populated
+	dst[0].inSet = dst[0].inSet || src[0].inSet
+	dst[1].inSet = dst[1].inSet || src[1].inSet
+}
+
+type hasLocation struct {
+	interior bool
+	boundary bool
+}
+
+func mergeLocations(dst *[2]hasLocation, src [2]hasLocation) {
+	dst[0].interior = dst[0].interior || src[0].interior
+	dst[1].interior = dst[1].interior || src[1].interior
+	dst[0].boundary = dst[0].boundary || src[0].boundary
+	dst[1].boundary = dst[1].boundary || src[1].boundary
+}
+
+func newLocationsOnBoundary(operand operand) [2]hasLocation {
+	var locs [2]hasLocation
+	locs[operand].boundary = true
+	return locs
+}
+
+func newLocationsOnInterior(operand operand) [2]hasLocation {
+	var locs [2]hasLocation
+	locs[operand].interior = true
+	return locs
+}
+
 const (
 	inputAInSet     uint8 = 0b0001
 	inputAPopulated uint8 = 0b0010
@@ -23,29 +88,28 @@ const (
 	// NOTE: We don't explicitly track exterior locations (they have to be inferred).
 )
 
-func assertPresenceBits(label uint8) {
-	if populatedMask&label != populatedMask {
-		panic(fmt.Sprintf("all presence bits in label not set: %v", label))
+func assertPresence(labels [2]label) {
+	if !labels[0].populated || !labels[1].populated {
+		panic(fmt.Sprintf("all presence flags in labels not set: %v", labels))
 	}
 }
 
-func selectUnion(label uint8) bool {
-	assertPresenceBits(label)
-	return label&inSetMask != 0
+func selectUnion(labels [2]label) bool {
+	assertPresence(labels)
+	return labels[0].inSet || labels[1].inSet
 }
 
-func selectIntersection(label uint8) bool {
-	assertPresenceBits(label)
-	return label&inSetMask == inSetMask
+func selectIntersection(labels [2]label) bool {
+	assertPresence(labels)
+	return labels[0].inSet && labels[1].inSet
 }
 
-func selectDifference(label uint8) bool {
-	assertPresenceBits(label)
-	return label&inSetMask == inputAInSet
+func selectDifference(labels [2]label) bool {
+	assertPresence(labels)
+	return labels[0].inSet && !labels[1].inSet
 }
 
-func selectSymmetricDifference(label uint8) bool {
-	assertPresenceBits(label)
-	vals := label & inSetMask
-	return vals == inputAInSet || vals == inputBInSet
+func selectSymmetricDifference(labels [2]label) bool {
+	assertPresence(labels)
+	return labels[0].inSet != labels[1].inSet
 }


### PR DESCRIPTION
## Description

Simplifies code by using explicit bools rather than bit fields.

## Check List

Have you:

- Added unit tests? N/A, existing.

- Add cmprefimpl tests? (if appropriate?) N/A, existing.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/341

## Benchmark Results

No significant change:

<details>

<summary>Click to expand</summary>

```
name                                                      old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0                                              2.34ns ± 8%    1.96ns ± 5%  -16.29%  (p=0.000 n=15+15)
LineEnvelope/1                                              1.37ns ± 4%    1.35ns ± 3%     ~     (p=0.241 n=14+14)
LineEnvelope/2                                              1.70ns ± 3%    1.69ns ± 3%     ~     (p=0.454 n=14+15)
LineEnvelope/3                                              1.55ns ± 3%    1.52ns ± 2%   -1.64%  (p=0.010 n=15+15)
MarshalWKB/polygon/n=10                                      231ns ± 4%     234ns ± 6%     ~     (p=0.124 n=14+15)
MarshalWKB/polygon/n=100                                     454ns ± 6%     453ns ± 6%     ~     (p=0.583 n=14+15)
MarshalWKB/polygon/n=1000                                   2.49µs ± 4%    2.53µs ± 8%     ~     (p=0.400 n=14+15)
MarshalWKB/polygon/n=10000                                  21.4µs ± 4%    21.4µs ± 6%     ~     (p=1.000 n=14+14)
UnmarshalWKB/polygon/n=10                                    408ns ± 8%     406ns ± 4%     ~     (p=0.919 n=14+14)
UnmarshalWKB/polygon/n=100                                   631ns ± 2%     629ns ± 6%     ~     (p=0.355 n=13+13)
UnmarshalWKB/polygon/n=1000                                 2.88µs ± 4%    2.93µs ± 3%   +1.75%  (p=0.012 n=13+14)
UnmarshalWKB/polygon/n=10000                                28.8µs ± 4%    29.0µs ± 5%     ~     (p=0.525 n=15+13)
IntersectsLineStringWithLineString/n=10                     1.72µs ± 9%    1.71µs ± 2%     ~     (p=0.890 n=13+13)
IntersectsLineStringWithLineString/n=100                    24.5µs ± 9%    24.7µs ± 5%     ~     (p=0.158 n=14+15)
IntersectsLineStringWithLineString/n=1000                    255µs ± 3%     258µs ± 6%     ~     (p=0.621 n=14+15)
IntersectsLineStringWithLineString/n=10000                  3.40ms ± 7%    3.44ms ± 5%     ~     (p=0.194 n=14+14)
IntersectsMultiPointWithMultiPoint/n=20                     1.85µs ± 2%    1.85µs ± 2%     ~     (p=0.675 n=15+15)
IntersectsMultiPointWithMultiPoint/n=200                    19.8µs ± 4%    19.8µs ± 4%     ~     (p=0.914 n=14+15)
IntersectsMultiPointWithMultiPoint/n=2000                    194µs ± 5%     196µs ± 4%     ~     (p=0.187 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000                  2.08ms ± 3%    2.13ms ± 3%   +2.60%  (p=0.001 n=12+15)
PolygonSingleRingValidation/n=10                            3.05µs ± 6%    3.06µs ± 3%     ~     (p=0.367 n=15+15)
PolygonSingleRingValidation/n=100                           43.6µs ± 4%    43.6µs ± 3%     ~     (p=0.940 n=15+14)
PolygonSingleRingValidation/n=1000                           526µs ± 6%     518µs ± 2%   -1.49%  (p=0.041 n=15+13)
PolygonSingleRingValidation/n=10000                         6.96ms ± 4%    6.96ms ± 4%     ~     (p=0.914 n=14+15)
PolygonMultipleRingsValidation/n=4                          8.58µs ± 4%    8.55µs ± 3%     ~     (p=0.614 n=13+13)
PolygonMultipleRingsValidation/n=36                         72.8µs ± 3%    73.0µs ± 3%     ~     (p=0.430 n=14+13)
PolygonMultipleRingsValidation/n=400                         961µs ± 5%     977µs ± 6%     ~     (p=0.239 n=14+13)
PolygonMultipleRingsValidation/n=4096                       12.3ms ± 3%    12.1ms ± 4%     ~     (p=0.477 n=14+15)
PolygonZigZagRingsValidation/n=10                           14.3µs ± 4%    14.2µs ± 3%     ~     (p=0.351 n=15+15)
PolygonZigZagRingsValidation/n=100                           167µs ± 4%     164µs ± 3%   -1.63%  (p=0.010 n=15+12)
PolygonZigZagRingsValidation/n=1000                         1.97ms ± 2%    1.98ms ± 3%     ~     (p=0.541 n=14+14)
PolygonZigZagRingsValidation/n=10000                        26.5ms ± 5%    26.5ms ± 7%     ~     (p=0.793 n=13+14)
PolygonAnnulusValidation/n=10                               4.54µs ± 4%    4.56µs ± 3%     ~     (p=0.344 n=13+14)
PolygonAnnulusValidation/n=100                              41.4µs ± 4%    42.2µs ± 5%   +1.98%  (p=0.037 n=14+15)
PolygonAnnulusValidation/n=1000                              730µs ± 5%     724µs ± 4%     ~     (p=0.285 n=15+15)
PolygonAnnulusValidation/n=10000                            8.49ms ± 3%    8.55ms ± 3%     ~     (p=0.285 n=15+15)
MultipolygonValidation/n=1                                   485ns ± 2%     487ns ± 3%     ~     (p=0.419 n=11+15)
MultipolygonValidation/n=4                                  1.11µs ± 4%    1.13µs ± 3%   +1.45%  (p=0.049 n=15+15)
MultipolygonValidation/n=16                                 4.50µs ± 4%    4.50µs ± 3%     ~     (p=0.717 n=15+13)
MultipolygonValidation/n=64                                 20.6µs ± 3%    20.7µs ± 3%     ~     (p=0.377 n=15+14)
MultipolygonValidation/n=256                                 134µs ± 2%     136µs ± 3%   +1.72%  (p=0.012 n=14+14)
MultipolygonValidation/n=1024                                630µs ± 3%     626µs ± 4%     ~     (p=0.486 n=15+15)
MultiPolygonTwoCircles/n=10                                 4.34µs ± 4%    4.33µs ± 2%     ~     (p=0.805 n=15+14)
MultiPolygonTwoCircles/n=100                                48.1µs ± 3%    48.2µs ± 1%     ~     (p=0.860 n=14+12)
MultiPolygonTwoCircles/n=1000                                534µs ± 4%     538µs ± 3%     ~     (p=0.254 n=13+15)
MultiPolygonTwoCircles/n=10000                              8.74ms ± 3%    8.82ms ± 4%     ~     (p=0.595 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1                      6.09µs ± 3%    6.13µs ± 4%     ~     (p=0.367 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10                     50.4µs ± 3%    50.5µs ± 4%     ~     (p=0.683 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100                     595µs ± 3%     593µs ± 2%     ~     (p=0.550 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1000                   7.30ms ± 3%    7.31ms ± 2%     ~     (p=0.458 n=14+13)
WKTParsing/point                                            2.14µs ± 3%    2.12µs ± 3%     ~     (p=0.269 n=13+15)
DistancePolygonToPolygonOrdering/n=100_swap=false           67.8µs ± 3%    68.8µs ± 5%     ~     (p=0.088 n=15+13)
DistancePolygonToPolygonOrdering/n=100_swap=true            67.7µs ± 3%    68.7µs ± 3%   +1.51%  (p=0.018 n=15+14)
DistancePolygonToPolygonOrdering/n=1000_swap=false          1.10ms ± 2%    1.10ms ± 3%     ~     (p=0.775 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true           1.09ms ± 3%    1.09ms ± 2%     ~     (p=0.525 n=15+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false     7.03µs ± 5%    7.06µs ± 4%     ~     (p=0.660 n=14+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true      7.05µs ± 5%    6.99µs ± 3%     ~     (p=0.624 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false    76.7µs ± 3%    77.2µs ± 3%     ~     (p=0.252 n=15+14)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true     76.5µs ± 3%    76.3µs ± 4%     ~     (p=0.867 n=14+13)
MultiLineStringIsSimpleManyLineStrings/n=100                65.2µs ± 3%    66.3µs ± 3%   +1.63%  (p=0.016 n=15+15)
MultiLineStringIsSimpleManyLineStrings/n=1000                716µs ± 4%     730µs ± 4%   +1.97%  (p=0.012 n=14+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10                          67.8µs ±11%    66.0µs ± 4%     ~     (p=0.290 n=15+14)
IntersectionWithoutValidation/n=100                          127µs ± 4%     129µs ± 5%     ~     (p=0.290 n=15+14)
IntersectionWithoutValidation/n=1000                         589µs ± 6%     590µs ± 5%     ~     (p=0.847 n=15+14)
IntersectionWithoutValidation/n=10000                       4.87ms ± 2%    4.96ms ± 6%     ~     (p=0.131 n=12+14)
NoOp/n=10                                                   5.18µs ± 9%    5.11µs ± 4%     ~     (p=0.477 n=15+14)
NoOp/n=100                                                  16.9µs ± 4%    16.9µs ± 3%     ~     (p=0.820 n=14+12)
NoOp/n=1000                                                  123µs ± 4%     124µs ± 4%     ~     (p=0.667 n=12+14)
NoOp/n=10000                                                1.30ms ±29%    1.27ms ±21%     ~     (p=0.847 n=14+15)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10                               2.56µs ± 4%    2.57µs ± 3%     ~     (p=0.579 n=14+14)
LineStringIsSimpleCircle/n=100                              44.8µs ± 4%    44.2µs ± 3%     ~     (p=0.234 n=14+15)
LineStringIsSimpleCircle/n=1000                              490µs ± 2%     497µs ± 4%   +1.55%  (p=0.046 n=12+14)
LineStringIsSimpleCircle/n=10000                            6.82ms ± 3%    6.74ms ± 3%     ~     (p=0.125 n=14+14)
LineStringIsSimpleZigZag/10                                 2.35µs ± 3%    2.30µs ± 2%   -1.87%  (p=0.006 n=14+13)
LineStringIsSimpleZigZag/100                                39.5µs ± 3%    39.3µs ± 5%     ~     (p=0.451 n=14+15)
LineStringIsSimpleZigZag/1000                                463µs ± 2%     463µs ± 3%     ~     (p=0.838 n=15+15)
LineStringIsSimpleZigZag/10000                              6.71ms ± 4%    6.75ms ± 3%     ~     (p=0.505 n=14+15)
SetOperation/n=4/Go_Intersection                            57.4µs ± 5%    59.2µs ± 6%   +3.08%  (p=0.003 n=14+15)
SetOperation/n=4/Go_Difference                              58.9µs ± 2%    60.9µs ± 5%   +3.39%  (p=0.000 n=13+15)
SetOperation/n=4/Go_SymmetricDifference                     76.1µs ±11%    76.1µs ± 3%     ~     (p=0.252 n=14+15)
SetOperation/n=4/Go_Union                                   61.9µs ± 8%    62.1µs ± 4%     ~     (p=0.583 n=14+13)
SetOperation/n=4/GEOS_Intersection                          66.8µs ± 4%    67.7µs ± 8%     ~     (p=0.650 n=13+15)
SetOperation/n=4/GEOS_Difference                            70.6µs ±10%    70.8µs ± 6%     ~     (p=0.571 n=14+14)
SetOperation/n=4/GEOS_SymmetricDifference                   99.0µs ± 8%    99.2µs ± 5%     ~     (p=0.769 n=14+14)
SetOperation/n=4/GEOS_Union                                 72.0µs ±13%    70.8µs ± 8%     ~     (p=0.458 n=15+14)
SetOperation/n=8/Go_Intersection                            73.3µs ±10%    74.4µs ± 5%     ~     (p=0.068 n=14+13)
SetOperation/n=8/Go_Difference                              75.6µs ±11%    75.9µs ± 7%     ~     (p=0.488 n=13+14)
SetOperation/n=8/Go_SymmetricDifference                     95.9µs ± 5%    95.7µs ± 3%     ~     (p=0.847 n=14+15)
SetOperation/n=8/Go_Union                                   76.6µs ± 7%    77.5µs ± 3%     ~     (p=0.234 n=14+15)
SetOperation/n=8/GEOS_Intersection                          79.0µs ± 5%    78.2µs ± 9%     ~     (p=0.387 n=13+15)
SetOperation/n=8/GEOS_Difference                            79.7µs ± 4%    79.2µs ± 5%     ~     (p=0.635 n=14+14)
SetOperation/n=8/GEOS_SymmetricDifference                    118µs ±14%     116µs ± 6%     ~     (p=0.920 n=13+13)
SetOperation/n=8/GEOS_Union                                 81.9µs ±10%    82.0µs ± 7%     ~     (p=0.780 n=15+14)
SetOperation/n=16/Go_Intersection                            102µs ±14%     102µs ± 4%     ~     (p=0.482 n=14+14)
SetOperation/n=16/Go_Difference                              109µs ± 6%     108µs ± 4%     ~     (p=0.331 n=15+14)
SetOperation/n=16/Go_SymmetricDifference                     143µs ± 5%     144µs ± 6%     ~     (p=0.454 n=14+14)
SetOperation/n=16/Go_Union                                   112µs ± 5%     113µs ± 4%     ~     (p=0.202 n=15+15)
SetOperation/n=16/GEOS_Intersection                         89.1µs ±13%    86.2µs ± 9%     ~     (p=0.116 n=15+15)
SetOperation/n=16/GEOS_Difference                           95.3µs ± 7%    93.9µs ± 5%     ~     (p=0.254 n=15+13)
SetOperation/n=16/GEOS_SymmetricDifference                   147µs ± 9%     148µs ± 4%     ~     (p=0.482 n=14+14)
SetOperation/n=16/GEOS_Union                                97.7µs ± 5%    97.3µs ± 5%     ~     (p=0.847 n=15+14)
SetOperation/n=32/Go_Intersection                            173µs ± 5%     174µs ± 3%     ~     (p=0.434 n=14+11)
SetOperation/n=32/Go_Difference                              181µs ± 5%     181µs ± 2%     ~     (p=0.928 n=13+15)
SetOperation/n=32/Go_SymmetricDifference                     239µs ± 5%     239µs ± 3%     ~     (p=0.595 n=15+15)
SetOperation/n=32/Go_Union                                   188µs ± 3%     187µs ± 3%     ~     (p=0.354 n=14+15)
SetOperation/n=32/GEOS_Intersection                          107µs ±12%     104µs ± 7%     ~     (p=0.367 n=15+15)
SetOperation/n=32/GEOS_Difference                            115µs ± 4%     116µs ±11%     ~     (p=0.488 n=13+14)
SetOperation/n=32/GEOS_SymmetricDifference                   192µs ± 3%     189µs ± 6%     ~     (p=0.145 n=12+14)
SetOperation/n=32/GEOS_Union                                 124µs ± 7%     123µs ± 8%     ~     (p=0.621 n=14+15)
SetOperation/n=64/Go_Intersection                            290µs ± 6%     287µs ± 3%     ~     (p=0.300 n=15+12)
SetOperation/n=64/Go_Difference                              302µs ± 2%     307µs ± 4%   +1.45%  (p=0.035 n=12+13)
SetOperation/n=64/Go_SymmetricDifference                     414µs ± 4%     416µs ± 5%     ~     (p=0.685 n=14+13)
SetOperation/n=64/Go_Union                                   323µs ± 7%     323µs ± 5%     ~     (p=0.541 n=14+14)
SetOperation/n=64/GEOS_Intersection                          135µs ± 5%     135µs ± 5%     ~     (p=0.652 n=15+14)
SetOperation/n=64/GEOS_Difference                            165µs ± 7%     162µs ± 3%     ~     (p=0.164 n=14+14)
SetOperation/n=64/GEOS_SymmetricDifference                   287µs ± 3%     285µs ± 4%     ~     (p=0.536 n=12+14)
SetOperation/n=64/GEOS_Union                                 179µs ± 5%     177µs ± 3%     ~     (p=0.239 n=14+13)
SetOperation/n=128/Go_Intersection                           538µs ± 3%     539µs ± 4%     ~     (p=0.910 n=14+14)
SetOperation/n=128/Go_Difference                             566µs ± 5%     561µs ± 3%     ~     (p=0.323 n=15+12)
SetOperation/n=128/Go_SymmetricDifference                    738µs ± 4%     744µs ± 2%     ~     (p=0.185 n=15+13)
SetOperation/n=128/Go_Union                                  583µs ± 3%     581µs ± 7%     ~     (p=0.539 n=15+15)
SetOperation/n=128/GEOS_Intersection                         200µs ± 4%     200µs ± 5%     ~     (p=0.935 n=15+15)
SetOperation/n=128/GEOS_Difference                           241µs ± 7%     235µs ± 5%     ~     (p=0.104 n=14+14)
SetOperation/n=128/GEOS_SymmetricDifference                  450µs ± 5%     450µs ± 5%     ~     (p=0.914 n=15+14)
SetOperation/n=128/GEOS_Union                                260µs ± 7%     256µs ± 5%     ~     (p=0.454 n=14+14)
SetOperation/n=256/Go_Intersection                          1.00ms ± 5%    1.01ms ± 5%     ~     (p=0.525 n=15+13)
SetOperation/n=256/Go_Difference                            1.07ms ± 6%    1.07ms ± 4%     ~     (p=0.223 n=13+13)
SetOperation/n=256/Go_SymmetricDifference                   1.46ms ± 5%    1.46ms ± 2%     ~     (p=0.724 n=13+13)
SetOperation/n=256/Go_Union                                 1.12ms ± 6%    1.13ms ± 4%     ~     (p=0.967 n=15+15)
SetOperation/n=256/GEOS_Intersection                         292µs ± 4%     291µs ± 3%     ~     (p=0.981 n=14+13)
SetOperation/n=256/GEOS_Difference                           383µs ± 5%     379µs ± 4%     ~     (p=0.220 n=14+13)
SetOperation/n=256/GEOS_SymmetricDifference                  839µs ± 5%     846µs ± 3%     ~     (p=0.311 n=13+13)
SetOperation/n=256/GEOS_Union                                438µs ± 6%     433µs ± 3%     ~     (p=0.389 n=15+15)
SetOperation/n=512/Go_Intersection                          2.00ms ± 5%    1.99ms ± 3%     ~     (p=0.838 n=15+15)
SetOperation/n=512/Go_Difference                            2.10ms ± 4%    2.07ms ± 5%     ~     (p=0.124 n=15+15)
SetOperation/n=512/Go_SymmetricDifference                   2.83ms ± 3%    2.83ms ± 5%     ~     (p=0.667 n=14+14)
SetOperation/n=512/Go_Union                                 2.15ms ± 4%    2.16ms ± 4%     ~     (p=0.616 n=14+13)
SetOperation/n=512/GEOS_Intersection                         526µs ± 5%     539µs ± 7%   +2.34%  (p=0.044 n=14+14)
SetOperation/n=512/GEOS_Difference                           699µs ± 3%     700µs ± 7%     ~     (p=0.486 n=15+15)
SetOperation/n=512/GEOS_SymmetricDifference                 1.59ms ± 7%    1.58ms ± 5%     ~     (p=0.838 n=15+15)
SetOperation/n=512/GEOS_Union                                804µs ± 6%     808µs ±11%     ~     (p=0.838 n=15+15)
SetOperation/n=1024/Go_Intersection                         3.97ms ± 2%    4.01ms ± 4%     ~     (p=0.186 n=14+15)
SetOperation/n=1024/Go_Difference                           4.07ms ± 4%    4.14ms ± 3%   +1.87%  (p=0.036 n=12+14)
SetOperation/n=1024/Go_SymmetricDifference                  5.83ms ± 3%    5.77ms ± 3%     ~     (p=0.093 n=12+15)
SetOperation/n=1024/Go_Union                                4.32ms ± 5%    4.31ms ± 3%     ~     (p=0.983 n=15+14)
SetOperation/n=1024/GEOS_Intersection                        982µs ± 8%     994µs ± 7%     ~     (p=0.376 n=14+14)
SetOperation/n=1024/GEOS_Difference                         1.42ms ± 5%    1.44ms ± 4%     ~     (p=0.186 n=15+14)
SetOperation/n=1024/GEOS_SymmetricDifference                3.23ms ± 3%    3.21ms ± 5%     ~     (p=0.234 n=15+14)
SetOperation/n=1024/GEOS_Union                              1.68ms ± 5%    1.68ms ± 4%     ~     (p=0.880 n=14+15)
SetOperation/n=2048/Go_Intersection                         8.25ms ± 8%    8.11ms ± 3%     ~     (p=0.305 n=15+15)
SetOperation/n=2048/Go_Difference                           8.97ms ± 2%    8.85ms ± 6%   -1.34%  (p=0.023 n=12+14)
SetOperation/n=2048/Go_SymmetricDifference                  12.5ms ± 5%    12.4ms ± 4%     ~     (p=0.533 n=15+14)
SetOperation/n=2048/Go_Union                                9.12ms ± 5%    9.14ms ± 5%     ~     (p=0.838 n=15+15)
SetOperation/n=2048/GEOS_Intersection                       2.04ms ± 4%    2.04ms ± 3%     ~     (p=0.806 n=15+15)
SetOperation/n=2048/GEOS_Difference                         2.63ms ± 4%    2.61ms ± 4%     ~     (p=0.305 n=15+15)
SetOperation/n=2048/GEOS_SymmetricDifference                6.18ms ± 3%    6.17ms ± 3%     ~     (p=0.793 n=13+14)
SetOperation/n=2048/GEOS_Union                              3.10ms ± 4%    3.11ms ± 6%     ~     (p=0.967 n=15+15)
SetOperation/n=4096/Go_Intersection                         17.7ms ± 3%    17.6ms ± 5%     ~     (p=0.486 n=15+15)
SetOperation/n=4096/Go_Difference                           18.5ms ± 4%    18.2ms ± 4%     ~     (p=0.085 n=15+14)
SetOperation/n=4096/Go_SymmetricDifference                  26.1ms ± 5%    26.0ms ± 4%     ~     (p=0.683 n=15+14)
SetOperation/n=4096/Go_Union                                19.2ms ± 5%    19.1ms ± 3%     ~     (p=0.914 n=15+14)
SetOperation/n=4096/GEOS_Intersection                       3.72ms ± 4%    3.67ms ± 4%     ~     (p=0.072 n=13+13)
SetOperation/n=4096/GEOS_Difference                         5.72ms ± 4%    5.74ms ± 2%     ~     (p=0.525 n=15+13)
SetOperation/n=4096/GEOS_SymmetricDifference                14.2ms ± 5%    14.2ms ± 3%     ~     (p=0.982 n=14+14)
SetOperation/n=4096/GEOS_Union                              6.61ms ± 5%    6.62ms ± 6%     ~     (p=0.847 n=14+15)
SetOperation/n=8192/Go_Intersection                         36.9ms ± 8%    36.8ms ± 6%     ~     (p=0.867 n=13+14)
SetOperation/n=8192/Go_Difference                           39.1ms ± 8%    38.7ms ± 4%     ~     (p=0.239 n=13+14)
SetOperation/n=8192/Go_SymmetricDifference                  54.0ms ± 4%    52.8ms ± 4%   -2.15%  (p=0.020 n=14+15)
SetOperation/n=8192/Go_Union                                40.5ms ± 6%    39.7ms ± 5%     ~     (p=0.126 n=15+15)
SetOperation/n=8192/GEOS_Intersection                       7.87ms ± 5%    7.74ms ± 4%     ~     (p=0.172 n=15+14)
SetOperation/n=8192/GEOS_Difference                         11.6ms ± 6%    11.5ms ± 4%     ~     (p=0.847 n=14+15)
SetOperation/n=8192/GEOS_SymmetricDifference                27.4ms ± 5%    27.4ms ± 4%     ~     (p=0.567 n=15+15)
SetOperation/n=8192/GEOS_Union                              13.2ms ± 4%    13.2ms ± 2%     ~     (p=1.000 n=15+14)
SetOperation/n=16384/Go_Intersection                        75.2ms ± 6%    73.8ms ± 3%     ~     (p=0.050 n=15+15)
SetOperation/n=16384/Go_Difference                          80.3ms ± 3%    80.3ms ± 6%     ~     (p=0.683 n=15+14)
SetOperation/n=16384/Go_SymmetricDifference                  114ms ± 3%     113ms ± 4%     ~     (p=0.624 n=15+15)
SetOperation/n=16384/Go_Union                               83.4ms ± 2%    83.7ms ± 3%     ~     (p=0.618 n=13+15)
SetOperation/n=16384/GEOS_Intersection                      15.5ms ± 6%    15.3ms ± 5%     ~     (p=0.715 n=14+15)
SetOperation/n=16384/GEOS_Difference                        23.9ms ± 3%    24.0ms ± 6%     ~     (p=0.914 n=15+14)
SetOperation/n=16384/GEOS_SymmetricDifference               60.5ms ± 8%    60.0ms ± 5%     ~     (p=0.583 n=14+13)
SetOperation/n=16384/GEOS_Union                             28.2ms ± 3%    28.4ms ± 5%     ~     (p=0.511 n=14+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Bulk/n=10                                                    886ns ± 4%     889ns ± 3%     ~     (p=0.480 n=14+13)
Bulk/n=100                                                  16.1µs ± 4%    16.0µs ± 3%     ~     (p=0.701 n=14+14)
Bulk/n=1000                                                  277µs ± 5%     274µs ± 4%     ~     (p=0.161 n=15+15)
Bulk/n=10000                                                4.03ms ± 7%    3.96ms ± 3%     ~     (p=0.170 n=15+13)
Bulk/n=100000                                               58.0ms ± 5%    58.9ms ± 6%     ~     (p=0.142 n=13+15)
RangeSearch/n=10                                            20.6ns ± 4%    20.4ns ± 4%     ~     (p=0.296 n=15+13)
RangeSearch/n=100                                           83.2ns ± 4%    82.8ns ± 3%     ~     (p=0.594 n=14+14)
RangeSearch/n=1000                                           307ns ± 5%     304ns ± 2%     ~     (p=0.227 n=14+15)
RangeSearch/n=10000                                         1.05µs ± 5%    1.05µs ± 4%     ~     (p=0.628 n=15+14)
RangeSearch/n=100000                                        10.9µs ±14%    10.6µs ± 6%     ~     (p=0.400 n=15+14)

name                                                      old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/1                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/2                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/3                                               0.00B          0.00B          ~     (all equal)
MarshalWKB/polygon/n=10                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000                                   164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000                                 164kB ± 0%     164kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10                     2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000                    205kB ± 0%     205kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000                  2.63MB ± 0%    2.63MB ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20                       324B ± 0%      324B ± 0%   +0.14%  (p=0.011 n=13+15)
IntersectsMultiPointWithMultiPoint/n=200                    3.08kB ± 0%    3.08kB ± 0%     ~     (p=0.844 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000                   49.3kB ± 0%    49.3kB ± 0%     ~     (p=0.958 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000                   339kB ± 0%     339kB ± 0%     ~     (p=0.751 n=15+15)
PolygonSingleRingValidation/n=10                            2.29kB ± 0%    2.29kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100                           24.4kB ± 0%    24.4kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000                           140kB ± 0%     140kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000                         1.97MB ± 0%    1.97MB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4                          6.61kB ± 0%    6.61kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36                         53.2kB ± 0%    53.2kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400                         597kB ± 0%     597kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096                       6.28MB ± 0%    6.28MB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10                           9.62kB ± 0%    9.62kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100                          88.0kB ± 0%    88.0kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000                          551kB ± 0%     551kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000                        7.24MB ± 0%    7.24MB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10                               4.10kB ± 0%    4.10kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100                              28.4kB ± 0%    28.4kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000                              379kB ± 0%     379kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000                            3.89MB ± 0%    3.89MB ± 0%     ~     (all equal)
MultipolygonValidation/n=1                                    481B ± 0%      481B ± 0%     ~     (all equal)
MultipolygonValidation/n=4                                    980B ± 0%      980B ± 0%     ~     (all equal)
MultipolygonValidation/n=16                                 4.16kB ± 0%    4.16kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64                                 17.0kB ± 0%    17.0kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256                                67.8kB ± 0%    67.8kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024                                271kB ± 0%     271kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10                                 5.15kB ± 0%    5.15kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100                                55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000                                345kB ± 0%     345kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000                              4.60MB ± 0%    4.60MB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1                      4.11kB ± 0%    4.11kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10                     22.7kB ± 0%    22.7kB ± 0%     ~     (p=0.571 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100                     172kB ± 0%     172kB ± 0%     ~     (p=0.236 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000                   2.04MB ± 0%    2.04MB ± 0%     ~     (p=0.372 n=15+15)
WKTParsing/point                                            1.93kB ± 0%    1.93kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false           40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true            40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false           369kB ± 0%     369kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true            369kB ± 0%     369kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false     5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true      5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false    60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.544 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true     60.1kB ± 0%    60.1kB ± 0%     ~     (p=1.000 n=15+15)
MultiLineStringIsSimpleManyLineStrings/n=100                59.2kB ± 0%    59.2kB ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000                491kB ± 0%     491kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10                          1.34kB ± 0%    1.34kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100                         6.47kB ± 0%    6.47kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=1000                        55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=10000                        558kB ± 0%     558kB ± 0%     ~     (all equal)
NoOp/n=10                                                     968B ± 0%      968B ± 0%     ~     (all equal)
NoOp/n=100                                                  5.78kB ± 0%    5.78kB ± 0%     ~     (all equal)
NoOp/n=1000                                                 49.6kB ± 0%    49.6kB ± 0%     ~     (all equal)
NoOp/n=10000                                                 492kB ± 0%     492kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10                               1.87kB ± 0%    1.87kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100                              24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000                              139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000                            1.97MB ± 0%    1.97MB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10                                 1.84kB ± 0%    1.84kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000                                139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000                              1.97MB ± 0%    1.97MB ± 0%     ~     (all equal)
SetOperation/n=4/Go_Intersection                            20.4kB ± 0%    20.5kB ± 0%   +0.62%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference                              21.4kB ± 0%    21.5kB ± 0%   +0.60%  (p=0.000 n=14+15)
SetOperation/n=4/Go_SymmetricDifference                     29.3kB ± 0%    29.5kB ± 0%   +0.44%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union                                   22.1kB ± 0%    22.2kB ± 0%   +0.57%  (p=0.000 n=14+15)
SetOperation/n=4/GEOS_Intersection                          1.78kB ± 0%    1.78kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference                            2.79kB ± 0%    2.79kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference                   10.7kB ± 0%    10.7kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Union                                 3.22kB ± 0%    3.22kB ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection                            27.1kB ± 0%    27.3kB ± 0%   +0.46%  (p=0.000 n=15+15)
SetOperation/n=8/Go_Difference                              27.3kB ± 0%    27.4kB ± 0%   +0.45%  (p=0.000 n=14+15)
SetOperation/n=8/Go_SymmetricDifference                     37.2kB ± 0%    37.3kB ± 0%   +0.35%  (p=0.000 n=14+15)
SetOperation/n=8/Go_Union                                   27.4kB ± 0%    27.5kB ± 0%   +0.48%  (p=0.000 n=15+14)
SetOperation/n=8/GEOS_Intersection                          3.35kB ± 0%    3.35kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference                            3.51kB ± 0%    3.51kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference                   13.2kB ± 0%    13.2kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Union                                 3.64kB ± 0%    3.64kB ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection                           37.4kB ± 0%    37.5kB ± 0%   +0.33%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Difference                             40.5kB ± 0%    40.6kB ± 0%   +0.32%  (p=0.000 n=15+14)
SetOperation/n=16/Go_SymmetricDifference                    59.5kB ± 0%    59.6kB ± 0%   +0.21%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Union                                  42.0kB ± 0%    42.1kB ± 0%   +0.30%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Intersection                         3.90kB ± 0%    3.90kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference                           6.70kB ± 0%    6.70kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference                  25.2kB ± 0%    25.2kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Union                                8.30kB ± 0%    8.30kB ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection                           68.0kB ± 0%    68.1kB ± 0%   +0.19%  (p=0.000 n=14+15)
SetOperation/n=32/Go_Difference                             70.6kB ± 0%    70.7kB ± 0%   +0.18%  (p=0.000 n=15+15)
SetOperation/n=32/Go_SymmetricDifference                     100kB ± 0%     101kB ± 0%   +0.12%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Union                                  71.0kB ± 0%    71.1kB ± 0%   +0.18%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Intersection                         8.87kB ± 0%    8.87kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference                           10.7kB ± 0%    10.7kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference                  39.7kB ± 0%    39.7kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Union                                11.5kB ± 0%    11.5kB ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection                            113kB ± 0%     113kB ± 0%   +0.12%  (p=0.000 n=13+15)
SetOperation/n=64/Go_Difference                              125kB ± 0%     126kB ± 0%   +0.10%  (p=0.000 n=14+15)
SetOperation/n=64/Go_SymmetricDifference                     191kB ± 0%     191kB ± 0%   +0.06%  (p=0.000 n=15+15)
SetOperation/n=64/Go_Union                                   129kB ± 0%     129kB ± 0%   +0.10%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Intersection                         12.6kB ± 0%    12.6kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference                           23.5kB ± 0%    23.5kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference                  87.4kB ± 0%    87.4kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Union                                28.0kB ± 0%    28.0kB ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection                           230kB ± 0%     230kB ± 0%   +0.06%  (p=0.000 n=15+14)
SetOperation/n=128/Go_Difference                             242kB ± 0%     243kB ± 0%   +0.05%  (p=0.000 n=15+15)
SetOperation/n=128/Go_SymmetricDifference                    353kB ± 0%     353kB ± 0%   +0.04%  (p=0.000 n=14+15)
SetOperation/n=128/Go_Union                                  244kB ± 0%     244kB ± 0%   +0.05%  (p=0.000 n=14+14)
SetOperation/n=128/GEOS_Intersection                        30.3kB ± 0%    30.3kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference                          40.0kB ± 0%    40.0kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference                  147kB ± 0%     147kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Union                               43.1kB ± 0%    43.1kB ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection                           417kB ± 0%     417kB ± 0%   +0.03%  (p=0.000 n=14+14)
SetOperation/n=256/Go_Difference                             466kB ± 0%     467kB ± 0%   +0.03%  (p=0.000 n=15+15)
SetOperation/n=256/Go_SymmetricDifference                    722kB ± 0%     722kB ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=256/Go_Union                                  477kB ± 0%     477kB ± 0%   +0.03%  (p=0.000 n=15+14)
SetOperation/n=256/GEOS_Intersection                        48.2kB ± 0%    48.2kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference                          92.6kB ± 0%    92.6kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference                  341kB ± 0%     341kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Union                                106kB ± 0%     106kB ± 0%     ~     (all equal)
SetOperation/n=512/Go_Intersection                           858kB ± 0%     858kB ± 0%   +0.02%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Difference                             905kB ± 0%     906kB ± 0%   +0.01%  (p=0.000 n=15+14)
SetOperation/n=512/Go_SymmetricDifference                   1.33MB ± 0%    1.33MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Union                                  926kB ± 0%     926kB ± 0%   +0.02%  (p=0.000 n=14+15)
SetOperation/n=512/GEOS_Intersection                         115kB ± 0%     115kB ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Difference                           159kB ± 0%     159kB ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference                  577kB ± 0%     577kB ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Union                                171kB ± 0%     171kB ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Intersection                         1.58MB ± 0%    1.58MB ± 0%   +0.01%  (p=0.000 n=14+15)
SetOperation/n=1024/Go_Difference                           1.77MB ± 0%    1.77MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_SymmetricDifference                  2.80MB ± 0%    2.80MB ± 0%   +0.00%  (p=0.000 n=14+14)
SetOperation/n=1024/Go_Union                                1.83MB ± 0%    1.83MB ± 0%   +0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/GEOS_Intersection                        189kB ± 0%     189kB ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Difference                          370kB ± 0%     370kB ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference                1.38MB ± 0%    1.38MB ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Union                               415kB ± 0%     415kB ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Intersection                         3.64MB ± 0%    3.64MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Difference                           3.87MB ± 0%    3.87MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference                  5.63MB ± 0%    5.63MB ± 0%   +0.00%  (p=0.004 n=14+15)
SetOperation/n=2048/Go_Union                                3.95MB ± 0%    3.95MB ± 0%   +0.00%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Intersection                        460kB ± 0%     460kB ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Difference                          648kB ± 0%     648kB ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference                2.32MB ± 0%    2.32MB ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Union                               689kB ± 0%     689kB ± 0%     ~     (p=0.074 n=15+12)
SetOperation/n=4096/Go_Intersection                         6.82MB ± 0%    6.82MB ± 0%     ~     (p=0.337 n=15+14)
SetOperation/n=4096/Go_Difference                           7.54MB ± 0%    7.54MB ± 0%   +0.00%  (p=0.001 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference                  11.6MB ± 0%    11.6MB ± 0%   +0.00%  (p=0.020 n=15+15)
SetOperation/n=4096/Go_Union                                7.79MB ± 0%    7.79MB ± 0%   +0.00%  (p=0.001 n=14+15)
SetOperation/n=4096/GEOS_Intersection                        755kB ± 0%     755kB ± 0%     ~     (p=0.115 n=15+14)
SetOperation/n=4096/GEOS_Difference                         1.45MB ± 0%    1.45MB ± 0%     ~     (p=0.147 n=15+15)
SetOperation/n=4096/GEOS_SymmetricDifference                5.34MB ± 0%    5.34MB ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Union                              1.63MB ± 0%    1.63MB ± 0%     ~     (all equal)
SetOperation/n=8192/Go_Intersection                         14.9MB ± 0%    14.9MB ± 0%     ~     (p=0.065 n=15+15)
SetOperation/n=8192/Go_Difference                           15.8MB ± 0%    15.8MB ± 0%   +0.00%  (p=0.017 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference                  22.7MB ± 0%    22.7MB ± 0%   +0.00%  (p=0.008 n=14+15)
SetOperation/n=8192/Go_Union                                16.1MB ± 0%    16.1MB ± 0%   +0.00%  (p=0.033 n=15+14)
SetOperation/n=8192/GEOS_Intersection                       1.76MB ± 0%    1.76MB ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Difference                         2.47MB ± 0%    2.47MB ± 0%     ~     (p=0.782 n=15+15)
SetOperation/n=8192/GEOS_SymmetricDifference                9.01MB ± 0%    9.01MB ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Union                              2.66MB ± 0%    2.66MB ± 0%     ~     (all equal)
SetOperation/n=16384/Go_Intersection                        27.9MB ± 0%    27.9MB ± 0%   +0.00%  (p=0.000 n=12+12)
SetOperation/n=16384/Go_Difference                          31.0MB ± 0%    31.0MB ± 0%   +0.00%  (p=0.005 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference                 47.3MB ± 0%    47.3MB ± 0%   +0.00%  (p=0.031 n=15+13)
SetOperation/n=16384/Go_Union                               32.0MB ± 0%    32.0MB ± 0%     ~     (p=0.063 n=15+15)
SetOperation/n=16384/GEOS_Intersection                      2.92MB ± 0%    2.92MB ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Difference                        5.68MB ± 0%    5.68MB ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference               21.1MB ± 0%    21.1MB ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Union                             6.45MB ± 0%    6.45MB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Bulk/n=10                                                   1.46kB ± 0%    1.46kB ± 0%     ~     (all equal)
Bulk/n=100                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (all equal)
Bulk/n=10000                                                1.57MB ± 0%    1.57MB ± 0%     ~     (all equal)
Bulk/n=100000                                               20.4MB ± 0%    20.4MB ± 0%     ~     (all equal)
RangeSearch/n=10                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000                                         0.00B          0.00B          ~     (all equal)

name                                                      old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0                                                0.00           0.00          ~     (all equal)
LineEnvelope/1                                                0.00           0.00          ~     (all equal)
LineEnvelope/2                                                0.00           0.00          ~     (all equal)
LineEnvelope/3                                                0.00           0.00          ~     (all equal)
MarshalWKB/polygon/n=10                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10                              12.0 ± 0%      12.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100                             76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000                             348 ± 0%       348 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000                          5.47k ± 0%     5.47k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4                            42.0 ± 0%      42.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36                            316 ± 0%       316 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400                         3.48k ± 0%     3.48k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096                        36.2k ± 0%     36.2k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10                             41.0 ± 0%      41.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100                             233 ± 0%       233 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000                          1.05k ± 0%     1.05k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000                         16.4k ± 0%     16.4k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10                                 22.0 ± 0%      22.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100                                76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000                             10.3k ± 0%     10.3k ± 0%     ~     (all equal)
MultipolygonValidation/n=1                                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4                                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=16                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64                                   91.0 ± 0%      91.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256                                   347 ± 0%       347 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024                                1.37k ± 0%     1.37k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10                                   29.0 ± 0%      29.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100                                   157 ± 0%       157 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000                                  701 ± 0%       701 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000                               10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1                        50.0 ± 0%      50.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10                        297 ± 0%       297 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100                     2.61k ± 0%     2.61k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000                    26.7k ± 0%     26.7k ± 0%     ~     (p=0.588 n=15+14)
WKTParsing/point                                              21.0 ± 0%      21.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true               234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true            2.10k ± 0%     2.10k ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true       77.0 ± 0%      77.0 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100                   371 ± 0%       371 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000                3.34k ± 0%     3.34k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=1000                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=10000                         48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10                                 7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100                                71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000                                343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000                             5.46k ± 0%     5.46k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
SetOperation/n=4/Go_Intersection                               276 ± 0%       276 ± 0%     ~     (all equal)
SetOperation/n=4/Go_Difference                                 280 ± 0%       280 ± 0%     ~     (all equal)
SetOperation/n=4/Go_SymmetricDifference                        377 ± 0%       377 ± 0%     ~     (all equal)
SetOperation/n=4/Go_Union                                      287 ± 0%       287 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Intersection                            52.0 ± 0%      52.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference                              55.0 ± 0%      55.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference                      147 ± 0%       147 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Union                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection                               292 ± 0%       292 ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8/Go_Difference                                 293 ± 0%       293 ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8/Go_SymmetricDifference                        396 ± 0%       396 ± 0%   +0.10%  (p=0.034 n=12+15)
SetOperation/n=8/Go_Union                                      298 ± 0%       298 ± 0%   +0.13%  (p=0.034 n=12+15)
SetOperation/n=8/GEOS_Intersection                            56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference                              56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference                      151 ± 0%       151 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Union                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection                              306 ± 0%       306 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Difference                                316 ± 0%       316 ± 0%     ~     (all equal)
SetOperation/n=16/Go_SymmetricDifference                       444 ± 0%       444 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Union                                     325 ± 0%       325 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Intersection                           56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference                             64.0 ± 0%      64.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference                     184 ± 0%       184 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Union                                  68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection                              357 ± 0%       357 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Difference                                363 ± 0%       363 ± 0%     ~     (all equal)
SetOperation/n=32/Go_SymmetricDifference                       515 ± 0%       515 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Union                                     368 ± 0%       368 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Intersection                           68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference                             72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference                     215 ± 0%       215 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Union                                  72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection                              398 ± 0%       398 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Difference                                432 ± 0%       432 ± 0%     ~     (all equal)
SetOperation/n=64/Go_SymmetricDifference                       682 ± 0%       682 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Union                                     445 ± 0%       445 ± 0%     ~     (p=0.084 n=15+14)
SetOperation/n=64/GEOS_Intersection                           72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference                              104 ± 0%       104 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference                     344 ± 0%       344 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Union                                   112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection                             572 ± 0%       572 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Difference                               598 ± 0%       598 ± 0%     ~     (all equal)
SetOperation/n=128/Go_SymmetricDifference                      945 ± 0%       945 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Union                                    603 ± 0%       603 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Intersection                           112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference                             136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference                    472 ± 0%       472 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Union                                  136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection                             731 ± 0%       731 ± 0%     ~     (p=0.156 n=15+12)
SetOperation/n=256/Go_Difference                               861 ± 0%       861 ± 0%     ~     (p=0.115 n=15+14)
SetOperation/n=256/Go_SymmetricDifference                    1.59k ± 0%     1.59k ± 0%     ~     (p=0.070 n=13+15)
SetOperation/n=256/Go_Union                                    890 ± 0%       890 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Intersection                           136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference                             264 ± 0%       264 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference                    984 ± 0%       984 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Union                                  288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/Go_Intersection                           1.40k ± 0%     1.40k ± 0%     ~     (p=0.700 n=15+15)
SetOperation/n=512/Go_Difference                             1.51k ± 0%     1.51k ± 0%     ~     (p=0.115 n=14+15)
SetOperation/n=512/Go_SymmetricDifference                    2.62k ± 0%     2.62k ± 0%     ~     (all equal)
SetOperation/n=512/Go_Union                                  1.51k ± 0%     1.51k ± 0%     ~     (p=0.051 n=14+15)
SetOperation/n=512/GEOS_Intersection                           288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Difference                             392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference                  1.50k ± 0%     1.50k ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Union                                  392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Intersection                          2.03k ± 0%     2.03k ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Difference                            2.54k ± 0%     2.54k ± 0%     ~     (all equal)
SetOperation/n=1024/Go_SymmetricDifference                   5.20k ± 0%     5.20k ± 0%     ~     (p=0.133 n=15+13)
SetOperation/n=1024/Go_Union                                 2.64k ± 0%     2.64k ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Intersection                          392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Difference                            904 ± 0%       904 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference                 3.54k ± 0%     3.54k ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Union                                 992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Intersection                          4.69k ± 0%     4.69k ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Difference                            5.12k ± 0%     5.12k ± 0%     ~     (all equal)
SetOperation/n=2048/Go_SymmetricDifference                   9.31k ± 0%     9.31k ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Union                                 5.12k ± 0%     5.12k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Intersection                          992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Difference                          1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference                 5.59k ± 0%     5.59k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Union                               1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/Go_Intersection                          7.17k ± 0%     7.17k ± 0%     ~     (p=0.181 n=15+14)
SetOperation/n=4096/Go_Difference                            9.22k ± 0%     9.22k ± 0%     ~     (all equal)
SetOperation/n=4096/Go_SymmetricDifference                   19.6k ± 0%     19.6k ± 0%     ~     (all equal)
SetOperation/n=4096/Go_Union                                 9.57k ± 0%     9.57k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Intersection                        1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Difference                          3.46k ± 0%     3.46k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference                 13.8k ± 0%     13.8k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Union                               3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/Go_Intersection                          17.8k ± 0%     17.8k ± 0%     ~     (p=0.700 n=15+15)
SetOperation/n=8192/Go_Difference                            19.5k ± 0%     19.5k ± 0%     ~     (all equal)
SetOperation/n=8192/Go_SymmetricDifference                   36.0k ± 0%     36.0k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8192/Go_Union                                 19.5k ± 0%     19.5k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Intersection                        3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Difference                          5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference                 22.0k ± 0%     22.0k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Union                               5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/Go_Intersection                         27.7k ± 0%     27.7k ± 0%     ~     (p=0.061 n=13+15)
SetOperation/n=16384/Go_Difference                           35.9k ± 0%     35.9k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference                  76.9k ± 0%     76.9k ± 0%     ~     (p=0.751 n=15+15)
SetOperation/n=16384/Go_Union                                37.2k ± 0%     37.2k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Intersection                       5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Difference                         13.7k ± 0%     13.7k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference                54.7k ± 0%     54.7k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Union                              15.1k ± 0%     15.1k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Bulk/n=10                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
RangeSearch/n=10                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000                                          0.00           0.00          ~     (all equal)

```

</details>