### PR TITLE
Add Scan Method To Each Geometry Type

### DIFF
--- a/.ci/docker-compose-pgscan.yml
+++ b/.ci/docker-compose-pgscan.yml
@@ -1,0 +1,20 @@
+version: "2.1"
+services:
+  postgis:
+    image: mdillon/postgis
+    healthcheck:
+      test: "pg_isready -U postgres"
+      interval: '100ms'
+      timeout: '1s'
+      retries: 50
+  tests:
+    image: golang:1.14
+    working_dir: /go/src/github.com/peterstace/simplefeatures
+    entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./internal/pgscan
+    volumes:
+      - ..:/go/src/github.com/peterstace/simplefeatures
+    environment:
+      - GO111MODULE=on
+    depends_on:
+      postgis:
+        condition: service_healthy

--- a/.ci/run_ci.sh
+++ b/.ci/run_ci.sh
@@ -8,7 +8,8 @@ here="$(dirname "$(readlink -f "$0")")"
 docker-compose -f "$here/docker-compose-lint.yml"    up --abort-on-container-exit
 docker-compose -f "$here/docker-compose-unit.yml"    up --abort-on-container-exit
 docker-compose -f "$here/docker-compose-geos.yml"    up --abort-on-container-exit
-docker-compose -f "$here/docker-compose-cmpgeos.yml" up --abort-on-container-exit
+docker-compose -f "$here/docker-compose-pgscan.yml"  up --abort-on-container-exit
 docker-compose -f "$here/docker-compose-cmppg.yml"   up --abort-on-container-exit
+docker-compose -f "$here/docker-compose-cmpgeos.yml" up --abort-on-container-exit
 
 printf "\nduration: %.1f seconds\n" "$(echo "$(date +%s.%N) - $start" | bc)"

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -146,6 +146,20 @@ func (c GeometryCollection) Value() (driver.Value, error) {
 	return c.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a GeometryCollection geometry, then an error is
+// returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (c *GeometryCollection) Scan(src interface{}) error {
+	return scanAsType(src, c, TypeGeometryCollection)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (c GeometryCollection) AsBinary() []byte {
 	return c.AppendWKB(nil)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -234,6 +234,19 @@ func (s LineString) Value() (driver.Value, error) {
 	return s.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a LineString geometry, then an error is returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (s *LineString) Scan(src interface{}) error {
+	return scanAsType(src, s, TypeLineString)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (s LineString) AsBinary() []byte {
 	return s.AppendWKB(nil)

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -252,6 +252,19 @@ func (m MultiLineString) Value() (driver.Value, error) {
 	return m.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a MultiLineString geometry, then an error is returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (m *MultiLineString) Scan(src interface{}) error {
+	return scanAsType(src, m, TypeMultiLineString)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (m MultiLineString) AsBinary() []byte {
 	return m.AppendWKB(nil)

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -161,6 +161,19 @@ func (m MultiPoint) Value() (driver.Value, error) {
 	return m.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a MultiPoint geometry, then an error is returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (m *MultiPoint) Scan(src interface{}) error {
+	return scanAsType(src, m, TypeMultiPoint)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (m MultiPoint) AsBinary() []byte {
 	return m.AppendWKB(nil)

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -278,6 +278,19 @@ func (m MultiPolygon) Value() (driver.Value, error) {
 	return m.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a MultiPolygon geometry, then an error is returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (m *MultiPolygon) Scan(src interface{}) error {
+	return scanAsType(src, m, TypeMultiPolygon)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (m MultiPolygon) AsBinary() []byte {
 	return m.AppendWKB(nil)

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -103,6 +103,19 @@ func (p Point) Value() (driver.Value, error) {
 	return p.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a Point geometry, then an error is returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (p *Point) Scan(src interface{}) error {
+	return scanAsType(src, p, TypePoint)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (p Point) AsBinary() []byte {
 	return p.AppendWKB(nil)

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -252,6 +252,19 @@ func (p Polygon) Value() (driver.Value, error) {
 	return p.AsBinary(), nil
 }
 
+// Scan implements the database/sql.Scanner interface by parsing the src value
+// as WKB (Well Known Binary).
+//
+// If the WKB doesn't represent a Polygon geometry, then an error is returned.
+//
+// It constructs the resultant geometry with no ConstructionOptions. If
+// ConstructionOptions are needed, then the value should be scanned into a byte
+// slice and then UnmarshalWKB called manually (passing in the
+// ConstructionOptions as desired).
+func (p *Polygon) Scan(src interface{}) error {
+	return scanAsType(src, p, TypePolygon)
+}
+
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
 func (p Polygon) AsBinary() []byte {
 	return p.AppendWKB(nil)

--- a/internal/pgscan/pgscan_test.go
+++ b/internal/pgscan/pgscan_test.go
@@ -1,0 +1,46 @@
+package pgscan
+
+import (
+	"database/sql"
+	"strconv"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+func TestPostgresScan(t *testing.T) {
+	const dbURL = "postgres://postgres:password@postgis:5432/postgres?sslmode=disable"
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range []struct {
+		wkt      string
+		concrete interface{ AsText() string }
+	}{
+		{"POINT(0 1)", new(geom.Point)},
+		{"MULTIPOINT((0 1))", new(geom.MultiPoint)},
+		{"LINESTRING(0 1,1 0)", new(geom.LineString)},
+		{"MULTILINESTRING((0 1,1 0))", new(geom.MultiLineString)},
+		{"POLYGON((0 0,1 0,0 1,0 0))", new(geom.Polygon)},
+		{"MULTIPOLYGON(((0 0,1 0,0 1,0 0)))", new(geom.MultiPolygon)},
+		{"GEOMETRYCOLLECTION(MULTIPOLYGON(((0 0,1 0,0 1,0 0))))", new(geom.GeometryCollection)},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			if err := db.QueryRow(
+				`SELECT ST_AsBinary(ST_GeomFromText($1))`,
+				tc.wkt,
+			).Scan(tc.concrete); err != nil {
+				t.Error(err)
+			}
+			if got := tc.concrete.AsText(); got != tc.wkt {
+				t.Errorf("want=%v got=%v", tc.wkt, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This makes each concrete geometry type implements the
database/sql.Scanner interface.

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) Yes, a new class of tests just for this issue. Basically postgres integration tests.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/351

## Benchmark Results

N/A