### PR TITLE
GEOS Direct Passthrough

### DIFF
--- a/geos/generic_operations.go
+++ b/geos/generic_operations.go
@@ -8,62 +8,18 @@ package geos
 import "C"
 
 import (
-	"errors"
-	"fmt"
-	"unsafe"
-
 	"github.com/peterstace/simplefeatures/geom"
 )
-
-// relatesAny checks if the two geometries are related using any of the masks.
-func relatesAny(g1, g2 geom.Geometry, masks ...string) (bool, error) {
-	for i, m := range masks {
-		r, err := relate(g1, g2, m)
-		if err != nil {
-			return false, wrap(err, "could not relate mask %d of %d", i+1, len(masks))
-		}
-		if r {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// relate invokes the GEOS GEOSRelatePattern function, which checks if two
-// geometries are related according to a DE-9IM 'relates' mask.
-func relate(g1, g2 geom.Geometry, mask string) (bool, error) {
-	if g1.IsGeometryCollection() || g2.IsGeometryCollection() {
-		return false, errors.New("GeometryCollection not supported")
-	}
-	if len(mask) != 9 {
-		return false, fmt.Errorf("mask has invalid length %d (must be 9)", len(mask))
-	}
-
-	// Not all versions of GEOS can handle Z and M geometries correctly. For
-	// Relates, we only need 2D geometries anyway.
-	g1 = g1.Force2D()
-	g2 = g2.Force2D()
-
-	// The bytes in cmask represent a NULL terminated string, hence it's 10
-	// chars long (rather than 9) and the last char is left as 0.
-	var cmask [10]byte
-	copy(cmask[:], mask)
-
-	var result bool
-	err := binaryOpE(g1, g2, func(h *handle, gh1, gh2 *C.GEOSGeometry) error {
-		var err error
-		result, err = h.boolErr(C.GEOSRelatePattern_r(
-			h.context, gh1, gh2, (*C.char)(unsafe.Pointer(&cmask)),
-		))
-		return wrap(err, "executing GEOSRelatePattern_r")
-	})
-	return result, err
-}
 
 func binaryOpE(
 	g1, g2 geom.Geometry,
 	op func(*handle, *C.GEOSGeometry, *C.GEOSGeometry) error,
 ) error {
+	// Not all versions of GEOS can handle Z and M geometries correctly. For
+	// binary operations, we only need 2D geometries anyway.
+	g1 = g1.Force2D()
+	g2 = g2.Force2D()
+
 	h, err := newHandle()
 	if err != nil {
 		return err
@@ -90,11 +46,6 @@ func binaryOpG(
 	opts []geom.ConstructorOption,
 	op func(C.GEOSContextHandle_t, *C.GEOSGeometry, *C.GEOSGeometry) *C.GEOSGeometry,
 ) (geom.Geometry, error) {
-	// Not all versions of GEOS can handle Z and M geometries correctly. For
-	// binary operations, we only need 2D geometries anyway.
-	g1 = g1.Force2D()
-	g2 = g2.Force2D()
-
 	var result geom.Geometry
 	err := binaryOpE(g1, g2, func(h *handle, gh1, gh2 *C.GEOSGeometry) error {
 		resultGH := op(h.context, gh1, gh2)
@@ -109,7 +60,24 @@ func binaryOpG(
 	return result, err
 }
 
+func binaryOpB(
+	g1, g2 geom.Geometry,
+	op func(C.GEOSContextHandle_t, *C.GEOSGeometry, *C.GEOSGeometry) C.char,
+) (bool, error) {
+	var result bool
+	err := binaryOpE(g1, g2, func(h *handle, gh1, gh2 *C.GEOSGeometry) error {
+		var err error
+		result, err = h.boolErr(op(h.context, gh1, gh2))
+		return err
+	})
+	return result, err
+}
+
 func unaryOpE(g geom.Geometry, op func(*handle, *C.GEOSGeometry) error) error {
+	// Not all versions of libgeos can handle Z and M geometries correctly. For
+	// unary operations, we only need 2D geometries anyway.
+	g = g.Force2D()
+
 	h, err := newHandle()
 	if err != nil {
 		return err
@@ -130,10 +98,6 @@ func unaryOpG(
 	opts []geom.ConstructorOption,
 	op func(C.GEOSContextHandle_t, *C.GEOSGeometry) *C.GEOSGeometry,
 ) (geom.Geometry, error) {
-	// Not all versions of libgeos can handle Z and M geometries correctly. For
-	// unary operations, we only need 2D geometries anyway.
-	g = g.Force2D()
-
 	var result geom.Geometry
 	err := unaryOpE(g, func(h *handle, gh *C.GEOSGeometry) error {
 		resultGH := op(h.context, gh)


### PR DESCRIPTION
## Description

    Use direct passthrough for all GEOS operations
    
    Previously, some GEOS operations such as Equals were defined in terms of
    checking Relate masks. This required some preliminary checks to be
    performed before hitting the main logic. These checks would now be
    performed inside GEOS itself.
    
    It is expected (although not confirmed) that there could be some
    performance enhancements due to this change, because GEOS is now better
    positioned to perform optimisations specific to each binary operation
    that would not be possible when constructing a mask.
    
    The original intention behind performing some of the logic in Go and
    only wrapping Relate was so that we could gradually bring over _all_
    operations to Go. That's not how the project evolved though (the Go-only
    operations live entirely within the `geom` package).

## Check List

Have you:

- Added unit tests? N/A, relies on existing.

- Add cmprefimpl tests? (if appropriate?). N/A

## Related Issue

N/A

## Benchmark Results

N/A