### PR TITLE
Add Fuzz Testing for WKT parsing

### DIFF
--- a/geom/.gitignore
+++ b/geom/.gitignore
@@ -1,0 +1,1 @@
+testdata

--- a/geom/wkt_fuzz_test.go
+++ b/geom/wkt_fuzz_test.go
@@ -1,0 +1,56 @@
+// +build gofuzzbeta
+
+package geom_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/internal/extract"
+)
+
+func FuzzParseUnmarshalWKT(f *testing.F) {
+	corpus, err := extract.StringsFromSource("..")
+	if err != nil {
+		f.Fatalf("could not build corpus: %v", err)
+	}
+	for _, str := range corpus {
+		if allowInCorpus(str) {
+			f.Add(str)
+			f.Log(str)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, wkt string) {
+		done := make(chan struct{})
+		go func() {
+			geom.UnmarshalWKT(wkt, geom.DisableAllValidations)
+			close(done)
+		}()
+		select {
+		case <-done:
+			// do nothing
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timed out")
+		}
+	})
+}
+
+func allowInCorpus(s string) bool {
+	for _, prefix := range []string{
+		"POINT",
+		"MULTIPOINT",
+		"LINESTRING",
+		"MULTILINESTRING",
+		"POLYGON",
+		"MULTIPOLYGON",
+		"GEOMETRYCOLLECTION",
+	} {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmprefimpl/cmpgeos/extract_source.go
+++ b/internal/cmprefimpl/cmpgeos/extract_source.go
@@ -2,63 +2,10 @@ package main
 
 import (
 	"errors"
-	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/peterstace/simplefeatures/geom"
 )
-
-func extractStringsFromSource(dir string) ([]string, error) {
-	var strs []string
-	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() || strings.Contains(path, ".git") {
-			return nil
-		}
-		pkgs, err := parser.ParseDir(new(token.FileSet), path, nil, 0)
-		if err != nil {
-			return err
-		}
-		for _, pkg := range pkgs {
-			ast.Inspect(pkg, func(n ast.Node) bool {
-				lit, ok := n.(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					return true
-				}
-				unquoted, err := strconv.Unquote(lit.Value)
-				if !ok {
-					// Shouldn't ever happen because we've validated that it's a string literal.
-					panic(fmt.Sprintf("could not unquote string '%s'from ast: %v", lit.Value, err))
-				}
-				strs = append(strs, unquoted)
-				return true
-			})
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	strSet := map[string]struct{}{}
-	for _, s := range strs {
-		strSet[strings.TrimSpace(s)] = struct{}{}
-	}
-	strs = strs[:0]
-	for s := range strSet {
-		strs = append(strs, s)
-	}
-	sort.Strings(strs)
-	return strs, nil
-}
 
 func convertToGeometries(candidates []string) ([]geom.Geometry, error) {
 	var geoms []geom.Geometry

--- a/internal/cmprefimpl/cmpgeos/main.go
+++ b/internal/cmprefimpl/cmpgeos/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/internal/extract"
 )
 
 // TODO: These are additional geometries. Needs something a bit more robust...
@@ -24,7 +25,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not get working dir: %v", err)
 	}
-	candidates, err := extractStringsFromSource(dir)
+	candidates, err := extract.StringsFromSource(dir)
 	if err != nil {
 		log.Fatalf("could not extract strings from src: %v", err)
 	}

--- a/internal/cmprefimpl/cmppg/fuzz_test.go
+++ b/internal/cmprefimpl/cmppg/fuzz_test.go
@@ -3,23 +3,19 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
 	"testing"
 
 	_ "github.com/lib/pq"
 	"github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/internal/extract"
 )
 
 func TestFuzz(t *testing.T) {
 	pg := setupDB(t)
-	candidates := extractStringsFromSource(t)
+	candidates, err := extract.StringsFromSource("../../..")
+	if err != nil {
+		t.Fatalf("could not extract strings from source: %v", err)
+	}
 
 	CheckWKTParse(t, pg, candidates)
 	CheckWKBParse(t, pg, candidates)
@@ -70,51 +66,6 @@ func setupDB(t *testing.T) PostGIS {
 		t.Fatal(err)
 	}
 	return PostGIS{db}
-}
-
-func extractStringsFromSource(t *testing.T) []string {
-	var strs []string
-	if err := filepath.Walk("../../..", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() || strings.Contains(path, ".git") {
-			return nil
-		}
-		pkgs, err := parser.ParseDir(new(token.FileSet), path, nil, 0)
-		if err != nil {
-			return err
-		}
-		for _, pkg := range pkgs {
-			ast.Inspect(pkg, func(n ast.Node) bool {
-				lit, ok := n.(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					return true
-				}
-				unquoted, err := strconv.Unquote(lit.Value)
-				if !ok {
-					// Shouldn't ever happen because we've validated that it's a string literal.
-					panic(fmt.Sprintf("could not unquote string '%s'from ast: %v", lit.Value, err))
-				}
-				strs = append(strs, unquoted)
-				return true
-			})
-		}
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	strSet := map[string]struct{}{}
-	for _, s := range strs {
-		strSet[strings.TrimSpace(s)] = struct{}{}
-	}
-	strs = strs[:0]
-	for s := range strSet {
-		strs = append(strs, s)
-	}
-	sort.Strings(strs)
-	return strs
 }
 
 func convertToGeometries(t *testing.T, candidates []string) []geom.Geometry {

--- a/internal/extract/extract_strings_from_source.go
+++ b/internal/extract/extract_strings_from_source.go
@@ -1,0 +1,60 @@
+package extract
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// StringsFromSource parses the Go files (recursively) contained in the given
+// dir, and returns any string literals contained therein.
+func StringsFromSource(dir string) ([]string, error) {
+	var strs []string
+	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() || strings.Contains(path, ".git") {
+			return nil
+		}
+		pkgs, err := parser.ParseDir(new(token.FileSet), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, pkg := range pkgs {
+			ast.Inspect(pkg, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				unquoted, err := strconv.Unquote(lit.Value)
+				if !ok {
+					// Shouldn't ever happen because we've validated that it's a string literal.
+					panic(fmt.Sprintf("could not unquote string '%s' from AST: %v", lit.Value, err))
+				}
+				strs = append(strs, unquoted)
+				return true
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	strSet := map[string]struct{}{}
+	for _, s := range strs {
+		strSet[strings.TrimSpace(s)] = struct{}{}
+	}
+	strs = strs[:0]
+	for s := range strSet {
+		strs = append(strs, s)
+	}
+	sort.Strings(strs)
+	return strs, nil
+}


### PR DESCRIPTION
## Description

Adds Fuzz testing for WKT parsing.

This requires the experimental branch `dev.fuzz` of the go toolchain to run (and is protected by a build tag so that it's not compiled using the mainline go tool).

The fuzz tests start with a corpus of WKT strings collected from the sourcecode of this repo. They then mutate the corpus (using increasing code coverage as a guiding force), checking to see if the `geom.UnmarshalWKT` function hits an infinite loop or panics.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

N/A