### PR TITLE
Improve Orientation Documentation

### DIFF
--- a/geom/alg_orientation.go
+++ b/geom/alg_orientation.go
@@ -1,30 +1,35 @@
 package geom
 
+// threePointOrientation describes the relationship between 3 distinct points
+// in the plane. The relationships as described in words (i.e. 'left', 'right',
+// 'collinear') assume that the X axis increases from left to right, and the Y
+// axis increases from bottom to top.
 type threePointOrientation int
 
 const (
-	// rightTurn indicates the orientation is right turn which is anticlockwise
+	// rightTurn indicates that the last point is to the right of the line
+	// formed by traversing from the first point to the second point.
+	//
+	// A---B
+	//      \
+	//       C
 	rightTurn threePointOrientation = iota + 1
-	// collinear indicates three points are on the same line
+
+	// collinear indicates that the three points are on the same line.
+	//
+	// A---B---C
 	collinear
-	// leftTurn indicates the orientation is left turn which is clockwise
+
+	// rightTurn indicates that the last point is to the left of the line
+	// formed by traversing from the first point to the second point.
+	//
+	//       C
+	//      /
+	// A---B
 	leftTurn
 )
 
-func (o threePointOrientation) String() string {
-	switch o {
-	case rightTurn:
-		return "right turn"
-	case collinear:
-		return "collinear"
-	case leftTurn:
-		return "left turn"
-	default:
-		return "invalid orientation"
-	}
-}
-
-// orientation checks if s is on the right hand side or left hand side of the line formed by p and q.
+// orientation calculates the 3 point orientation between p, q, and s.
 func orientation(p, q, s XY) threePointOrientation {
 	cp := q.Sub(p).Cross(s.Sub(q))
 	switch {


### PR DESCRIPTION
## Description

Visual descriptions of orientation (such as 'left' or 'right') depend on the coordinate system, but are independent of the actual numbers. I've made that a bit clearer in the doc comments.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

N/A

## Benchmark Results

N/A