### PR TITLE
Bitset Bugfixes

### DIFF
--- a/geom/bitset.go
+++ b/geom/bitset.go
@@ -27,11 +27,11 @@ func (b *BitSet) Set(i int, newVal bool) {
 				make([]uint64, idx-len(b.masks)+1)...,
 			)
 		}
-		b.masks[idx] |= (1 << i % 64)
+		b.masks[idx] |= (1 << (i % 64))
 	} else {
 		idx := i / 64
 		if idx < len(b.masks) {
-			b.masks[i] &= ^(1 << (i % 64))
+			b.masks[idx] &= ^(1 << (i % 64))
 		}
 	}
 }

--- a/geom/bitset_test.go
+++ b/geom/bitset_test.go
@@ -1,0 +1,38 @@
+package geom_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+func TestBitSet(t *testing.T) {
+	t.Run("one bit at a time", func(t *testing.T) {
+		for i := 0; i < 256; i++ {
+			t.Run(fmt.Sprintf("bit %d", i), func(t *testing.T) {
+				var s geom.BitSet
+				expectFalse(t, s.Get(i))
+				s.Set(i, true)
+				expectTrue(t, s.Get(i))
+				s.Set(i, false)
+				expectFalse(t, s.Get(i))
+			})
+		}
+	})
+	t.Run("many bits at a time", func(t *testing.T) {
+		const n = 512
+		var want [n]bool
+		rnd := rand.New(rand.NewSource(0))
+		var s geom.BitSet
+		for i := 0; i < n; i++ {
+			choice := rnd.Intn(n)
+			want[choice] = !want[choice]
+			s.Set(choice, want[choice])
+			for j := 0; j < n; j++ {
+				expectBoolEq(t, s.Get(j), want[j])
+			}
+		}
+	})
+}

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -81,6 +81,16 @@ func expectBoolEq(t *testing.T, got, want bool) {
 	}
 }
 
+func expectTrue(t *testing.T, got bool) {
+	t.Helper()
+	expectBoolEq(t, got, true)
+}
+
+func expectFalse(t *testing.T, got bool) {
+	t.Helper()
+	expectBoolEq(t, got, false)
+}
+
 func expectXYEq(t *testing.T, got, want XY) {
 	t.Helper()
 	if got != want {


### PR DESCRIPTION
## Description

These bugs were found as the result of adding unit tests for BitSet.
They're fairly serious bugs, but fortunately only affect the population
of MultiPoint sets that contain empty Points.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

N/A

## Benchmark Results

N/A