### PR TITLE
Explicitly Allow Trailing WKB Bytes

### DIFF
--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -11,6 +11,10 @@ import (
 // UnmarshalWKB reads the Well Known Binary (WKB), and returns the
 // corresponding Geometry.
 func UnmarshalWKB(wkb []byte, opts ...ConstructorOption) (Geometry, error) {
+	// Note that we purposefully DON'T check for the presence of trailing
+	// bytes. There is nothing in the OGC spec indicating that trailing bytes
+	// are illegal. Some Esri software will add (useless) trailing bytes to
+	// their WKBs.
 	p := wkbParser{body: wkb, opts: opts}
 	return p.run()
 }

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -114,6 +114,11 @@ func TestWKBParseValid(t *testing.T) {
 			wkt: "POINT EMPTY",
 		},
 		{
+			// Trailing byte
+			wkb: "0101000000000000000000f87f000000000000f87f00",
+			wkt: "POINT EMPTY",
+		},
+		{
 			wkb: "01e9030000000000000000f87f000000000000f87f000000000000f87f",
 			wkt: "POINT Z EMPTY",
 		},


### PR DESCRIPTION
## Description

Explicitly allow trailing bytes after WKBs. See comment in diff for details.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

https://github.com/peterstace/simplefeatures/issues/369

## Benchmark Results

N/A