### PR TITLE
Add `DumpCoordinates` methods

### DIFF
--- a/geom/bitset.go
+++ b/geom/bitset.go
@@ -1,5 +1,7 @@
 package geom
 
+import "math/bits"
+
 // BitSet is a set data structure that holds a mapping from non-negative
 // integers to boolean values (bits). The zero value is the BitSet with all
 // bits set to false.
@@ -34,6 +36,15 @@ func (b *BitSet) Set(i int, newVal bool) {
 			b.masks[idx] &= ^(1 << (i % 64))
 		}
 	}
+}
+
+// CountTrue counts the number of elements in the set that are true.
+func (b *BitSet) CountTrue() int {
+	var count int
+	for _, mask := range b.masks {
+		count += bits.OnesCount64(mask)
+	}
+	return count
 }
 
 // Clone makes a deep copy of the BitSet.

--- a/geom/bitset_test.go
+++ b/geom/bitset_test.go
@@ -16,8 +16,10 @@ func TestBitSet(t *testing.T) {
 				expectFalse(t, s.Get(i))
 				s.Set(i, true)
 				expectTrue(t, s.Get(i))
+				expectIntEq(t, s.CountTrue(), 1)
 				s.Set(i, false)
 				expectFalse(t, s.Get(i))
+				expectIntEq(t, s.CountTrue(), 0)
 			})
 		}
 	})
@@ -30,9 +32,14 @@ func TestBitSet(t *testing.T) {
 			choice := rnd.Intn(n)
 			want[choice] = !want[choice]
 			s.Set(choice, want[choice])
+			var wantCountTrue int
 			for j := 0; j < n; j++ {
 				expectBoolEq(t, s.Get(j), want[j])
+				if want[j] {
+					wantCountTrue++
+				}
 			}
+			expectIntEq(t, s.CountTrue(), wantCountTrue)
 		}
 	})
 }

--- a/geom/coordinate_type.go
+++ b/geom/coordinate_type.go
@@ -1,5 +1,7 @@
 package geom
 
+import "fmt"
+
 // CoordinatesType controls the dimensionality and type of data used to encode
 // a point location.  At minimum, a point location is defined by X and Y
 // coordinates. It may optionally include a Z value, representing height. It
@@ -23,7 +25,10 @@ const (
 
 // String gives a string representation of a CoordinatesType.
 func (t CoordinatesType) String() string {
-	return [4]string{"XY", "XYZ", "XYM", "XYZM"}[t]
+	if t >= 0 && t < 4 {
+		return [4]string{"XY", "XYZ", "XYM", "XYZM"}[t]
+	}
+	return fmt.Sprintf("unknown coordinate type (%d)", t)
 }
 
 // Dimension returns the number of float64 coordinates required to encode a

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -52,6 +52,11 @@ func TestDumpCoordinatesMultiPoint(t *testing.T) {
 			inputWKT:    "MULTIPOINT ZM(3 4 5 6)",
 			want:        NewSequence([]float64{3, 4, 5, 6}, DimXYZM),
 		},
+		{
+			description: "reproduce bug",
+			inputWKT:    "MULTIPOINT Z(3 4 5,6 7 8)",
+			want:        NewSequence([]float64{3, 4, 5, 6, 7, 8}, DimXYZ),
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := geomFromWKT(t, tc.inputWKT).AsMultiPoint().DumpCoordinates()

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -29,8 +29,8 @@ func TestDumpCoordinatesMultiPoint(t *testing.T) {
 		},
 		{
 			description: "multiple non-empty points",
-			inputWKT:    "MULTIPOINT(1 2,3 4)",
-			want:        NewSequence([]float64{1, 2, 3, 4}, DimXY),
+			inputWKT:    "MULTIPOINT(1 2,3 4,5 6)",
+			want:        NewSequence([]float64{1, 2, 3, 4, 5, 6}, DimXY),
 		},
 		{
 			description: "mix of empty and non-empty points",
@@ -55,6 +55,60 @@ func TestDumpCoordinatesMultiPoint(t *testing.T) {
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := geomFromWKT(t, tc.inputWKT).AsMultiPoint().DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
+		})
+	}
+}
+
+func TestDumpCoordinatesMultiLineString(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        Sequence
+	}{
+		{
+			description: "empty",
+			inputWKT:    "MULTILINESTRING EMPTY",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "contains empty LineString",
+			inputWKT:    "MULTILINESTRING(EMPTY)",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "single non-empty LineString",
+			inputWKT:    "MULTILINESTRING((1 2,3 4))",
+			want:        NewSequence([]float64{1, 2, 3, 4}, DimXY),
+		},
+		{
+			description: "multiple non-empty LineStrings",
+			inputWKT:    "MULTILINESTRING((1 2,3 4),(5 6,7 8))",
+			want:        NewSequence([]float64{1, 2, 3, 4, 5, 6, 7, 8}, DimXY),
+		},
+		{
+			description: "mix of empty and non-empty LineStrings",
+			inputWKT:    "MULTILINESTRING(EMPTY,(1 2,3 4))",
+			want:        NewSequence([]float64{1, 2, 3, 4}, DimXY),
+		},
+		{
+			description: "Z coordinates",
+			inputWKT:    "MULTILINESTRING Z((1 2 3,3 4 5))",
+			want:        NewSequence([]float64{1, 2, 3, 3, 4, 5}, DimXYZ),
+		},
+		{
+			description: "M coordinates",
+			inputWKT:    "MULTILINESTRING M((1 2 3,3 4 5))",
+			want:        NewSequence([]float64{1, 2, 3, 3, 4, 5}, DimXYM),
+		},
+		{
+			description: "ZM coordinates",
+			inputWKT:    "MULTILINESTRING ZM((1 2 3 4,3 4 5 6))",
+			want:        NewSequence([]float64{1, 2, 3, 4, 3, 4, 5, 6}, DimXYZM),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := geomFromWKT(t, tc.inputWKT).AsMultiLineString().DumpCoordinates()
 			expectSequenceEq(t, got, tc.want)
 		})
 	}

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -172,3 +172,57 @@ func TestDumpCoordinatesPolygon(t *testing.T) {
 		})
 	}
 }
+
+func TestDumpCoordinatesMultiPolygon(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        Sequence
+	}{
+		{
+			description: "empty",
+			inputWKT:    "MULTIPOLYGON EMPTY",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "multi polygon with empty polygon",
+			inputWKT:    "MULTIPOLYGON(EMPTY)",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "contains single ring",
+			inputWKT:    "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))",
+			want:        NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0}, DimXY),
+		},
+		{
+			description: "multiple rings in a single polygon",
+			inputWKT:    "MULTIPOLYGON(((0 0,0 10,10 0,0 0),(1 1,1 2,2 2,2 1,1 1)))",
+			want:        NewSequence([]float64{0, 0, 0, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1}, DimXY),
+		},
+		{
+			description: "multiple polygons",
+			inputWKT:    "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((10 10,10 11,11 10,10 10)))",
+			want:        NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0, 10, 10, 10, 11, 11, 10, 10, 10}, DimXY),
+		},
+		{
+			description: "Z coordinates",
+			inputWKT:    "MULTIPOLYGON Z(((0 0 10,0 1 10,1 0 10,0 0 10)))",
+			want:        NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, DimXYZ),
+		},
+		{
+			description: "M coordinates",
+			inputWKT:    "MULTIPOLYGON M(((0 0 10,0 1 10,1 0 10,0 0 10)))",
+			want:        NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, DimXYM),
+		},
+		{
+			description: "ZM coordinates",
+			inputWKT:    "MULTIPOLYGON ZM(((0 0 20 10,0 1 20 10,1 0 20 10,0 0 20 10)))",
+			want:        NewSequence([]float64{0, 0, 20, 10, 0, 1, 20, 10, 1, 0, 20, 10, 0, 0, 20, 10}, DimXYZM),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := geomFromWKT(t, tc.inputWKT).AsMultiPolygon().DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
+		})
+	}
+}

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -280,3 +280,52 @@ func TestDumpCoordinatesMultiPolygon(t *testing.T) {
 		})
 	}
 }
+
+func TestDumpCoordinatesGeometry(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        Sequence
+	}{
+		{
+			description: "Point",
+			inputWKT:    "POINT Z(0 1 2)",
+			want:        NewSequence([]float64{0, 1, 2}, DimXYZ),
+		},
+		{
+			description: "LineString",
+			inputWKT:    "LINESTRING Z(0 1 2,3 4 5)",
+			want:        NewSequence([]float64{0, 1, 2, 3, 4, 5}, DimXYZ),
+		},
+		{
+			description: "Polygon",
+			inputWKT:    "POLYGON Z((0 0 1,0 1 1,1 0 1,0 0 1))",
+			want:        NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, DimXYZ),
+		},
+		{
+			description: "MultiPoint",
+			inputWKT:    "MULTIPOINT Z(0 1 2,3 4 5)",
+			want:        NewSequence([]float64{0, 1, 2, 3, 4, 5}, DimXYZ),
+		},
+		{
+			description: "MultiLineString",
+			inputWKT:    "MULTILINESTRING Z((0 1 2,3 4 5))",
+			want:        NewSequence([]float64{0, 1, 2, 3, 4, 5}, DimXYZ),
+		},
+		{
+			description: "MultiPolygon",
+			inputWKT:    "MULTIPOLYGON Z(((0 0 1,0 1 1,1 0 1,0 0 1)))",
+			want:        NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, DimXYZ),
+		},
+		//{
+		//	description: "GeometryCollection",
+		//	inputWKT:    "GEOMETRYCOLLECTION Z(POINT Z(0 1 2))",
+		//	want:        NewSequence([]float64{0, 1, 2}, DimXYZ),
+		//},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := geomFromWKT(t, tc.inputWKT).DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
+		})
+	}
+}

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -6,6 +6,60 @@ import (
 	. "github.com/peterstace/simplefeatures/geom"
 )
 
+func TestDumpCoordinatesPoint(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        Sequence
+	}{
+		{
+			description: "empty",
+			inputWKT:    "POINT EMPTY",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "empty z",
+			inputWKT:    "POINT Z EMPTY",
+			want:        NewSequence(nil, DimXYZ),
+		},
+		{
+			description: "empty m",
+			inputWKT:    "POINT M EMPTY",
+			want:        NewSequence(nil, DimXYM),
+		},
+		{
+			description: "empty zm",
+			inputWKT:    "POINT ZM EMPTY",
+			want:        NewSequence(nil, DimXYZM),
+		},
+		{
+			description: "non-empty",
+			inputWKT:    "POINT(1 2)",
+			want:        NewSequence([]float64{1, 2}, DimXY),
+		},
+		{
+			description: "non-empty z",
+			inputWKT:    "POINT Z(1 2 3)",
+			want:        NewSequence([]float64{1, 2, 3}, DimXYZ),
+		},
+		{
+			description: "non-empty m",
+			inputWKT:    "POINT M(1 2 3)",
+			want:        NewSequence([]float64{1, 2, 3}, DimXYM),
+		},
+		{
+			description: "non-empty zm",
+			inputWKT:    "POINT ZM(1 2 3 4)",
+			want:        NewSequence([]float64{1, 2, 3, 4}, DimXYZM),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := geomFromWKT(t, tc.inputWKT).AsPoint().DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
+		})
+	}
+}
+
 func TestDumpCoordinatesMultiPoint(t *testing.T) {
 	for _, tc := range []struct {
 		description string

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -1,0 +1,75 @@
+package geom_test
+
+import (
+	"testing"
+
+	. "github.com/peterstace/simplefeatures/geom"
+)
+
+func TestDumpCoordinatesMultiPoint(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        []Coordinates
+	}{
+		{
+			description: "empty",
+			inputWKT:    "MULTIPOINT EMPTY",
+			want:        nil,
+		},
+		{
+			description: "contains empty point",
+			inputWKT:    "MULTIPOINT(EMPTY)",
+			want:        nil,
+		},
+		{
+			description: "single non-empty point",
+			inputWKT:    "MULTIPOINT(1 2)",
+			want: []Coordinates{
+				NewXYCoordinates(1, 2),
+			},
+		},
+		{
+			description: "multiple non-empty points",
+			inputWKT:    "MULTIPOINT(1 2,3 4)",
+			want: []Coordinates{
+				NewXYCoordinates(1, 2),
+				NewXYCoordinates(3, 4),
+			},
+		},
+		{
+			description: "mix of empty and non-empty points",
+			inputWKT:    "MULTIPOINT(EMPTY,3 4)",
+			want: []Coordinates{
+				NewXYCoordinates(3, 4),
+			},
+		},
+		{
+			description: "Z coordinates",
+			inputWKT:    "MULTIPOINT Z(3 4 5)",
+			want: []Coordinates{
+				NewXYZCoordinates(3, 4, 5),
+			},
+		},
+		{
+			description: "M coordinates",
+			inputWKT:    "MULTIPOINT M(3 4 6)",
+			want: []Coordinates{
+				NewXYMCoordinates(3, 4, 6),
+			},
+		},
+		{
+			description: "ZM coordinates",
+			inputWKT:    "MULTIPOINT ZM(3 4 5 6)",
+			want: []Coordinates{
+				NewXYZMCoordinates(3, 4, 5, 6),
+			},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			mp := geomFromWKT(t, tc.inputWKT).AsMultiPoint()
+			got := mp.DumpCoordinates()
+			expectCoordinateSliceEq(t, got, tc.want)
+		})
+	}
+}

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -281,6 +281,45 @@ func TestDumpCoordinatesMultiPolygon(t *testing.T) {
 	}
 }
 
+func TestDumpCoordinatesGeometryCollection(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        Sequence
+	}{
+		{
+			description: "empty",
+			inputWKT:    "GEOMETRYCOLLECTION EMPTY",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "empty z",
+			inputWKT:    "GEOMETRYCOLLECTION Z EMPTY",
+			want:        NewSequence(nil, DimXYZ),
+		},
+		{
+			description: "single point",
+			inputWKT:    "GEOMETRYCOLLECTION(POINT(1 2))",
+			want:        NewSequence([]float64{1, 2}, DimXY),
+		},
+		{
+			description: "single point z",
+			inputWKT:    "GEOMETRYCOLLECTION Z(POINT Z(1 2 0))",
+			want:        NewSequence([]float64{1, 2, 0}, DimXYZ),
+		},
+		{
+			description: "nested",
+			inputWKT:    "GEOMETRYCOLLECTION Z(GEOMETRYCOLLECTION Z(POINT Z(1 2 0)))",
+			want:        NewSequence([]float64{1, 2, 0}, DimXYZ),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := geomFromWKT(t, tc.inputWKT).AsGeometryCollection().DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
+		})
+	}
+}
+
 func TestDumpCoordinatesGeometry(t *testing.T) {
 	for _, tc := range []struct {
 		description string
@@ -317,11 +356,11 @@ func TestDumpCoordinatesGeometry(t *testing.T) {
 			inputWKT:    "MULTIPOLYGON Z(((0 0 1,0 1 1,1 0 1,0 0 1)))",
 			want:        NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, DimXYZ),
 		},
-		//{
-		//	description: "GeometryCollection",
-		//	inputWKT:    "GEOMETRYCOLLECTION Z(POINT Z(0 1 2))",
-		//	want:        NewSequence([]float64{0, 1, 2}, DimXYZ),
-		//},
+		{
+			description: "GeometryCollection",
+			inputWKT:    "GEOMETRYCOLLECTION Z(POINT Z(0 1 2))",
+			want:        NewSequence([]float64{0, 1, 2}, DimXYZ),
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := geomFromWKT(t, tc.inputWKT).DumpCoordinates()

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -118,3 +118,57 @@ func TestDumpCoordinatesMultiLineString(t *testing.T) {
 		})
 	}
 }
+
+func TestDumpCoordinatesPolygon(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		inputWKT    string
+		want        Sequence
+	}{
+		{
+			description: "empty",
+			inputWKT:    "POLYGON EMPTY",
+			want:        NewSequence(nil, DimXY),
+		},
+		{
+			description: "contains single ring",
+			inputWKT:    "POLYGON((0 0,0 1,1 0,0 0))",
+			want:        NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0}, DimXY),
+		},
+		{
+			description: "multiple rings",
+			inputWKT:    "POLYGON((0 0,0 10,10 0,0 0),(1 1,1 2,2 2,2 1,1 1))",
+			want:        NewSequence([]float64{0, 0, 0, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1}, DimXY),
+		},
+		{
+			description: "Z coordinates",
+			inputWKT:    "POLYGON Z((0 0 -1,0 10 -1,10 0 -1,0 0 -1),(1 1 -1,1 2 -1,2 2 -1,2 1 -1,1 1 -1))",
+			want: NewSequence([]float64{
+				0, 0, -1,
+				0, 10, -1,
+				10, 0, -1,
+				0, 0, -1,
+				1, 1, -1,
+				1, 2, -1,
+				2, 2, -1,
+				2, 1, -1,
+				1, 1, -1,
+			}, DimXYZ),
+		},
+		{
+			description: "M coordinates",
+			inputWKT:    "POLYGON M((0 0 10,0 1 10,1 0 10,0 0 10))",
+			want:        NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, DimXYM),
+		},
+		{
+			description: "ZM coordinates",
+			inputWKT:    "POLYGON ZM((0 0 10 20,0 1 10 20,1 0 10 20,0 0 10 20))",
+			want:        NewSequence([]float64{0, 0, 10, 20, 0, 1, 10, 20, 1, 0, 10, 20, 0, 0, 10, 20}, DimXYZM),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := geomFromWKT(t, tc.inputWKT).AsPolygon().DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
+		})
+	}
+}

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -10,66 +10,52 @@ func TestDumpCoordinatesMultiPoint(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        []Coordinates
+		want        Sequence
 	}{
 		{
 			description: "empty",
 			inputWKT:    "MULTIPOINT EMPTY",
-			want:        nil,
+			want:        NewSequence(nil, DimXY),
 		},
 		{
 			description: "contains empty point",
 			inputWKT:    "MULTIPOINT(EMPTY)",
-			want:        nil,
+			want:        NewSequence(nil, DimXY),
 		},
 		{
 			description: "single non-empty point",
 			inputWKT:    "MULTIPOINT(1 2)",
-			want: []Coordinates{
-				NewXYCoordinates(1, 2),
-			},
+			want:        NewSequence([]float64{1, 2}, DimXY),
 		},
 		{
 			description: "multiple non-empty points",
 			inputWKT:    "MULTIPOINT(1 2,3 4)",
-			want: []Coordinates{
-				NewXYCoordinates(1, 2),
-				NewXYCoordinates(3, 4),
-			},
+			want:        NewSequence([]float64{1, 2, 3, 4}, DimXY),
 		},
 		{
 			description: "mix of empty and non-empty points",
 			inputWKT:    "MULTIPOINT(EMPTY,3 4)",
-			want: []Coordinates{
-				NewXYCoordinates(3, 4),
-			},
+			want:        NewSequence([]float64{3, 4}, DimXY),
 		},
 		{
 			description: "Z coordinates",
 			inputWKT:    "MULTIPOINT Z(3 4 5)",
-			want: []Coordinates{
-				NewXYZCoordinates(3, 4, 5),
-			},
+			want:        NewSequence([]float64{3, 4, 5}, DimXYZ),
 		},
 		{
 			description: "M coordinates",
 			inputWKT:    "MULTIPOINT M(3 4 6)",
-			want: []Coordinates{
-				NewXYMCoordinates(3, 4, 6),
-			},
+			want:        NewSequence([]float64{3, 4, 6}, DimXYM),
 		},
 		{
 			description: "ZM coordinates",
 			inputWKT:    "MULTIPOINT ZM(3 4 5 6)",
-			want: []Coordinates{
-				NewXYZMCoordinates(3, 4, 5, 6),
-			},
+			want:        NewSequence([]float64{3, 4, 5, 6}, DimXYZM),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			mp := geomFromWKT(t, tc.inputWKT).AsMultiPoint()
-			got := mp.DumpCoordinates()
-			expectCoordinateSliceEq(t, got, tc.want)
+			got := geomFromWKT(t, tc.inputWKT).AsMultiPoint().DumpCoordinates()
+			expectSequenceEq(t, got, tc.want)
 		})
 	}
 }

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -1,6 +1,8 @@
 package geom
 
-// Coordinates represents a point location.
+// Coordinates represents a point location. Coordinates values may be
+// constructed manually using the type definition directly. Alternatively, one
+// of the New(XYZM)Coordinates constructor functions can be used.
 type Coordinates struct {
 	// XY represents the XY position of the point location.
 	XY
@@ -17,4 +19,40 @@ type Coordinates struct {
 	// Type indicates the coordinates type, and therefore whether
 	// or not Z and M are populated.
 	Type CoordinatesType
+}
+
+// NewXYCoordinates constructs a new set of coordinates of type XY.
+func NewXYCoordinates(x, y float64) Coordinates {
+	return Coordinates{
+		Type: DimXY,
+		XY:   XY{x, y},
+	}
+}
+
+// NewXYZCoordinates constructs a new set of coordinates of type XYZ.
+func NewXYZCoordinates(x, y, z float64) Coordinates {
+	return Coordinates{
+		Type: DimXYZ,
+		XY:   XY{x, y},
+		Z:    z,
+	}
+}
+
+// NewXYMCoordinates constructs a new set of coordinates of type XYM.
+func NewXYMCoordinates(x, y, m float64) Coordinates {
+	return Coordinates{
+		Type: DimXYM,
+		XY:   XY{x, y},
+		M:    m,
+	}
+}
+
+// NewXYZMCoordinates constructs a new set of coordinates of type XYZM.
+func NewXYZMCoordinates(x, y, z, m float64) Coordinates {
+	return Coordinates{
+		Type: DimXYZM,
+		XY:   XY{x, y},
+		Z:    z,
+		M:    m,
+	}
 }

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -62,39 +62,3 @@ func (c Coordinates) appendFloat64s(dst []float64) []float64 {
 		panic(c.Type.String())
 	}
 }
-
-// NewXYCoordinates constructs a new set of coordinates of type XY.
-func NewXYCoordinates(x, y float64) Coordinates {
-	return Coordinates{
-		Type: DimXY,
-		XY:   XY{x, y},
-	}
-}
-
-// NewXYZCoordinates constructs a new set of coordinates of type XYZ.
-func NewXYZCoordinates(x, y, z float64) Coordinates {
-	return Coordinates{
-		Type: DimXYZ,
-		XY:   XY{x, y},
-		Z:    z,
-	}
-}
-
-// NewXYMCoordinates constructs a new set of coordinates of type XYM.
-func NewXYMCoordinates(x, y, m float64) Coordinates {
-	return Coordinates{
-		Type: DimXYM,
-		XY:   XY{x, y},
-		M:    m,
-	}
-}
-
-// NewXYZMCoordinates constructs a new set of coordinates of type XYZM.
-func NewXYZMCoordinates(x, y, z, m float64) Coordinates {
-	return Coordinates{
-		Type: DimXYZM,
-		XY:   XY{x, y},
-		Z:    z,
-		M:    m,
-	}
-}

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -21,6 +21,23 @@ type Coordinates struct {
 	Type CoordinatesType
 }
 
+// appendFloat64s appends the coordinates to dst, taking into
+// consideration the coordinate type.
+func (c Coordinates) appendFloat64s(dst []float64) []float64 {
+	switch c.Type {
+	case DimXY:
+		return append(dst, c.X, c.Y)
+	case DimXYZ:
+		return append(dst, c.X, c.Y, c.Z)
+	case DimXYM:
+		return append(dst, c.X, c.Y, c.M)
+	case DimXYZM:
+		return append(dst, c.X, c.Y, c.Z, c.M)
+	default:
+		panic(c.Type.String())
+	}
+}
+
 // NewXYCoordinates constructs a new set of coordinates of type XY.
 func NewXYCoordinates(x, y float64) Coordinates {
 	return Coordinates{

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -1,5 +1,10 @@
 package geom
 
+import (
+	"strconv"
+	"strings"
+)
+
 // Coordinates represents a point location. Coordinates values may be
 // constructed manually using the type definition directly. Alternatively, one
 // of the New(XYZM)Coordinates constructor functions can be used.
@@ -19,6 +24,26 @@ type Coordinates struct {
 	// Type indicates the coordinates type, and therefore whether
 	// or not Z and M are populated.
 	Type CoordinatesType
+}
+
+// String gives a string representation of the coordinates.
+func (c Coordinates) String() string {
+	var sb strings.Builder
+	sb.WriteString("Coordinates[")
+	sb.WriteString(c.Type.String())
+	sb.WriteString("] ")
+	sb.WriteString(strconv.FormatFloat(c.X, 'f', -1, 64))
+	sb.WriteRune(' ')
+	sb.WriteString(strconv.FormatFloat(c.Y, 'f', -1, 64))
+	if c.Type.Is3D() {
+		sb.WriteRune(' ')
+		sb.WriteString(strconv.FormatFloat(c.Z, 'f', -1, 64))
+	}
+	if c.Type.IsMeasured() {
+		sb.WriteRune(' ')
+		sb.WriteString(strconv.FormatFloat(c.M, 'f', -1, 64))
+	}
+	return sb.String()
 }
 
 // appendFloat64s appends the coordinates to dst, taking into

--- a/geom/type_coordinates_test.go
+++ b/geom/type_coordinates_test.go
@@ -1,0 +1,41 @@
+package geom_test
+
+import (
+	"strconv"
+	"testing"
+
+	. "github.com/peterstace/simplefeatures/geom"
+)
+
+func TestCoordinatesString(t *testing.T) {
+	for i, tc := range []struct {
+		coords Coordinates
+		want   string
+	}{
+		{
+			Coordinates{},
+			"Coordinates[XY] 0 0",
+		},
+		{
+			Coordinates{XY: XY{X: 1, Y: 2}},
+			"Coordinates[XY] 1 2",
+		},
+		{
+			Coordinates{XY: XY{X: 1, Y: 2}, Z: 3, Type: DimXYZ},
+			"Coordinates[XYZ] 1 2 3",
+		},
+		{
+			Coordinates{XY: XY{X: 1, Y: 2}, M: 3, Type: DimXYM},
+			"Coordinates[XYM] 1 2 3",
+		},
+		{
+			Coordinates{XY: XY{X: 1, Y: 2}, Z: 3, M: 4, Type: DimXYZM},
+			"Coordinates[XYZM] 1 2 3 4",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := tc.coords.String()
+			expectStringEq(t, got, tc.want)
+		})
+	}
+}

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -773,7 +773,7 @@ func (g Geometry) appendDump(gs []Geometry) []Geometry {
 func (g Geometry) DumpCoordinates() Sequence {
 	switch g.gtype {
 	case TypeGeometryCollection:
-		panic("GeometryCollection not yet handled")
+		return g.AsGeometryCollection().DumpCoordinates()
 	case TypePoint:
 		return g.AsPoint().DumpCoordinates()
 	case TypeLineString:
@@ -787,6 +787,6 @@ func (g Geometry) DumpCoordinates() Sequence {
 	case TypeMultiPolygon:
 		return g.AsMultiPolygon().DumpCoordinates()
 	default:
-		panic("invalid")
+		panic("unknown type: " + g.Type().String())
 	}
 }

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -767,3 +767,26 @@ func (g Geometry) appendDump(gs []Geometry) []Geometry {
 	}
 	return gs
 }
+
+// DumpCoordinates returns the control points making up the geometry as a
+// Sequence.
+func (g Geometry) DumpCoordinates() Sequence {
+	switch g.gtype {
+	case TypeGeometryCollection:
+		panic("GeometryCollection not yet handled")
+	case TypePoint:
+		return g.AsPoint().DumpCoordinates()
+	case TypeLineString:
+		return g.AsLineString().Coordinates()
+	case TypePolygon:
+		return g.AsPolygon().DumpCoordinates()
+	case TypeMultiPoint:
+		return g.AsMultiPoint().DumpCoordinates()
+	case TypeMultiLineString:
+		return g.AsMultiLineString().DumpCoordinates()
+	case TypeMultiPolygon:
+		return g.AsMultiPolygon().DumpCoordinates()
+	default:
+		panic("invalid")
+	}
+}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -448,3 +448,13 @@ func (c GeometryCollection) Dump() []Geometry {
 	}
 	return gs
 }
+
+// DumpCoordinates returns a Sequence holding all control points in the
+// GeometryCollection.
+func (c GeometryCollection) DumpCoordinates() Sequence {
+	var coords []float64
+	for _, g := range c.geoms {
+		coords = g.DumpCoordinates().appendAllPoints(coords)
+	}
+	return NewSequence(coords, c.ctype)
+}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -301,7 +301,7 @@ func (m MultiLineString) MarshalJSON() ([]byte, error) {
 	return dst, nil
 }
 
-// Coordinates returns the coordinates of each constintuent LineString in the
+// Coordinates returns the coordinates of each constituent LineString in the
 // MultiLineString.
 func (m MultiLineString) Coordinates() []Sequence {
 	n := m.NumLineStrings()
@@ -446,4 +446,20 @@ func (m MultiLineString) Dump() []LineString {
 	lss := make([]LineString, len(m.lines))
 	copy(lss, m.lines)
 	return lss
+}
+
+// DumpCoordinates returns the coordinates (as a Sequence) that constitute the
+// MultiLineString.
+func (m MultiLineString) DumpCoordinates() Sequence {
+	var n int
+	for _, ls := range m.lines {
+		n += ls.seq.Length() * m.ctype.Dimension()
+	}
+	coords := make([]float64, 0, n)
+	for _, ls := range m.lines {
+		coords = append(ls.Coordinates().appendAllPoints(coords))
+	}
+	seq := NewSequence(coords, m.ctype)
+	seq.assertNoUnusedCapacity()
+	return seq
 }

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -299,12 +299,22 @@ func (m MultiPoint) Dump() []Point {
 // a Sequence.
 func (m MultiPoint) DumpCoordinates() Sequence {
 	n := m.seq.Length()
-	var nonEmpty []float64
+	var empty int
+	for i := 0; i < n; i++ {
+		if m.empty.Get(i) {
+			empty++
+		}
+	}
+
+	nonEmpty := make([]float64, 0, n-empty)
 	for i := 0; i < n; i++ {
 		if m.empty.Get(i) {
 			continue
 		}
 		nonEmpty = m.seq.Get(i).appendFloat64s(nonEmpty)
 	}
-	return NewSequence(nonEmpty, m.seq.CoordinatesType())
+
+	seq := NewSequence(nonEmpty, m.seq.CoordinatesType())
+	seq.assertNoUnusedCapacity()
+	return seq
 }

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -298,16 +298,17 @@ func (m MultiPoint) Dump() []Point {
 // DumpCoordinates returns the non-empty points in a MultiPoint represented as
 // a Sequence.
 func (m MultiPoint) DumpCoordinates() Sequence {
+	ctype := m.CoordinatesType()
 	n := m.seq.Length()
 	empty := m.empty.CountTrue()
-	nonEmpty := make([]float64, 0, n-empty)
+	nonEmpty := make([]float64, 0, ctype.Dimension()*(n-empty))
 	for i := 0; i < n; i++ {
 		if m.empty.Get(i) {
 			continue
 		}
 		nonEmpty = m.seq.Get(i).appendFloat64s(nonEmpty)
 	}
-	seq := NewSequence(nonEmpty, m.seq.CoordinatesType())
+	seq := NewSequence(nonEmpty, ctype)
 	seq.assertNoUnusedCapacity()
 	return seq
 }

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -299,13 +299,7 @@ func (m MultiPoint) Dump() []Point {
 // a Sequence.
 func (m MultiPoint) DumpCoordinates() Sequence {
 	n := m.seq.Length()
-	var empty int
-	for i := 0; i < n; i++ {
-		if m.empty.Get(i) {
-			empty++
-		}
-	}
-
+	empty := m.empty.CountTrue()
 	nonEmpty := make([]float64, 0, n-empty)
 	for i := 0; i < n; i++ {
 		if m.empty.Get(i) {
@@ -313,7 +307,6 @@ func (m MultiPoint) DumpCoordinates() Sequence {
 		}
 		nonEmpty = m.seq.Get(i).appendFloat64s(nonEmpty)
 	}
-
 	seq := NewSequence(nonEmpty, m.seq.CoordinatesType())
 	seq.assertNoUnusedCapacity()
 	return seq

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -295,16 +295,16 @@ func (m MultiPoint) Dump() []Point {
 	return pts
 }
 
-// DumpCoordinates returns the MultiPoint represented as a slice of
-// coordinates.
-func (m MultiPoint) DumpCoordinates() []Coordinates {
+// DumpCoordinates returns the non-empty points in a MultiPoint represented as
+// a Sequence.
+func (m MultiPoint) DumpCoordinates() Sequence {
 	n := m.seq.Length()
-	coords := make([]Coordinates, 0, n)
+	var nonEmpty []float64
 	for i := 0; i < n; i++ {
 		if m.empty.Get(i) {
 			continue
 		}
-		coords = append(coords, m.seq.Get(i))
+		nonEmpty = m.seq.Get(i).appendFloat64s(nonEmpty)
 	}
-	return coords
+	return NewSequence(nonEmpty, m.seq.CoordinatesType())
 }

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -294,3 +294,17 @@ func (m MultiPoint) Dump() []Point {
 	}
 	return pts
 }
+
+// DumpCoordinates returns the MultiPoint represented as a slice of
+// coordinates.
+func (m MultiPoint) DumpCoordinates() []Coordinates {
+	n := m.seq.Length()
+	coords := make([]Coordinates, 0, n)
+	for i := 0; i < n; i++ {
+		if m.empty.Get(i) {
+			continue
+		}
+		coords = append(coords, m.seq.Get(i))
+	}
+	return coords
+}

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -474,3 +474,26 @@ func (m MultiPolygon) Dump() []Polygon {
 	copy(ps, m.polys)
 	return ps
 }
+
+// DumpCoordinates returns the points making up the rings in a MultiPolygon as
+// a Sequence.
+func (m MultiPolygon) DumpCoordinates() Sequence {
+	var n int
+	for _, p := range m.polys {
+		for _, r := range p.rings {
+			n += r.Coordinates().Length()
+		}
+	}
+	ctype := m.CoordinatesType()
+	coords := make([]float64, 0, n*ctype.Dimension())
+
+	for _, p := range m.polys {
+		for _, r := range p.rings {
+			coords = r.Coordinates().appendAllPoints(coords)
+		}
+	}
+
+	seq := NewSequence(coords, ctype)
+	seq.assertNoUnusedCapacity()
+	return seq
+}

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -219,3 +219,19 @@ func (p Point) asXYs() []XY {
 	}
 	return nil
 }
+
+// DumpCoordinates returns a Sequence representing the point. For an empty
+// Point, the Sequence will be empty. For a non-empty Point, the Sequence will
+// contain the single set of coordinates representing the point.
+func (p Point) DumpCoordinates() Sequence {
+	ctype := p.CoordinatesType()
+	var floats []float64
+	coords, ok := p.Coordinates()
+	if ok {
+		n := ctype.Dimension()
+		floats = coords.appendFloat64s(make([]float64, 0, n))
+	}
+	seq := NewSequence(floats, ctype)
+	seq.assertNoUnusedCapacity()
+	return seq
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -543,3 +543,20 @@ func (p Polygon) controlPoints() int {
 	}
 	return sum
 }
+
+// DumpCoordinates returns the points making up the rings in a Polygon as a
+// Sequence.
+func (p Polygon) DumpCoordinates() Sequence {
+	var n int
+	for _, r := range p.rings {
+		n += r.Coordinates().Length()
+	}
+	ctype := p.CoordinatesType()
+	coords := make([]float64, 0, n*ctype.Dimension())
+	for _, r := range p.rings {
+		coords = r.Coordinates().appendAllPoints(coords)
+	}
+	seq := NewSequence(coords, ctype)
+	seq.assertNoUnusedCapacity()
+	return seq
+}

--- a/geom/type_sequence.go
+++ b/geom/type_sequence.go
@@ -1,5 +1,7 @@
 package geom
 
+import "fmt"
+
 // Sequence represents a list of point locations.  It is immutable after
 // creation.  All locations in the Sequence are specified using the same
 // coordinates type.
@@ -146,6 +148,15 @@ func (s Sequence) appendAllPoints(dst []float64) []float64 {
 func (s Sequence) appendPoint(dst []float64, i int) []float64 {
 	stride := s.ctype.Dimension()
 	return append(dst, s.floats[i*stride:(i+1)*stride]...)
+}
+
+// assertNoUnusedCapacity panics if the backing slice contains any unused
+// capacity.
+func (s Sequence) assertNoUnusedCapacity() {
+	if cap(s.floats)-len(s.floats) != 0 {
+		panic(fmt.Sprintf("unused capacity assertion "+
+			"failure: cap=%d len=%d", cap(s.floats), len(s.floats)))
+	}
 }
 
 // getLine extracts a 2D line segment from a sequence by joining together

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -166,3 +166,29 @@ func expectBytesEq(t *testing.T, got, want []byte) {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
+
+func expectCoordinateSliceEq(t *testing.T, got, want []Coordinates) {
+	t.Helper()
+	show := func() {
+		t.Logf("len(got): %d", len(got))
+		for i, c := range got {
+			t.Logf("got[%d]: %v", i, c)
+		}
+		t.Logf("len(want): %d", len(want))
+		for i, c := range want {
+			t.Logf("want[%d]: %v", i, c)
+		}
+	}
+
+	if len(want) != len(got) {
+		t.Errorf("length mismatch: got=%d want=%d", len(got), len(want))
+		show()
+		return
+	}
+	for i, g := range got {
+		w := want[i]
+		if g != w {
+			t.Errorf("mismatch at %d: got:%v want:%v", i, g, w)
+		}
+	}
+}

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -167,26 +167,26 @@ func expectBytesEq(t *testing.T, got, want []byte) {
 	}
 }
 
-func expectCoordinateSliceEq(t *testing.T, got, want []Coordinates) {
+func expectSequenceEq(t *testing.T, got, want Sequence) {
 	t.Helper()
 	show := func() {
-		t.Logf("len(got): %d", len(got))
-		for i, c := range got {
-			t.Logf("got[%d]: %v", i, c)
+		t.Logf("len(got): %d", got.Length())
+		for i := 0; i < got.Length(); i++ {
+			t.Logf("got[%d]: %v", i, got.Get(i))
 		}
-		t.Logf("len(want): %d", len(want))
-		for i, c := range want {
-			t.Logf("want[%d]: %v", i, c)
+		t.Logf("len(want): %d", want.Length())
+		for i := 0; i < want.Length(); i++ {
+			t.Logf("want[%d]: %v", i, want.Get(i))
 		}
 	}
-
-	if len(want) != len(got) {
-		t.Errorf("length mismatch: got=%d want=%d", len(got), len(want))
+	if got.Length() != want.Length() {
+		t.Errorf("length mismatch: got=%d want=%d", got.Length(), want.Length())
 		show()
 		return
 	}
-	for i, g := range got {
-		w := want[i]
+	for i := 0; i < got.Length(); i++ {
+		w := want.Get(i)
+		g := got.Get(i)
 		if g != w {
 			t.Errorf("mismatch at %d: got:%v want:%v", i, g, w)
 		}

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -170,17 +170,22 @@ func expectBytesEq(t *testing.T, got, want []byte) {
 func expectSequenceEq(t *testing.T, got, want Sequence) {
 	t.Helper()
 	show := func() {
-		t.Logf("len(got): %d", got.Length())
+		t.Logf("len(got): %d, ct(got): %s", got.Length(), got.CoordinatesType())
 		for i := 0; i < got.Length(); i++ {
 			t.Logf("got[%d]: %v", i, got.Get(i))
 		}
-		t.Logf("len(want): %d", want.Length())
+		t.Logf("len(want): %d, ct(want): %s", want.Length(), want.CoordinatesType())
 		for i := 0; i < want.Length(); i++ {
 			t.Logf("want[%d]: %v", i, want.Get(i))
 		}
 	}
+	if got.CoordinatesType() != want.CoordinatesType() {
+		t.Errorf("mismatched coordinate type")
+		show()
+		return
+	}
 	if got.Length() != want.Length() {
-		t.Errorf("length mismatch: got=%d want=%d", got.Length(), want.Length())
+		t.Errorf("length mismatch")
 		show()
 		return
 	}


### PR DESCRIPTION
## Description

Adds `DumpCoordinates` methods on geometry types. These methods give back a
`Sequence` that contains all points in the geometry.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- Part of https://github.com/peterstace/simplefeatures/issues/378

## Benchmark Results

N/A