### PR TITLE
Collapse Point Constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Encoding and decoding WKB directly:
 
 ```go
 // Marshal as WKB
-pt := geom.NewPointFromXY(geom.XY{1.5, 2.5})
+coords := geom.OptionalCoordinates{XY: geom.XY{1.5, 2.5}}
+pt := geom.NewPoint(coords)
 wkb := pt.AsBinary()
 fmt.Println(wkb) // Prints: [1 1 0 0 0 0 0 0 0 0 0 248 63 0 0 0 0 0 0 4 64]
 
@@ -199,7 +200,8 @@ db.Exec(`
 )
 
 // Insert our geometry and population data into PostGIS via WKB.
-nyc := geom.NewPointFromXY(geom.XY{-74.0, 40.7})
+coords := geom.OptionalCoordinates{XY: geom.XY{-74.0, 40.7}}
+nyc := geom.NewPoint(coords)
 db.Exec(`
     INSERT INTO my_table
     (my_geom, population)

--- a/geom/accessor_test.go
+++ b/geom/accessor_test.go
@@ -25,10 +25,10 @@ func TestLineStringAccessor(t *testing.T) {
 	pt56 := xyCoords(5, 6)
 
 	t.Run("start", func(t *testing.T) {
-		expectGeomEq(t, ls.StartPoint().AsGeometry(), NewPoint(pt12).AsGeometry())
+		expectGeomEq(t, ls.StartPoint().AsGeometry(), NewPoint(pt12.AsOptionalCoordinates()).AsGeometry())
 	})
 	t.Run("end", func(t *testing.T) {
-		expectGeomEq(t, ls.EndPoint().AsGeometry(), NewPoint(pt56).AsGeometry())
+		expectGeomEq(t, ls.EndPoint().AsGeometry(), NewPoint(pt56.AsOptionalCoordinates()).AsGeometry())
 	})
 	t.Run("num points", func(t *testing.T) {
 		expectIntEq(t, seq.Length(), 3)

--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -17,7 +17,7 @@ func convexHull(g Geometry) Geometry {
 
 	// Check for point case:
 	if !hasAtLeast2DistinctPointsInXYs(pts) {
-		return NewPointFromXY(pts[0]).AsGeometry()
+		return pts[0].AsPoint().AsGeometry()
 	}
 
 	hull := monotoneChain(pts)

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -16,9 +16,9 @@ func intersectionOfIndexedLines(
 				return nil
 			}
 			if inter.ptA == inter.ptB {
-				if pt := inter.ptA; !seen[pt] {
-					pts = append(pts, NewPointFromXY(pt))
-					seen[pt] = true
+				if xy := inter.ptA; !seen[xy] {
+					pts = append(pts, xy.AsPoint())
+					seen[xy] = true
 				}
 			} else {
 				lss = append(lss, line{inter.ptA, inter.ptB}.asLineString())
@@ -41,7 +41,7 @@ func intersectionOfMultiPointAndMultiPoint(mp1, mp2 MultiPoint) MultiPoint {
 	for i := 0; i < mp2.NumPoints(); i++ {
 		xy, ok := mp2.PointN(i).XY()
 		if ok && inMP1[xy] {
-			pts = append(pts, NewPointFromXY(xy))
+			pts = append(pts, xy.AsPoint())
 		}
 	}
 	return NewMultiPoint(pts)

--- a/geom/alg_point_on_surface.go
+++ b/geom/alg_point_on_surface.go
@@ -127,7 +127,7 @@ func pointOnAreaSurface(poly Polygon) (Point, float64) {
 	}
 	midX := (bestA + bestB) / 2
 
-	return NewPointFromXY(XY{midX, midY}), bestB - bestA
+	return XY{midX, midY}.AsPoint(), bestB - bestA
 }
 
 func sortAndUniquifyFloats(fs []float64) []float64 {

--- a/geom/coordinate_type.go
+++ b/geom/coordinate_type.go
@@ -7,6 +7,8 @@ import "fmt"
 // coordinates. It may optionally include a Z value, representing height. It
 // may also optionally include an M value, traditionally representing an
 // arbitrary user defined measurement associated with each point location.
+//
+// The zero value of CoordinatesType is DimXY.
 type CoordinatesType byte
 
 const (

--- a/geom/dcel_extract.go
+++ b/geom/dcel_extract.go
@@ -31,11 +31,11 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]label) bool) (
 		return NewMultiLineStringFromLineStrings(linears).AsGeometry(), nil
 	case len(areals) == 0 && len(linears) == 0 && len(points) > 0:
 		if len(points) == 1 {
-			return NewPointFromXY(points[0]).AsGeometry(), nil
+			return points[0].AsPoint().AsGeometry(), nil
 		}
 		pts := make([]Point, len(points))
 		for i, xy := range points {
-			pts[i] = NewPointFromXY(xy)
+			pts[i] = xy.AsPoint()
 		}
 		return NewMultiPoint(pts).AsGeometry(), nil
 	default:
@@ -47,7 +47,7 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]label) bool) (
 			geoms = append(geoms, ls.AsGeometry())
 		}
 		for _, xy := range points {
-			geoms = append(geoms, NewPointFromXY(xy).AsGeometry())
+			geoms = append(geoms, xy.AsPoint().AsGeometry())
 		}
 		return NewGeometryCollection(geoms).AsGeometry(), nil
 	}

--- a/geom/dcel_interaction_points_test.go
+++ b/geom/dcel_interaction_points_test.go
@@ -153,7 +153,7 @@ func TestFindInteractionPoints(t *testing.T) {
 			gotXYs := findInteractionPoints(inputs)
 			var gotPoints []Point
 			for xy := range gotXYs {
-				gotPoints = append(gotPoints, NewPointFromXY(xy))
+				gotPoints = append(gotPoints, xy.AsPoint())
 			}
 			got := NewMultiPoint(gotPoints).AsGeometry()
 

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -104,8 +104,8 @@ func BenchmarkIntersectsMultiPointWithMultiPoint(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
 			var pointsA, pointsB []Point
 			for i := 0; i < sz; i++ {
-				pointsA = append(pointsA, NewPointFromXY(XY{X: rnd.Float64(), Y: rnd.Float64()}))
-				pointsB = append(pointsB, NewPointFromXY(XY{X: rnd.Float64(), Y: rnd.Float64()}))
+				pointsA = append(pointsA, XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint())
+				pointsB = append(pointsB, XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint())
 			}
 			mpA := NewMultiPoint(pointsA).AsGeometry()
 			mpB := NewMultiPoint(pointsB).AsGeometry()

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -5,20 +5,17 @@ import (
 	"strings"
 )
 
-// Coordinates represents a point location. Coordinates values may be
-// constructed manually using the type definition directly. Alternatively, one
-// of the New(XYZM)Coordinates constructor functions can be used.
+// Coordinates represents a point location.
 type Coordinates struct {
 	// XY represents the XY position of the point location.
 	XY
 
-	// Z represents the height of the location. Its value is zero
-	// for non-3D coordinate types.
+	// Z represents the height of the location. It's ignored for non-3D
+	// coordinate types.
 	Z float64
 
-	// M represents a user defined measure associated with the
-	// location. Its value is zero for non-measure coordinate
-	// types.
+	// M represents a user defined measure associated with the location. It's
+	// ignored for non-measure coordinate types.
 	M float64
 
 	// Type indicates the coordinates type, and therefore whether

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -23,6 +23,18 @@ type Coordinates struct {
 	Type CoordinatesType
 }
 
+// AsOptionalCoordinates is a convenience method to convert this set of
+// Coordinates into a populated set of OptionalCoordinates.
+func (c Coordinates) AsOptionalCoordinates() OptionalCoordinates {
+	return OptionalCoordinates{
+		Type:  c.Type,
+		Empty: false,
+		XY:    c.XY,
+		Z:     c.Z,
+		M:     c.M,
+	}
+}
+
 // String gives a string representation of the coordinates.
 func (c Coordinates) String() string {
 	var sb strings.Builder

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -56,7 +56,7 @@ func EnvelopeFromGeoms(geoms ...Geometry) (Envelope, bool) {
 // LineString or Point geometry is returned.
 func (e Envelope) AsGeometry() Geometry {
 	if e.min == e.max {
-		return NewPointFromXY(e.min).AsGeometry()
+		return e.min.AsPoint().AsGeometry()
 	}
 
 	if e.min.X == e.max.X || e.min.Y == e.max.Y {

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -287,7 +287,7 @@ func highestDimensionIgnoreEmpties(g Geometry) int {
 // Centroid of a GeometryCollection is the centroid of its parts' centroids.
 func (c GeometryCollection) Centroid() Point {
 	if c.IsEmpty() {
-		return NewEmptyPoint(DimXY)
+		return Point{}
 	}
 	switch highestDimensionIgnoreEmpties(c.AsGeometry()) {
 	case 0:
@@ -325,7 +325,7 @@ func (c GeometryCollection) pointCentroid() Point {
 			}
 		}
 	})
-	return NewPointFromXY(sumPoints.Scale(1 / float64(numPoints)))
+	return sumPoints.Scale(1 / float64(numPoints)).AsPoint()
 }
 
 func (c GeometryCollection) linearCentroid() Point {
@@ -356,7 +356,7 @@ func (c GeometryCollection) linearCentroid() Point {
 			}
 		}
 	})
-	return NewPointFromXY(weightedCentroid.Scale(1 / lengthSum))
+	return weightedCentroid.Scale(1 / lengthSum).AsPoint()
 }
 
 func (c GeometryCollection) arealCentroid() Point {
@@ -379,7 +379,7 @@ func (c GeometryCollection) arealCentroid() Point {
 				centroid.Scale(area / areaSum))
 		}
 	})
-	return NewPointFromXY(weightedCentroid)
+	return weightedCentroid.AsPoint()
 }
 
 // CoordinatesType returns the CoordinatesType used to represent points making

--- a/geom/type_geometry_test.go
+++ b/geom/type_geometry_test.go
@@ -21,7 +21,7 @@ func TestZeroGeometry(t *testing.T) {
 	expectNoErr(t, err)
 	expectStringEq(t, strings.TrimSpace(buf.String()), `{"type":"GeometryCollection","geometries":[]}`)
 
-	z = NewPointFromXY(XY{1, 2}).AsGeometry() // Set away from zero value
+	z = XY{1, 2}.AsPoint().AsGeometry() // Set away from zero value
 	expectBoolEq(t, z.IsPoint(), true)
 	err = json.NewDecoder(&buf).Decode(&z)
 	expectNoErr(t, err)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -70,18 +70,20 @@ func (s LineString) AsGeometry() Geometry {
 // empty then it returns the empty Point.
 func (s LineString) StartPoint() Point {
 	if s.IsEmpty() {
-		return NewEmptyPoint(s.CoordinatesType())
+		return Point{}.ForceCoordinatesType(s.CoordinatesType())
 	}
-	return NewPoint(s.seq.Get(0))
+	coords := s.seq.Get(0).AsOptionalCoordinates()
+	return NewPoint(coords)
 }
 
 // EndPoint gives the last point of the LineString. If the LineString is empty
 // then it returns the empty Point.
 func (s LineString) EndPoint() Point {
 	if s.IsEmpty() {
-		return NewEmptyPoint(s.CoordinatesType())
+		return Point{}.ForceCoordinatesType(s.CoordinatesType())
 	}
-	return NewPoint(s.seq.Get(s.seq.Length() - 1))
+	coords := s.seq.Get(s.seq.Length() - 1).AsOptionalCoordinates()
+	return NewPoint(coords)
 }
 
 // AsText returns the WKT (Well Known Text) representation of this geometry.
@@ -321,9 +323,9 @@ func (s LineString) Length() float64 {
 func (s LineString) Centroid() Point {
 	sumXY, sumLength := sumCentroidAndLengthOfLineString(s)
 	if sumLength == 0 {
-		return NewEmptyPoint(DimXY)
+		return Point{}
 	}
-	return NewPointFromXY(sumXY.Scale(1.0 / sumLength))
+	return sumXY.Scale(1.0 / sumLength).AsPoint()
 }
 
 func sumCentroidAndLengthOfLineString(s LineString) (sumXY XY, sumLength float64) {
@@ -388,7 +390,7 @@ func (s LineString) PointOnSurface() Point {
 	n := s.seq.Length()
 	nearest := newNearestPointAccumulator(s.Centroid())
 	for i := 1; i < n-1; i++ {
-		candidate := NewPointFromXY(s.seq.GetXY(i))
+		candidate := s.seq.GetXY(i).AsPoint()
 		nearest.consider(candidate)
 	}
 	if !nearest.point.IsEmpty() {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -167,7 +167,7 @@ func (m MultiLineString) IsSimple() bool {
 					return rtree.Stop
 				}
 				boundary := intersectionOfMultiPointAndMultiPoint(ls.Boundary(), otherLS.Boundary())
-				if !hasIntersectionPointWithMultiPoint(NewPointFromXY(inter.ptA), boundary) {
+				if !hasIntersectionPointWithMultiPoint(inter.ptA.AsPoint(), boundary) {
 					isSimple = false
 					return rtree.Stop
 				}
@@ -356,9 +356,9 @@ func (m MultiLineString) Centroid() Point {
 		sumLength += length
 	}
 	if sumLength == 0 {
-		return NewEmptyPoint(DimXY)
+		return Point{}
 	}
-	return NewPointFromXY(sumXY.Scale(1.0 / sumLength))
+	return sumXY.Scale(1.0 / sumLength).AsPoint()
 }
 
 // Reverse in the case of MultiLineString outputs each component line string in their
@@ -422,7 +422,7 @@ func (m MultiLineString) PointOnSurface() Point {
 		seq := m.LineStringN(i).Coordinates()
 		n := seq.Length()
 		for j := 1; j < n-1; j++ {
-			candidate := NewPointFromXY(seq.GetXY(j))
+			candidate := seq.GetXY(j).AsPoint()
 			nearest.consider(candidate)
 		}
 	}

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -212,7 +212,8 @@ func (m MultiPoint) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Mult
 	for i, pt := range m.points {
 		if c, ok := pt.Coordinates(); ok {
 			c.XY = fn(c.XY)
-			txPoints[i] = NewPoint(c, opts...)
+			oc := c.AsOptionalCoordinates()
+			txPoints[i] = NewPoint(oc, opts...)
 		} else {
 			txPoints[i] = pt
 		}
@@ -232,9 +233,9 @@ func (m MultiPoint) Centroid() Point {
 		}
 	}
 	if n == 0 {
-		return NewEmptyPoint(DimXY)
+		return Point{}
 	}
-	return NewPointFromXY(sum.Scale(1 / float64(n)))
+	return sum.Scale(1 / float64(n)).AsPoint()
 }
 
 // Reverse in the case of MultiPoint outputs each component point in their

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -168,8 +168,8 @@ func validatePolyNotInsidePoly(p1, p2 indexedLines) error {
 		for k := 0; k+1 < len(pts); k++ {
 			midpoint := pts[k].Add(pts[k+1]).Scale(0.5)
 			if relatePointToPolygon(midpoint, p1) == interior {
-				return validationError{fmt.Sprintf("multipolygon child polygon "+
-					"interiors intersect at %s", NewPointFromXY(midpoint).AsText())}
+				msg := fmt.Sprintf("multipolygon child polygon interiors intersect at %v", midpoint)
+				return validationError{msg}
 			}
 		}
 	}
@@ -366,7 +366,7 @@ func (m MultiPolygon) Area(opts ...AreaOption) float64 {
 // Point if the multi polygon is empty.
 func (m MultiPolygon) Centroid() Point {
 	if m.IsEmpty() {
-		return NewEmptyPoint(DimXY)
+		return Point{}
 	}
 
 	areas := make([]float64, m.NumPolygons())
@@ -384,7 +384,7 @@ func (m MultiPolygon) Centroid() Point {
 			weightedCentroid = weightedCentroid.Add(centroid.Scale(areas[i] / totalArea))
 		}
 	}
-	return NewPointFromXY(weightedCentroid)
+	return weightedCentroid.AsPoint()
 }
 
 // Reverse in the case of MultiPolygon outputs the component polygons in their original order,

--- a/geom/type_optional_coordinates.go
+++ b/geom/type_optional_coordinates.go
@@ -8,8 +8,8 @@ import (
 // OptionalCoordinates represent a point location that may be empty.
 type OptionalCoordinates struct {
 	// Type indicates the coordinates type, and therefore whether or not Z and
-	// M are populated. Type has semantic meaning even if the coordinates are
-	// empty.
+	// M are populated. Type must be populated even when the coordinates are
+	// empty (i.e. empty coordinates have a well defined type).
 	Type CoordinatesType
 
 	// Empty indicates if the coordinates are empty or not.

--- a/geom/type_optional_coordinates.go
+++ b/geom/type_optional_coordinates.go
@@ -1,0 +1,53 @@
+package geom
+
+import (
+	"strconv"
+	"strings"
+)
+
+// OptionalCoordinates represent a point location that may be empty.
+type OptionalCoordinates struct {
+	// Type indicates the coordinates type, and therefore whether or not Z and
+	// M are populated. Type has semantic meaning even if the coordinates are
+	// empty.
+	Type CoordinatesType
+
+	// Empty indicates if the coordinates are empty or not.
+	Empty bool
+
+	// XY represents the XY position of the point location. It's ignored for
+	// empty coordinates.
+	XY
+
+	// Z represents the height of the location. It's ignored for empty or
+	// non-3D coordinate types.
+	Z float64
+
+	// M represents a user defined measure associated with the location. It's
+	// ignored for empty or non-measure coordinate types.
+	M float64
+}
+
+// String gives a string representation of the optional coordinates.
+func (c OptionalCoordinates) String() string {
+	var sb strings.Builder
+	sb.WriteString("OptionalCoordinates[")
+	sb.WriteString(c.Type.String())
+	sb.WriteString("] ")
+	if c.Empty {
+		sb.WriteString("EMPTY")
+		return sb.String()
+	}
+	sb.WriteString(strconv.FormatFloat(c.X, 'f', -1, 64))
+	sb.WriteRune(' ')
+	sb.WriteString(strconv.FormatFloat(c.Y, 'f', -1, 64))
+	if c.Type.Is3D() {
+		sb.WriteRune(' ')
+		sb.WriteString(strconv.FormatFloat(c.Z, 'f', -1, 64))
+	}
+	if c.Type.IsMeasured() {
+		sb.WriteRune(' ')
+		sb.WriteString(strconv.FormatFloat(c.M, 'f', -1, 64))
+	}
+	return sb.String()
+}

--- a/geom/type_optional_coordinates_test.go
+++ b/geom/type_optional_coordinates_test.go
@@ -1,0 +1,57 @@
+package geom_test
+
+import (
+	"strconv"
+	"testing"
+
+	. "github.com/peterstace/simplefeatures/geom"
+)
+
+func TestOptionalCoordinatesString(t *testing.T) {
+	for i, tc := range []struct {
+		input OptionalCoordinates
+		want  string
+	}{
+		{
+			OptionalCoordinates{},
+			"OptionalCoordinates[XY] 0 0",
+		},
+		{
+			OptionalCoordinates{Type: DimXY, XY: XY{X: 1, Y: 2}},
+			"OptionalCoordinates[XY] 1 2",
+		},
+		{
+			OptionalCoordinates{Type: DimXYZ, XY: XY{X: 1, Y: 2}, Z: 3},
+			"OptionalCoordinates[XYZ] 1 2 3",
+		},
+		{
+			OptionalCoordinates{Type: DimXYM, XY: XY{X: 1, Y: 2}, M: 3},
+			"OptionalCoordinates[XYM] 1 2 3",
+		},
+		{
+			OptionalCoordinates{Type: DimXYZM, XY: XY{X: 1, Y: 2}, Z: 3, M: 4},
+			"OptionalCoordinates[XYZM] 1 2 3 4",
+		},
+		{
+			OptionalCoordinates{Type: DimXY, Empty: true},
+			"OptionalCoordinates[XY] EMPTY",
+		},
+		{
+			OptionalCoordinates{Type: DimXYZ, Empty: true},
+			"OptionalCoordinates[XYZ] EMPTY",
+		},
+		{
+			OptionalCoordinates{Type: DimXYM, Empty: true},
+			"OptionalCoordinates[XYM] EMPTY",
+		},
+		{
+			OptionalCoordinates{Type: DimXYZM, Empty: true},
+			"OptionalCoordinates[XYZM] EMPTY",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := tc.input.String()
+			expectStringEq(t, got, tc.want)
+		})
+	}
+}

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -19,18 +19,9 @@ type Point struct {
 }
 
 // NewPoint creates a new point gives its Coordinates.
-func NewPoint(c Coordinates, _ ...ConstructorOption) Point {
-	return Point{c, true}
-}
-
-// NewEmptyPoint creates a Point that is empty.
-func NewEmptyPoint(ctype CoordinatesType) Point {
-	return Point{Coordinates{Type: ctype}, false}
-}
-
-// NewPointFromXY creates a new point from an XY.
-func NewPointFromXY(xy XY, _ ...ConstructorOption) Point {
-	return Point{Coordinates{XY: xy, Type: DimXY}, true}
+func NewPoint(oc OptionalCoordinates, _ ...ConstructorOption) Point {
+	c := Coordinates{oc.XY, oc.Z, oc.M, oc.Type}
+	return Point{c, !oc.Empty}
 }
 
 // Type returns the GeometryType for a Point
@@ -168,7 +159,8 @@ func (p Point) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Point, er
 	}
 	newC := p.coords
 	newC.XY = fn(newC.XY)
-	return NewPoint(newC, opts...), nil
+	newOC := newC.AsOptionalCoordinates()
+	return NewPoint(newOC, opts...), nil
 }
 
 // Centroid of a point is that point.
@@ -196,7 +188,7 @@ func (p Point) CoordinatesType() CoordinatesType {
 // is added, then new values are populated with 0.
 func (p Point) ForceCoordinatesType(newCType CoordinatesType) Point {
 	if !p.full {
-		return NewEmptyPoint(newCType)
+		return Point{coords: Coordinates{Type: newCType}}
 	}
 	if newCType.Is3D() != p.coords.Type.Is3D() {
 		p.coords.Z = 0

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -409,7 +409,7 @@ func signedAreaOfLinearRing(lr LineString, transform func(XY) XY) float64 {
 // the Polygon is empty.
 func (p Polygon) Centroid() Point {
 	if p.IsEmpty() {
-		return NewEmptyPoint(DimXY)
+		return Point{}
 	}
 
 	// The basis of this approach is taken from:
@@ -431,7 +431,7 @@ func (p Polygon) Centroid() Point {
 		centroid = centroid.Add(
 			weightedCentroid(p.InteriorRingN(i), areas[i+1], sumAreas))
 	}
-	return NewPointFromXY(centroid)
+	return centroid.AsPoint()
 }
 
 func weightedCentroid(ring LineString, ringArea, totalArea float64) XY {

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -161,7 +161,7 @@ func (p *wkbParser) parseFloat64() (float64, error) {
 }
 
 func (p *wkbParser) parsePoint(ctype CoordinatesType) (Point, error) {
-	c := Coordinates{Type: ctype}
+	c := OptionalCoordinates{Type: ctype}
 	var err error
 	c.X, err = p.parseFloat64()
 	if err != nil {
@@ -187,7 +187,10 @@ func (p *wkbParser) parsePoint(ctype CoordinatesType) (Point, error) {
 
 	if math.IsNaN(c.X) && math.IsNaN(c.Y) {
 		// Empty points are represented as NaN,NaN in WKB.
-		return Point{}.ForceCoordinatesType(ctype), nil
+		c.Empty = true
+		c.XY = XY{}
+		c.Z = 0
+		c.M = 0
 	}
 	if math.IsNaN(c.X) || math.IsNaN(c.Y) {
 		return Point{}, wkbSyntaxError{"point contains mixed NaN values"}

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -187,10 +187,7 @@ func (p *wkbParser) parsePoint(ctype CoordinatesType) (Point, error) {
 
 	if math.IsNaN(c.X) && math.IsNaN(c.Y) {
 		// Empty points are represented as NaN,NaN in WKB.
-		c.Empty = true
-		c.XY = XY{}
-		c.Z = 0
-		c.M = 0
+		c = OptionalCoordinates{Type: ctype, Empty: true}
 	}
 	if math.IsNaN(c.X) || math.IsNaN(c.Y) {
 		return Point{}, wkbSyntaxError{"point contains mixed NaN values"}

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -12,6 +12,12 @@ type XY struct {
 	X, Y float64
 }
 
+// AsPoint is a convenience function to the XY value into a Point
+// geometry.
+func (w XY) AsPoint() Point {
+	return NewPoint(OptionalCoordinates{XY: w})
+}
+
 // Sub returns the result of subtracting the other XY from this XY (in the same
 // manner as vector subtraction).
 func (w XY) Sub(o XY) XY {

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -12,7 +12,7 @@ type XY struct {
 	X, Y float64
 }
 
-// AsPoint is a convenience function to the XY value into a Point
+// AsPoint is a convenience function to convert this XY value into a Point
 // geometry.
 func (w XY) AsPoint() Point {
 	return NewPoint(OptionalCoordinates{XY: w})

--- a/internal/cmprefimpl/cmpgeos/handle.go
+++ b/internal/cmprefimpl/cmpgeos/handle.go
@@ -261,7 +261,7 @@ func (h *Handle) decodeGeomHandle(gh *C.GEOSGeometry) (geom.Geometry, error) {
 			return geom.Geometry{}, err
 		}
 		if isEmpty {
-			return geom.NewEmptyPoint(geom.DimXY).AsGeometry(), nil
+			return geom.Point{}.AsGeometry(), nil
 		}
 		return h.decodeGeomHandleUsingWKB(gh)
 	case "MultiPoint":
@@ -280,7 +280,7 @@ func (h *Handle) decodeGeomHandle(gh *C.GEOSGeometry) (geom.Geometry, error) {
 				return geom.Geometry{}, err
 			}
 			if isEmpty {
-				subPoints[i] = geom.NewEmptyPoint(geom.DimXY)
+				subPoints[i] = geom.Point{}
 			} else {
 				subPointAsGeom, err := h.decodeGeomHandleUsingWKB(sub)
 				if err != nil {

--- a/internal/cmprefimpl/cmpgeos/util_test.go
+++ b/internal/cmprefimpl/cmpgeos/util_test.go
@@ -25,7 +25,7 @@ func TestMantissaTerminatesQuickly(t *testing.T) {
 		{math.Pi, false},
 	} {
 		t.Run(fmt.Sprintf("%v", tt.f), func(t *testing.T) {
-			pt := geom.NewPointFromXY(geom.XY{X: tt.f, Y: tt.f}).AsGeometry()
+			pt := geom.XY{X: tt.f, Y: tt.f}.AsPoint().AsGeometry()
 			got := mantissaTerminatesQuickly(pt)
 			if got != tt.want {
 				t.Errorf("got=%v want=%v", got, tt.want)


### PR DESCRIPTION
## Description

- Collapses the 3 point constructor functions (`NewEmptyPoint`, `NewPoint`, and
  `NewPointFromXY`) into a single constructor function.

- Introduce a new `OptionalCoordinates` type, which represents coordinates that
  may or may not be empty. This is used in the new point constructor.

## Check List

Have you:

- Added unit tests? Relies on existing (and updated) unit tests.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

Fixes https://github.com/peterstace/simplefeatures/issues/402

## Benchmark Results

N/A