### PR TITLE
Remove `NewPointFromXY` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Encoding and decoding WKB directly:
 
 ```go
 // Marshal as WKB
-pt := geom.NewPointFromXY(geom.XY{1.5, 2.5})
+coords := geom.Coordinates{XY: geom.XY{1.5, 2.5}}
+pt := geom.NewPoint(coords)
 wkb := pt.AsBinary()
 fmt.Println(wkb) // Prints: [1 1 0 0 0 0 0 0 0 0 0 248 63 0 0 0 0 0 0 4 64]
 
@@ -199,7 +200,8 @@ db.Exec(`
 )
 
 // Insert our geometry and population data into PostGIS via WKB.
-nyc := geom.NewPointFromXY(geom.XY{-74.0, 40.7})
+coords := geom.Coordinates{XY: geom.XY{-74.0, 40.7}}
+nyc := geom.NewPoint(coords)
 db.Exec(`
     INSERT INTO my_table
     (my_geom, population)

--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -17,7 +17,7 @@ func convexHull(g Geometry) Geometry {
 
 	// Check for point case:
 	if !hasAtLeast2DistinctPointsInXYs(pts) {
-		return NewPointFromXY(pts[0]).AsGeometry()
+		return pts[0].AsPoint().AsGeometry()
 	}
 
 	hull := monotoneChain(pts)

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -17,7 +17,7 @@ func intersectionOfIndexedLines(
 			}
 			if inter.ptA == inter.ptB {
 				if pt := inter.ptA; !seen[pt] {
-					pts = append(pts, NewPointFromXY(pt))
+					pts = append(pts, pt.AsPoint())
 					seen[pt] = true
 				}
 			} else {
@@ -41,7 +41,7 @@ func intersectionOfMultiPointAndMultiPoint(mp1, mp2 MultiPoint) MultiPoint {
 	for i := 0; i < mp2.NumPoints(); i++ {
 		xy, ok := mp2.PointN(i).XY()
 		if ok && inMP1[xy] {
-			pts = append(pts, NewPointFromXY(xy))
+			pts = append(pts, xy.AsPoint())
 		}
 	}
 	return NewMultiPoint(pts)

--- a/geom/alg_point_on_surface.go
+++ b/geom/alg_point_on_surface.go
@@ -127,7 +127,7 @@ func pointOnAreaSurface(poly Polygon) (Point, float64) {
 	}
 	midX := (bestA + bestB) / 2
 
-	return NewPointFromXY(XY{midX, midY}), bestB - bestA
+	return XY{midX, midY}.AsPoint(), bestB - bestA
 }
 
 func sortAndUniquifyFloats(fs []float64) []float64 {

--- a/geom/dcel_extract.go
+++ b/geom/dcel_extract.go
@@ -31,11 +31,11 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]label) bool) (
 		return NewMultiLineStringFromLineStrings(linears).AsGeometry(), nil
 	case len(areals) == 0 && len(linears) == 0 && len(points) > 0:
 		if len(points) == 1 {
-			return NewPointFromXY(points[0]).AsGeometry(), nil
+			return points[0].AsPoint().AsGeometry(), nil
 		}
 		pts := make([]Point, len(points))
 		for i, xy := range points {
-			pts[i] = NewPointFromXY(xy)
+			pts[i] = xy.AsPoint()
 		}
 		return NewMultiPoint(pts).AsGeometry(), nil
 	default:
@@ -47,7 +47,7 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]label) bool) (
 			geoms = append(geoms, ls.AsGeometry())
 		}
 		for _, xy := range points {
-			geoms = append(geoms, NewPointFromXY(xy).AsGeometry())
+			geoms = append(geoms, xy.AsPoint().AsGeometry())
 		}
 		return NewGeometryCollection(geoms).AsGeometry(), nil
 	}

--- a/geom/dcel_interaction_points_test.go
+++ b/geom/dcel_interaction_points_test.go
@@ -153,7 +153,7 @@ func TestFindInteractionPoints(t *testing.T) {
 			gotXYs := findInteractionPoints(inputs)
 			var gotPoints []Point
 			for xy := range gotXYs {
-				gotPoints = append(gotPoints, NewPointFromXY(xy))
+				gotPoints = append(gotPoints, xy.AsPoint())
 			}
 			got := NewMultiPoint(gotPoints).AsGeometry()
 

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -104,8 +104,8 @@ func BenchmarkIntersectsMultiPointWithMultiPoint(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
 			var pointsA, pointsB []Point
 			for i := 0; i < sz; i++ {
-				pointsA = append(pointsA, NewPointFromXY(XY{X: rnd.Float64(), Y: rnd.Float64()}))
-				pointsB = append(pointsB, NewPointFromXY(XY{X: rnd.Float64(), Y: rnd.Float64()}))
+				pointsA = append(pointsA, XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint())
+				pointsB = append(pointsB, XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint())
 			}
 			mpA := NewMultiPoint(pointsA).AsGeometry()
 			mpB := NewMultiPoint(pointsB).AsGeometry()

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -56,7 +56,7 @@ func EnvelopeFromGeoms(geoms ...Geometry) (Envelope, bool) {
 // LineString or Point geometry is returned.
 func (e Envelope) AsGeometry() Geometry {
 	if e.min == e.max {
-		return NewPointFromXY(e.min).AsGeometry()
+		return e.min.AsPoint().AsGeometry()
 	}
 
 	if e.min.X == e.max.X || e.min.Y == e.max.Y {

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -325,7 +325,7 @@ func (c GeometryCollection) pointCentroid() Point {
 			}
 		}
 	})
-	return NewPointFromXY(sumPoints.Scale(1 / float64(numPoints)))
+	return sumPoints.Scale(1 / float64(numPoints)).AsPoint()
 }
 
 func (c GeometryCollection) linearCentroid() Point {
@@ -356,7 +356,7 @@ func (c GeometryCollection) linearCentroid() Point {
 			}
 		}
 	})
-	return NewPointFromXY(weightedCentroid.Scale(1 / lengthSum))
+	return weightedCentroid.Scale(1 / lengthSum).AsPoint()
 }
 
 func (c GeometryCollection) arealCentroid() Point {
@@ -379,7 +379,7 @@ func (c GeometryCollection) arealCentroid() Point {
 				centroid.Scale(area / areaSum))
 		}
 	})
-	return NewPointFromXY(weightedCentroid)
+	return weightedCentroid.AsPoint()
 }
 
 // CoordinatesType returns the CoordinatesType used to represent points making

--- a/geom/type_geometry_test.go
+++ b/geom/type_geometry_test.go
@@ -21,7 +21,7 @@ func TestZeroGeometry(t *testing.T) {
 	expectNoErr(t, err)
 	expectStringEq(t, strings.TrimSpace(buf.String()), `{"type":"GeometryCollection","geometries":[]}`)
 
-	z = NewPointFromXY(XY{1, 2}).AsGeometry() // Set away from zero value
+	z = XY{1, 2}.AsPoint().AsGeometry() // Set away from zero value
 	expectBoolEq(t, z.IsPoint(), true)
 	err = json.NewDecoder(&buf).Decode(&z)
 	expectNoErr(t, err)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -323,7 +323,7 @@ func (s LineString) Centroid() Point {
 	if sumLength == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return NewPointFromXY(sumXY.Scale(1.0 / sumLength))
+	return sumXY.Scale(1.0 / sumLength).AsPoint()
 }
 
 func sumCentroidAndLengthOfLineString(s LineString) (sumXY XY, sumLength float64) {
@@ -388,7 +388,7 @@ func (s LineString) PointOnSurface() Point {
 	n := s.seq.Length()
 	nearest := newNearestPointAccumulator(s.Centroid())
 	for i := 1; i < n-1; i++ {
-		candidate := NewPointFromXY(s.seq.GetXY(i))
+		candidate := s.seq.GetXY(i).AsPoint()
 		nearest.consider(candidate)
 	}
 	if !nearest.point.IsEmpty() {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -167,7 +167,7 @@ func (m MultiLineString) IsSimple() bool {
 					return rtree.Stop
 				}
 				boundary := intersectionOfMultiPointAndMultiPoint(ls.Boundary(), otherLS.Boundary())
-				if !hasIntersectionPointWithMultiPoint(NewPointFromXY(inter.ptA), boundary) {
+				if !hasIntersectionPointWithMultiPoint(inter.ptA.AsPoint(), boundary) {
 					isSimple = false
 					return rtree.Stop
 				}
@@ -358,7 +358,7 @@ func (m MultiLineString) Centroid() Point {
 	if sumLength == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return NewPointFromXY(sumXY.Scale(1.0 / sumLength))
+	return sumXY.Scale(1.0 / sumLength).AsPoint()
 }
 
 // Reverse in the case of MultiLineString outputs each component line string in their
@@ -422,7 +422,7 @@ func (m MultiLineString) PointOnSurface() Point {
 		seq := m.LineStringN(i).Coordinates()
 		n := seq.Length()
 		for j := 1; j < n-1; j++ {
-			candidate := NewPointFromXY(seq.GetXY(j))
+			candidate := seq.GetXY(j).AsPoint()
 			nearest.consider(candidate)
 		}
 	}

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -234,7 +234,7 @@ func (m MultiPoint) Centroid() Point {
 	if n == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return NewPointFromXY(sum.Scale(1 / float64(n)))
+	return sum.Scale(1 / float64(n)).AsPoint()
 }
 
 // Reverse in the case of MultiPoint outputs each component point in their

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -169,7 +169,7 @@ func validatePolyNotInsidePoly(p1, p2 indexedLines) error {
 			midpoint := pts[k].Add(pts[k+1]).Scale(0.5)
 			if relatePointToPolygon(midpoint, p1) == interior {
 				return validationError{fmt.Sprintf("multipolygon child polygon "+
-					"interiors intersect at %s", NewPointFromXY(midpoint).AsText())}
+					"interiors intersect at %s", midpoint.AsPoint().AsText())}
 			}
 		}
 	}
@@ -384,7 +384,7 @@ func (m MultiPolygon) Centroid() Point {
 			weightedCentroid = weightedCentroid.Add(centroid.Scale(areas[i] / totalArea))
 		}
 	}
-	return NewPointFromXY(weightedCentroid)
+	return weightedCentroid.AsPoint()
 }
 
 // Reverse in the case of MultiPolygon outputs the component polygons in their original order,

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -28,11 +28,6 @@ func NewEmptyPoint(ctype CoordinatesType) Point {
 	return Point{Coordinates{Type: ctype}, false}
 }
 
-// NewPointFromXY creates a new point from an XY.
-func NewPointFromXY(xy XY, _ ...ConstructorOption) Point {
-	return Point{Coordinates{XY: xy, Type: DimXY}, true}
-}
-
 // Type returns the GeometryType for a Point
 func (p Point) Type() GeometryType {
 	return TypePoint

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -431,7 +431,7 @@ func (p Polygon) Centroid() Point {
 		centroid = centroid.Add(
 			weightedCentroid(p.InteriorRingN(i), areas[i+1], sumAreas))
 	}
-	return NewPointFromXY(centroid)
+	return centroid.AsPoint()
 }
 
 func weightedCentroid(ring LineString, ringArea, totalArea float64) XY {

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -12,6 +12,12 @@ type XY struct {
 	X, Y float64
 }
 
+// AsPoint is a convenience function to convert this XY value into a Point
+// geometry.
+func (w XY) AsPoint() Point {
+	return NewPoint(Coordinates{XY: w, Type: DimXY})
+}
+
 // Sub returns the result of subtracting the other XY from this XY (in the same
 // manner as vector subtraction).
 func (w XY) Sub(o XY) XY {

--- a/internal/cmprefimpl/cmpgeos/util_test.go
+++ b/internal/cmprefimpl/cmpgeos/util_test.go
@@ -25,7 +25,7 @@ func TestMantissaTerminatesQuickly(t *testing.T) {
 		{math.Pi, false},
 	} {
 		t.Run(fmt.Sprintf("%v", tt.f), func(t *testing.T) {
-			pt := geom.NewPointFromXY(geom.XY{X: tt.f, Y: tt.f}).AsGeometry()
+			pt := geom.XY{X: tt.f, Y: tt.f}.AsPoint().AsGeometry()
 			got := mantissaTerminatesQuickly(pt)
 			if got != tt.want {
 				t.Errorf("got=%v want=%v", got, tt.want)


### PR DESCRIPTION
## Description

This constructor has too much redundancy with the `NewPoint` constructor.  The `NewPoint` constructor is now supplemented by a new `AsPoint` helper method on the `XY` type.

Note that the method signature of `AsPoint` and `NewPoint` will need to change to additionally return an error as part of https://github.com/peterstace/simplefeatures/issues/396 (so that will need to get done before the next tag).

## Check List

Have you:

- Added unit tests? N/A, relies on existing.

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

Part of https://github.com/peterstace/simplefeatures/issues/402, a less extreme alternative to the approach taken in PR https://github.com/peterstace/simplefeatures/pull/404

There is some discussion about this approach in this comment thread: https://github.com/peterstace/simplefeatures/pull/404#discussion_r687585264

## Benchmark Results

N/A