### PR TITLE
Use TB Interface For Test Helpers

### DIFF
--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/peterstace/simplefeatures/geom"
 )
 
-func geomFromWKT(t *testing.T, wkt string) Geometry {
+func geomFromWKT(t testing.TB, wkt string) Geometry {
 	t.Helper()
 	geom, err := UnmarshalWKT(wkt)
 	if err != nil {
@@ -17,7 +17,7 @@ func geomFromWKT(t *testing.T, wkt string) Geometry {
 	return geom
 }
 
-func geomsFromWKTs(t *testing.T, wkts []string) []Geometry {
+func geomsFromWKTs(t testing.TB, wkts []string) []Geometry {
 	t.Helper()
 	var gs []Geometry
 	for _, wkt := range wkts {
@@ -58,7 +58,7 @@ func upcastPolygons(ps []Polygon) []Geometry {
 	return gs
 }
 
-func expectPanics(t *testing.T, fn func()) {
+func expectPanics(t testing.TB, fn func()) {
 	t.Helper()
 	defer func() {
 		if r := recover(); r != nil {
@@ -69,28 +69,28 @@ func expectPanics(t *testing.T, fn func()) {
 	fn()
 }
 
-func expectNoErr(t *testing.T, err error) {
+func expectNoErr(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func expectErr(t *testing.T, err error) {
+func expectErr(t testing.TB, err error) {
 	t.Helper()
 	if err == nil {
 		t.Fatal("expected error but got nil")
 	}
 }
 
-func expectGeomEq(t *testing.T, got, want Geometry, opts ...ExactEqualsOption) {
+func expectGeomEq(t testing.TB, got, want Geometry, opts ...ExactEqualsOption) {
 	t.Helper()
 	if !ExactEquals(got, want, opts...) {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got.AsText(), want.AsText())
 	}
 }
 
-func expectGeomsEq(t *testing.T, got, want []Geometry, opts ...ExactEqualsOption) {
+func expectGeomsEq(t testing.TB, got, want []Geometry, opts ...ExactEqualsOption) {
 	t.Helper()
 	if len(got) != len(want) {
 		t.Errorf("\ngot:  len %d\nwant: len %d\n", len(got), len(want))
@@ -102,72 +102,72 @@ func expectGeomsEq(t *testing.T, got, want []Geometry, opts ...ExactEqualsOption
 	}
 }
 
-func expectCoordsEq(t *testing.T, got, want Coordinates) {
+func expectCoordsEq(t testing.TB, got, want Coordinates) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectStringEq(t *testing.T, got, want string) {
+func expectStringEq(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %q\nwant: %q\n", got, want)
 	}
 }
 
-func expectIntEq(t *testing.T, got, want int) {
+func expectIntEq(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %d\nwant: %d\n", got, want)
 	}
 }
 
-func expectBoolEq(t *testing.T, got, want bool) {
+func expectBoolEq(t testing.TB, got, want bool) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %t\nwant: %t\n", got, want)
 	}
 }
 
-func expectTrue(t *testing.T, got bool) {
+func expectTrue(t testing.TB, got bool) {
 	t.Helper()
 	expectBoolEq(t, got, true)
 }
 
-func expectFalse(t *testing.T, got bool) {
+func expectFalse(t testing.TB, got bool) {
 	t.Helper()
 	expectBoolEq(t, got, false)
 }
 
-func expectXYEq(t *testing.T, got, want XY) {
+func expectXYEq(t testing.TB, got, want XY) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
-func expectXYWithinTolerance(t *testing.T, got, want XY, tolerance float64) {
+func expectXYWithinTolerance(t testing.TB, got, want XY, tolerance float64) {
 	t.Helper()
 	if delta := math.Abs(got.Sub(want).Length()); delta > tolerance {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectCoordinatesTypeEq(t *testing.T, got, want CoordinatesType) {
+func expectCoordinatesTypeEq(t testing.TB, got, want CoordinatesType) {
 	t.Helper()
 	if got != want {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectBytesEq(t *testing.T, got, want []byte) {
+func expectBytesEq(t testing.TB, got, want []byte) {
 	t.Helper()
 	if !bytes.Equal(got, want) {
 		t.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectSequenceEq(t *testing.T, got, want Sequence) {
+func expectSequenceEq(t testing.TB, got, want Sequence) {
 	t.Helper()
 	show := func() {
 		t.Logf("len(got): %d, ct(got): %s", got.Length(), got.CoordinatesType())


### PR DESCRIPTION
## Description

These test helpers are useful for more than just unit tests. E.g. they can be used to verify that preliminary benchmark setup is correct. I needed this in a separate PR, but added it here instead since it's a fairly separate change.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

N/A