### PR TITLE
Rename Geometry Constructor Methods For Consistency

### DIFF
--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -40,7 +40,7 @@ func convexHull(g Geometry) Geometry {
 	if err != nil {
 		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid ring: %v", err))
 	}
-	poly, err := NewPolygonFromRings([]LineString{ring})
+	poly, err := NewPolygon([]LineString{ring})
 	if err != nil {
 		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid polygon: %v", err))
 	}

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -26,7 +26,7 @@ func intersectionOfIndexedLines(
 			return nil
 		})
 	}
-	return NewMultiPoint(pts), NewMultiLineStringFromLineStrings(lss)
+	return NewMultiPoint(pts), NewMultiLineString(lss)
 }
 
 func intersectionOfMultiPointAndMultiPoint(mp1, mp2 MultiPoint) MultiPoint {

--- a/geom/alg_simplify.go
+++ b/geom/alg_simplify.go
@@ -60,7 +60,7 @@ func (s simplifier) simplifyMultiLineString(mls MultiLineString) (MultiLineStrin
 			lss = append(lss, ls)
 		}
 	}
-	return NewMultiLineStringFromLineStrings(lss, s.opts...), nil
+	return NewMultiLineString(lss, s.opts...), nil
 }
 
 func (s simplifier) simplifyPolygon(poly Polygon) (Polygon, error) {
@@ -88,7 +88,7 @@ func (s simplifier) simplifyPolygon(poly Polygon) (Polygon, error) {
 			rings = append(rings, interior)
 		}
 	}
-	return NewPolygonFromRings(rings, s.opts...)
+	return NewPolygon(rings, s.opts...)
 }
 
 func (s simplifier) simplifyMultiPolygon(mp MultiPolygon) (MultiPolygon, error) {
@@ -103,7 +103,7 @@ func (s simplifier) simplifyMultiPolygon(mp MultiPolygon) (MultiPolygon, error) 
 			polys = append(polys, poly)
 		}
 	}
-	return NewMultiPolygonFromPolygons(polys, s.opts...)
+	return NewMultiPolygon(polys, s.opts...)
 }
 
 func (s simplifier) simplifyGeometryCollection(gc GeometryCollection) (GeometryCollection, error) {

--- a/geom/dcel_extract.go
+++ b/geom/dcel_extract.go
@@ -19,7 +19,7 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]label) bool) (
 		if len(areals) == 1 {
 			return areals[0].AsGeometry(), nil
 		}
-		mp, err := NewMultiPolygonFromPolygons(areals)
+		mp, err := NewMultiPolygon(areals)
 		if err != nil {
 			return Geometry{}, fmt.Errorf("could not extract areal geometry from DCEL: %v", err)
 		}
@@ -28,7 +28,7 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]label) bool) (
 		if len(linears) == 1 {
 			return linears[0].AsGeometry(), nil
 		}
-		return NewMultiLineStringFromLineStrings(linears).AsGeometry(), nil
+		return NewMultiLineString(linears).AsGeometry(), nil
 	case len(areals) == 0 && len(linears) == 0 && len(points) > 0:
 		if len(points) == 1 {
 			return points[0].AsPoint().AsGeometry(), nil
@@ -99,7 +99,7 @@ func (d *doublyConnectedEdgeList) extractPolygons(include func([2]label) bool) (
 
 		// Construct the polygon.
 		orderCCWRingFirst(rings)
-		poly, err := NewPolygonFromRings(rings)
+		poly, err := NewPolygon(rings)
 		if err != nil {
 			return nil, err
 		}

--- a/geom/dcel_ghosts.go
+++ b/geom/dcel_ghosts.go
@@ -53,7 +53,7 @@ func spanningTree(xys []XY) MultiLineString {
 		})
 	}
 
-	return NewMultiLineStringFromLineStrings(lss)
+	return NewMultiLineString(lss)
 }
 
 func appendXYForPoint(xys []XY, pt Point) []XY {

--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -271,7 +271,7 @@ func reNodeMultiLineString(mls MultiLineString, cut cutSet, nodes nodeSet) (Mult
 			return MultiLineString{}, err
 		}
 	}
-	return NewMultiLineStringFromLineStrings(lss, DisableAllValidations), nil
+	return NewMultiLineString(lss, DisableAllValidations), nil
 }
 
 func reNodePolygon(poly Polygon, cut cutSet, nodes nodeSet) (Polygon, error) {
@@ -284,7 +284,7 @@ func reNodePolygon(poly Polygon, cut cutSet, nodes nodeSet) (Polygon, error) {
 	for i := 0; i < n; i++ {
 		rings[i] = reNodedBoundary.LineStringN(i)
 	}
-	reNodedPoly, err := NewPolygonFromRings(rings, DisableAllValidations)
+	reNodedPoly, err := NewPolygon(rings, DisableAllValidations)
 	if err != nil {
 		return Polygon{}, err
 	}
@@ -301,7 +301,7 @@ func reNodeMultiPolygonString(mp MultiPolygon, cut cutSet, nodes nodeSet) (Multi
 			return MultiPolygon{}, err
 		}
 	}
-	reNodedMP, err := NewMultiPolygonFromPolygons(polys, DisableAllValidations)
+	reNodedMP, err := NewMultiPolygon(polys, DisableAllValidations)
 	if err != nil {
 		return MultiPolygon{}, err
 	}

--- a/geom/geojson_unmarshal.go
+++ b/geom/geojson_unmarshal.go
@@ -259,7 +259,7 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 				return Geometry{}, err
 			}
 		}
-		poly, err := NewPolygonFromRings(rings, opts...)
+		poly, err := NewPolygon(rings, opts...)
 		return poly.AsGeometry(), err
 	case geojsonMultiPoint:
 		// GeoJSON MultiPoints cannot contain empty Points.
@@ -289,7 +289,7 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 				return Geometry{}, err
 			}
 		}
-		return NewMultiLineStringFromLineStrings(lss, opts...).AsGeometry(), nil
+		return NewMultiLineString(lss, opts...).AsGeometry(), nil
 	case geojsonMultiPolygon:
 		if len(node.coords) == 0 {
 			return MultiPolygon{}.ForceCoordinatesType(ctype).AsGeometry(), nil
@@ -306,13 +306,13 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 				}
 			}
 			var err error
-			polys[i], err = NewPolygonFromRings(rings, opts...)
+			polys[i], err = NewPolygon(rings, opts...)
 			if err != nil {
 				return Geometry{}, err
 			}
 			polys[i] = polys[i].ForceCoordinatesType(ctype)
 		}
-		mp, err := NewMultiPolygonFromPolygons(polys, opts...)
+		mp, err := NewMultiPolygon(polys, opts...)
 		return mp.AsGeometry(), err
 	case geojsonGeometryCollection:
 		if len(node.geoms) == 0 {

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -28,7 +28,7 @@ func regularPolygon(center XY, radius float64, sides int) Polygon {
 	if err != nil {
 		panic(err)
 	}
-	poly, err := NewPolygonFromRings([]LineString{ring}, geom.DisableAllValidations)
+	poly, err := NewPolygon([]LineString{ring}, geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}
@@ -138,7 +138,7 @@ func BenchmarkPolygonSingleRingValidation(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewPolygonFromRings(rings); err != nil {
+				if _, err := NewPolygon(rings); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -177,7 +177,7 @@ func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewPolygonFromRings(rings); err != nil {
+				if _, err := NewPolygon(rings); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -215,7 +215,7 @@ func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := NewPolygonFromRings([]LineString{outerRing, leftRing, rightRing})
+				_, err := NewPolygon([]LineString{outerRing, leftRing, rightRing})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -232,7 +232,7 @@ func BenchmarkPolygonAnnulusValidation(b *testing.B) {
 			rings := []LineString{outer, inner}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewPolygonFromRings(rings); err != nil {
+				if _, err := NewPolygon(rings); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -260,7 +260,7 @@ func BenchmarkMultipolygonValidation(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				polys[i], err = NewPolygonFromRings([]LineString{ring})
+				polys[i], err = NewPolygon([]LineString{ring})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -268,7 +268,7 @@ func BenchmarkMultipolygonValidation(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewMultiPolygonFromPolygons(polys); err != nil {
+				if _, err := NewMultiPolygon(polys); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -286,7 +286,7 @@ func BenchmarkMultiPolygonTwoCircles(b *testing.B) {
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewMultiPolygonFromPolygons(polys); err != nil {
+				if _, err := NewMultiPolygon(polys); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -314,11 +314,11 @@ func BenchmarkMultiPolygonMultipleTouchingPoints(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			p1, err := NewPolygonFromRings([]LineString{ls1})
+			p1, err := NewPolygon([]LineString{ls1})
 			if err != nil {
 				b.Fatal(err)
 			}
-			p2, err := NewPolygonFromRings([]LineString{ls2})
+			p2, err := NewPolygon([]LineString{ls2})
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -326,7 +326,7 @@ func BenchmarkMultiPolygonMultipleTouchingPoints(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := NewMultiPolygonFromPolygons(polys)
+				_, err := NewMultiPolygon(polys)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -406,7 +406,7 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 				}
 				lss = append(lss, ls)
 			}
-			mls := NewMultiLineStringFromLineStrings(lss)
+			mls := NewMultiLineString(lss)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -76,7 +76,7 @@ func (e Envelope) AsGeometry() Geometry {
 	if err != nil {
 		panic(fmt.Sprintf("constructing geometry from envelope: %v", err))
 	}
-	poly, err := NewPolygonFromRings([]LineString{ls})
+	poly, err := NewPolygon([]LineString{ls})
 	if err != nil {
 		panic(fmt.Sprintf("constructing geometry from envelope: %v", err))
 	}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -344,7 +344,7 @@ func sumCentroidAndLengthOfLineString(s LineString) (sumXY XY, sumLength float64
 // AsMultiLineString is a convenience function that converts this LineString
 // into a MultiLineString.
 func (s LineString) AsMultiLineString() MultiLineString {
-	return NewMultiLineStringFromLineStrings([]LineString{s})
+	return NewMultiLineString([]LineString{s})
 }
 
 // Reverse in the case of LineString outputs the coordinates in reverse order.

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -18,9 +18,9 @@ type MultiLineString struct {
 	ctype CoordinatesType
 }
 
-// NewMultiLineString creates a MultiLineString from its
-// constituent LineStrings. The coordinates type of the MultiLineString is the
-// lowest common coordinates type of its LineStrings.
+// NewMultiLineString creates a MultiLineString from its constituent
+// LineStrings. The coordinates type of the MultiLineString is the lowest
+// common coordinates type of its LineStrings.
 func NewMultiLineString(lines []LineString, opts ...ConstructorOption) MultiLineString {
 	if len(lines) == 0 {
 		return MultiLineString{}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -18,10 +18,10 @@ type MultiLineString struct {
 	ctype CoordinatesType
 }
 
-// NewMultiLineStringFromLineStrings creates a MultiLineString from its
+// NewMultiLineString creates a MultiLineString from its
 // constituent LineStrings. The coordinates type of the MultiLineString is the
 // lowest common coordinates type of its LineStrings.
-func NewMultiLineStringFromLineStrings(lines []LineString, opts ...ConstructorOption) MultiLineString {
+func NewMultiLineString(lines []LineString, opts ...ConstructorOption) MultiLineString {
 	if len(lines) == 0 {
 		return MultiLineString{}
 	}
@@ -332,7 +332,7 @@ func (m MultiLineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) 
 			return MultiLineString{}, wrapTransformed(err)
 		}
 	}
-	return NewMultiLineStringFromLineStrings(transformed, opts...), nil
+	return NewMultiLineString(transformed, opts...), nil
 }
 
 // Length gives the sum of the lengths of the constituent members of the multi

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -25,11 +25,11 @@ type MultiPolygon struct {
 	ctype CoordinatesType
 }
 
-// NewMultiPolygonFromPolygons creates a MultiPolygon from its constituent
+// NewMultiPolygon creates a MultiPolygon from its constituent
 // Polygons. It gives an error if any of the MultiPolygon assertions are not
 // maintained. The coordinates type of the MultiPolygon is the lowest common
 // coordinates type its Polygons.
-func NewMultiPolygonFromPolygons(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, error) {
+func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, error) {
 	if len(polys) == 0 {
 		return MultiPolygon{}, nil
 	}
@@ -269,7 +269,7 @@ func (m MultiPolygon) Boundary() MultiLineString {
 			bounds = append(bounds, r.Force2D())
 		}
 	}
-	return NewMultiLineStringFromLineStrings(bounds)
+	return NewMultiLineString(bounds)
 }
 
 // Value implements the database/sql/driver.Valuer interface by returning the
@@ -348,7 +348,7 @@ func (m MultiPolygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Mu
 		}
 		polys[i] = transformed
 	}
-	mp, err := NewMultiPolygonFromPolygons(polys, opts...)
+	mp, err := NewMultiPolygon(polys, opts...)
 	return mp.ForceCoordinatesType(m.ctype), wrapTransformed(err)
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -25,10 +25,10 @@ type MultiPolygon struct {
 	ctype CoordinatesType
 }
 
-// NewMultiPolygon creates a MultiPolygon from its constituent
-// Polygons. It gives an error if any of the MultiPolygon assertions are not
-// maintained. The coordinates type of the MultiPolygon is the lowest common
-// coordinates type its Polygons.
+// NewMultiPolygon creates a MultiPolygon from its constituent Polygons. It
+// gives an error if any of the MultiPolygon assertions are not maintained. The
+// coordinates type of the MultiPolygon is the lowest common coordinates type
+// its Polygons.
 func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, error) {
 	if len(polys) == 0 {
 		return MultiPolygon{}, nil

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -30,11 +30,11 @@ type Polygon struct {
 	ctype CoordinatesType
 }
 
-// NewPolygonFromRings creates a polygon given its rings. The outer ring is
-// first, and any inner rings follow. If no rings are provided, then the
-// returned Polygon is the empty Polygon. The coordinate type of the polygon is
-// the lowest common coordinate type of its rings.
-func NewPolygonFromRings(rings []LineString, opts ...ConstructorOption) (Polygon, error) {
+// NewPolygon creates a polygon given its rings. The outer ring is first, and
+// any inner rings follow. If no rings are provided, then the returned Polygon
+// is the empty Polygon. The coordinate type of the polygon is the lowest
+// common coordinate type of its rings.
+func NewPolygon(rings []LineString, opts ...ConstructorOption) (Polygon, error) {
 	if len(rings) == 0 {
 		return Polygon{}, nil
 	}
@@ -251,7 +251,7 @@ func (p Polygon) Envelope() (Envelope, bool) {
 // Polygons, this is the MultiLineString collection containing all of the
 // rings.
 func (p Polygon) Boundary() MultiLineString {
-	return NewMultiLineStringFromLineStrings(p.rings).Force2D()
+	return NewMultiLineString(p.rings).Force2D()
 }
 
 // Value implements the database/sql/driver.Valuer interface by returning the
@@ -332,7 +332,7 @@ func (p Polygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Polygon
 			return Polygon{}, wrapTransformed(err)
 		}
 	}
-	poly, err := NewPolygonFromRings(transformed, opts...)
+	poly, err := NewPolygon(transformed, opts...)
 	return poly.ForceCoordinatesType(p.ctype), wrapTransformed(err)
 }
 
@@ -472,7 +472,7 @@ func (p Polygon) AsMultiPolygon() MultiPolygon {
 	if !p.IsEmpty() {
 		polys = []Polygon{p}
 	}
-	mp, err := NewMultiPolygonFromPolygons(polys)
+	mp, err := NewMultiPolygon(polys)
 	if err != nil {
 		// Cannot occur due to construction. A valid polygon will always be a
 		// valid multipolygon.

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -258,7 +258,7 @@ func (p *wkbParser) parsePolygon(ctype CoordinatesType) (Polygon, error) {
 			return Polygon{}, err
 		}
 	}
-	return NewPolygonFromRings(rings, p.opts...)
+	return NewPolygon(rings, p.opts...)
 }
 
 func (p *wkbParser) parseMultiPoint(ctype CoordinatesType) (MultiPoint, error) {
@@ -302,7 +302,7 @@ func (p *wkbParser) parseMultiLineString(ctype CoordinatesType) (MultiLineString
 		}
 		lss[i] = geom.AsLineString()
 	}
-	return NewMultiLineStringFromLineStrings(lss, p.opts...), nil
+	return NewMultiLineString(lss, p.opts...), nil
 }
 
 func (p *wkbParser) parseMultiPolygon(ctype CoordinatesType) (MultiPolygon, error) {
@@ -324,7 +324,7 @@ func (p *wkbParser) parseMultiPolygon(ctype CoordinatesType) (MultiPolygon, erro
 		}
 		polys[i] = geom.AsPolygon()
 	}
-	return NewMultiPolygonFromPolygons(polys, p.opts...)
+	return NewMultiPolygon(polys, p.opts...)
 }
 
 func (p *wkbParser) parseGeometryCollection(ctype CoordinatesType) (GeometryCollection, error) {

--- a/geom/wkt_parser.go
+++ b/geom/wkt_parser.go
@@ -267,7 +267,7 @@ func (p *parser) nextPolygonText(ctype CoordinatesType) (Polygon, error) {
 	if len(rings) == 0 {
 		return Polygon{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewPolygonFromRings(rings, p.opts...)
+	return NewPolygon(rings, p.opts...)
 }
 
 func (p *parser) nextMultiLineString(ctype CoordinatesType) (MultiLineString, error) {
@@ -278,7 +278,7 @@ func (p *parser) nextMultiLineString(ctype CoordinatesType) (MultiLineString, er
 	if len(lss) == 0 {
 		return MultiLineString{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewMultiLineStringFromLineStrings(lss, p.opts...), nil
+	return NewMultiLineString(lss, p.opts...), nil
 }
 
 func (p *parser) nextPolygonOrMultiLineStringText(ctype CoordinatesType) ([]LineString, error) {
@@ -403,7 +403,7 @@ func (p *parser) nextMultiPolygonText(ctype CoordinatesType) (MultiPolygon, erro
 	if len(polys) == 0 {
 		return MultiPolygon{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewMultiPolygonFromPolygons(polys, p.opts...)
+	return NewMultiPolygon(polys, p.opts...)
 }
 
 func (p *parser) nextGeometryCollectionText(ctype CoordinatesType) (GeometryCollection, error) {

--- a/geom/zero_value_test.go
+++ b/geom/zero_value_test.go
@@ -46,7 +46,7 @@ func TestZeroValueGeometries(t *testing.T) {
 
 func TestEmptySliceConstructors(t *testing.T) {
 	t.Run("Polygon", func(t *testing.T) {
-		p, err := NewPolygonFromRings(nil)
+		p, err := NewPolygon(nil)
 		expectNoErr(t, err)
 		expectBoolEq(t, p.IsEmpty(), true)
 		expectCoordinatesTypeEq(t, p.CoordinatesType(), DimXY)
@@ -57,12 +57,12 @@ func TestEmptySliceConstructors(t *testing.T) {
 		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
 	})
 	t.Run("MultiLineString", func(t *testing.T) {
-		mls := NewMultiLineStringFromLineStrings(nil)
+		mls := NewMultiLineString(nil)
 		expectIntEq(t, mls.NumLineStrings(), 0)
 		expectCoordinatesTypeEq(t, mls.CoordinatesType(), DimXY)
 	})
 	t.Run("MultiPolygon", func(t *testing.T) {
-		mp, err := NewMultiPolygonFromPolygons(nil)
+		mp, err := NewMultiPolygon(nil)
 		expectNoErr(t, err)
 		expectIntEq(t, mp.NumPolygons(), 0)
 		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)

--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -26,7 +26,7 @@ func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	if err != nil {
 		panic(err)
 	}
-	poly, err := geom.NewPolygonFromRings([]geom.LineString{ring}, geom.DisableAllValidations)
+	poly, err := geom.NewPolygon([]geom.LineString{ring}, geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cmprefimpl/cmpgeos/handle.go
+++ b/internal/cmprefimpl/cmpgeos/handle.go
@@ -315,7 +315,7 @@ func (h *Handle) decodeGeomHandle(gh *C.GEOSGeometry) (geom.Geometry, error) {
 			}
 			subPolys[i] = subPolyAsGeom.AsPolygon()
 		}
-		mp, err := geom.NewMultiPolygonFromPolygons(subPolys)
+		mp, err := geom.NewMultiPolygon(subPolys)
 		return mp.AsGeometry(), err
 	case "GeometryCollection":
 		n := C.GEOSGetNumGeometries_r(h.context, gh)

--- a/internal/perf/util.go
+++ b/internal/perf/util.go
@@ -24,7 +24,7 @@ func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	if err != nil {
 		panic(err)
 	}
-	poly, err := geom.NewPolygonFromRings([]geom.LineString{ring}, geom.DisableAllValidations)
+	poly, err := geom.NewPolygon([]geom.LineString{ring}, geom.DisableAllValidations)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description

The vast majority of constructors are now in the form `NewFoo`, where `Foo` is the name of the thing being constructed (e.g. a geometry type such as `MultiPolygon`).

Previously, the constructors were named so that the type that was being constructed _from_ was also mentioned.

E.g. `NewPolygonFromRings` was renamed to `NewPolygon`. The `FromRings` part really was redundant, since polygons are always constructed from their constituent rings (there really is no other practical way to construct them).

## Check List

Have you:

- Added unit tests? N/A, just a rename.

- Add cmprefimpl tests? (if appropriate?) N/A.

## Related Issue

N/A

## Benchmark Results

N/A