### PR TITLE
Fix Spelling Error In Marshaler Comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fix spelling of "Marshaller" when referring to the interface defined in the
+  `encoding/json` package.
+
 ## v0.34.0
 
 2021-11-02

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -247,7 +247,7 @@ func (g Geometry) AsText() string {
 	}
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (g Geometry) MarshalJSON() ([]byte, error) {
 	switch g.gtype {

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -177,7 +177,7 @@ func (c GeometryCollection) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (c GeometryCollection) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypeGeometryCollection, c.ctype)
 	n := c.NumGeometries()
@@ -195,7 +195,7 @@ func (c GeometryCollection) ConvexHull() Geometry {
 	return convexHull(c.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (c GeometryCollection) MarshalJSON() ([]byte, error) {
 	buf := []byte(`{"type":"GeometryCollection","geometries":`)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -269,7 +269,7 @@ func (s LineString) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (s LineString) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypeLineString, s.CoordinatesType())
 	marsh.writeSequence(s.seq)
@@ -282,7 +282,7 @@ func (s LineString) ConvexHull() Geometry {
 	return convexHull(s.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (s LineString) MarshalJSON() ([]byte, error) {
 	var dst []byte

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -268,7 +268,7 @@ func (m MultiLineString) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (m MultiLineString) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypeMultiLineString, m.ctype)
 	n := m.NumLineStrings()
@@ -286,7 +286,7 @@ func (m MultiLineString) ConvexHull() Geometry {
 	return convexHull(m.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (m MultiLineString) MarshalJSON() ([]byte, error) {
 	var dst []byte

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -144,7 +144,7 @@ func (m MultiPoint) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (m MultiPoint) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypeMultiPoint, m.CoordinatesType())
 	n := m.NumPoints()
@@ -162,7 +162,7 @@ func (m MultiPoint) ConvexHull() Geometry {
 	return convexHull(m.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (m MultiPoint) MarshalJSON() ([]byte, error) {
 	var dst []byte

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -286,7 +286,7 @@ func (m MultiPolygon) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (m MultiPolygon) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypeMultiPolygon, m.ctype)
 	n := m.NumPolygons()
@@ -304,7 +304,7 @@ func (m MultiPolygon) ConvexHull() Geometry {
 	return convexHull(m.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (m MultiPolygon) MarshalJSON() ([]byte, error) {
 	var dst []byte

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -153,7 +153,7 @@ func (p Point) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (p Point) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypePoint, p.CoordinatesType())
 	if !p.full {
@@ -172,7 +172,7 @@ func (p Point) ConvexHull() Geometry {
 	return convexHull(p.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (p Point) MarshalJSON() ([]byte, error) {
 	var dst []byte

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -280,7 +280,7 @@ func (p Polygon) AsBinary() []byte {
 // AppendWKB appends the WKB (Well Known Text) representation of the geometry
 // to the input slice.
 func (p Polygon) AppendWKB(dst []byte) []byte {
-	marsh := newWKBMarshaller(dst)
+	marsh := newWKBMarshaler(dst)
 	marsh.writeByteOrder()
 	marsh.writeGeomType(TypePolygon, p.ctype)
 	marsh.writeCount(len(p.rings))
@@ -297,7 +297,7 @@ func (p Polygon) ConvexHull() Geometry {
 	return convexHull(p.AsGeometry())
 }
 
-// MarshalJSON implements the encoding/json.Marshaller interface by encoding
+// MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (p Polygon) MarshalJSON() ([]byte, error) {
 	var dst []byte

--- a/geom/wkb_marshal.go
+++ b/geom/wkb_marshal.go
@@ -25,15 +25,15 @@ func init() {
 
 }
 
-type wkbMarshaller struct {
+type wkbMarshaler struct {
 	buf []byte
 }
 
-func newWKBMarshaller(buf []byte) *wkbMarshaller {
-	return &wkbMarshaller{buf}
+func newWKBMarshaler(buf []byte) *wkbMarshaler {
+	return &wkbMarshaler{buf}
 }
 
-func (m *wkbMarshaller) writeByteOrder() {
+func (m *wkbMarshaler) writeByteOrder() {
 	if nativeOrder == binary.LittleEndian {
 		m.buf = append(m.buf, 1)
 	} else {
@@ -41,26 +41,26 @@ func (m *wkbMarshaller) writeByteOrder() {
 	}
 }
 
-func (m *wkbMarshaller) writeGeomType(geomType GeometryType, ctype CoordinatesType) {
+func (m *wkbMarshaler) writeGeomType(geomType GeometryType, ctype CoordinatesType) {
 	gt := [...]uint32{7, 1, 2, 3, 4, 5, 6}[geomType]
 	var buf [4]byte
 	nativeOrder.PutUint32(buf[:], uint32(ctype)*1000+gt)
 	m.buf = append(m.buf, buf[:]...)
 }
 
-func (m *wkbMarshaller) writeFloat64(f float64) {
+func (m *wkbMarshaler) writeFloat64(f float64) {
 	var buf [8]byte
 	nativeOrder.PutUint64(buf[:], math.Float64bits(f))
 	m.buf = append(m.buf, buf[:]...)
 }
 
-func (m *wkbMarshaller) writeCount(n int) {
+func (m *wkbMarshaler) writeCount(n int) {
 	var buf [4]byte
 	nativeOrder.PutUint32(buf[:], uint32(n))
 	m.buf = append(m.buf, buf[:]...)
 }
 
-func (m *wkbMarshaller) writeCoordinates(c Coordinates) {
+func (m *wkbMarshaler) writeCoordinates(c Coordinates) {
 	m.writeFloat64(c.X)
 	m.writeFloat64(c.Y)
 	if c.Type.Is3D() {
@@ -71,7 +71,7 @@ func (m *wkbMarshaller) writeCoordinates(c Coordinates) {
 	}
 }
 
-func (m *wkbMarshaller) writeSequence(seq Sequence) {
+func (m *wkbMarshaler) writeSequence(seq Sequence) {
 	n := seq.Length()
 	m.writeCount(n)
 


### PR DESCRIPTION
## Description

Fix "marshaler" spelling to match the Go std lib.

It seems as though there are two spellings of "Marshal/Marshall" and "Marshaller/Marshaller". When referring to the `encoding/json.Marshaler` interface, we should use the same spelling as the standard library (since they [define that interface](https://pkg.go.dev/encoding/json#Marshaler)). For consistency, we should use the same spelling in other places too.


## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

Noticed as part of https://github.com/peterstace/simplefeatures/issues/403

## Benchmark Results

N/A