### PR TITLE
Unmarshal GeoJSON into Concrete Geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Fix spelling of "Marshaller" when referring to the interface defined in the
   `encoding/json` package.
 
+- Add `UnmarshalJSON` methods to each concrete geometry type
+  (`GeometryCollection`, `Point`, `MultiPoint`, `LineString`,
+  `MultiLineString`, `Polygon`, `MultiPolygon`). This causes these types to
+  implement the `encoding/json.Unmarshaler` interface. GeoJSON can now be
+  unmarshalled directly into a concrete geometry type.
+
 ## v0.34.0
 
 2021-11-02

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -77,3 +77,12 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 	}
 	return geojsonSyntaxError{err.Error()}
 }
+
+type wrongTypeDuringUnmarshalError struct {
+	destType   GeometryType
+	actualType GeometryType
+}
+
+func (e wrongTypeDuringUnmarshalError) Error() string {
+	return fmt.Sprintf("cannot unmarshal %s into %s", e.actualType, e.destType)
+}

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -77,15 +77,3 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 	}
 	return geojsonSyntaxError{err.Error()}
 }
-
-// badUnmarshalDestError indicates that the serialised geometry being
-// unmarshalled doesn't have the correct type compared to the unmarshal
-// destination type.
-type badUnmarshalDestError struct {
-	destType   GeometryType
-	actualType GeometryType
-}
-
-func (e badUnmarshalDestError) Error() string {
-	return fmt.Sprintf("cannot unmarshal %s into %s", e.actualType, e.destType)
-}

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -78,11 +78,14 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 	return geojsonSyntaxError{err.Error()}
 }
 
-type wrongTypeDuringUnmarshalError struct {
+// badUnmarshalDestError indicates that the serialised geometry being
+// unmarshalled doesn't have the correct type compared to the unmarshal
+// destination type.
+type badUnmarshalDestError struct {
 	destType   GeometryType
 	actualType GeometryType
 }
 
-func (e wrongTypeDuringUnmarshalError) Error() string {
+func (e badUnmarshalDestError) Error() string {
 	return fmt.Sprintf("cannot unmarshal %s into %s", e.actualType, e.destType)
 }

--- a/geom/geojson_unmarshal_test.go
+++ b/geom/geojson_unmarshal_test.go
@@ -377,3 +377,26 @@ func TestGeoJSONUnmarshalDisableAllValidations(t *testing.T) {
 		})
 	}
 }
+
+func TestGeoJSONUnmarshalIntoConcreteGeometryValid(t *testing.T) {
+	for i, tc := range []struct {
+		target interface {
+			json.Unmarshaler
+			AsGeometry() geom.Geometry
+		}
+		geojson string
+		wantWKT string
+	}{
+		{
+			target:  new(Point),
+			geojson: `{"type":"Point","coordinates":[1,2]}`,
+			wantWKT: "POINT(1 2)",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			err := json.Unmarshal([]byte(tc.geojson), tc.target)
+			expectNoErr(t, err)
+			expectGeomEq(t, tc.target.AsGeometry(), geomFromWKT(t, tc.wantWKT))
+		})
+	}
+}

--- a/geom/geojson_unmarshal_test.go
+++ b/geom/geojson_unmarshal_test.go
@@ -471,3 +471,38 @@ func TestGeoJSONUnmarshalIntoConcreteGeometryWrongType(t *testing.T) {
 		})
 	}
 }
+
+func TestGeoJSONUnmarshalIntoConcreteGeometryDoesNotAlterParent(t *testing.T) {
+	t.Run("MultiPoint", func(t *testing.T) {
+		const parentWKT = "MULTIPOINT((1 2))"
+		parent := geomFromWKT(t, parentWKT).MustAsMultiPoint()
+		child := parent.PointN(0)
+		err := json.Unmarshal([]byte(`{"type":"Point","coordinates":[9,9]}`), &child)
+		expectNoErr(t, err)
+		expectGeomEq(t, parent.AsGeometry(), geomFromWKT(t, parentWKT))
+	})
+	t.Run("MultiLineString", func(t *testing.T) {
+		const parentWKT = "MULTILINESTRING((1 2,3 4))"
+		parent := geomFromWKT(t, parentWKT).MustAsMultiLineString()
+		child := parent.LineStringN(0)
+		err := json.Unmarshal([]byte(`{"type":"LineString","coordinates":[[9,9],[8,8]]}`), &child)
+		expectNoErr(t, err)
+		expectGeomEq(t, parent.AsGeometry(), geomFromWKT(t, parentWKT))
+	})
+	t.Run("MultiPolygon", func(t *testing.T) {
+		const parentWKT = "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))"
+		parent := geomFromWKT(t, parentWKT).MustAsMultiPolygon()
+		child := parent.PolygonN(0)
+		err := json.Unmarshal([]byte(`{"type":"Polygon","coordinates":[[[4,4],[4,5],[5,4],[4,4]]]}`), &child)
+		expectNoErr(t, err)
+		expectGeomEq(t, parent.AsGeometry(), geomFromWKT(t, parentWKT))
+	})
+	t.Run("GeometryCollection", func(t *testing.T) {
+		const parentWKT = "GEOMETRYCOLLECTION(POINT(1 2))"
+		parent := geomFromWKT(t, parentWKT).MustAsGeometryCollection()
+		child := parent.GeometryN(0)
+		err := json.Unmarshal([]byte(`{"type":"Point","coordinates":[9,9]}`), &child)
+		expectNoErr(t, err)
+		expectGeomEq(t, parent.AsGeometry(), geomFromWKT(t, parentWKT))
+	})
+}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -212,6 +212,24 @@ func (c GeometryCollection) MarshalJSON() ([]byte, error) {
 	return buf, nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a GeometryCollection.
+func (c *GeometryCollection) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	gc, ok := g.AsGeometryCollection()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypeGeometryCollection,
+			actualType: g.Type(),
+		}
+	}
+	*c = gc
+	return nil
+}
+
 // TransformXY transforms this GeometryCollection into another GeometryCollection according to fn.
 func (c GeometryCollection) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (GeometryCollection, error) {
 	transformed := make([]Geometry, len(c.geoms))

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -166,7 +166,7 @@ func (c GeometryCollection) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (c *GeometryCollection) Scan(src interface{}) error {
-	return scanAsType(src, c, TypeGeometryCollection)
+	return scanAsType(src, c)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -215,19 +215,7 @@ func (c GeometryCollection) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a GeometryCollection.
 func (c *GeometryCollection) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	gc, ok := g.AsGeometryCollection()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypeGeometryCollection,
-			actualType: g.Type(),
-		}
-	}
-	*c = gc
-	return nil
+	return unmarshalGeoJSONAsType(buf, c)
 }
 
 // TransformXY transforms this GeometryCollection into another GeometryCollection according to fn.

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -221,7 +221,7 @@ func (c *GeometryCollection) UnmarshalJSON(buf []byte) error {
 	}
 	gc, ok := g.AsGeometryCollection()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypeGeometryCollection,
 			actualType: g.Type(),
 		}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -301,7 +301,7 @@ func (s *LineString) UnmarshalJSON(buf []byte) error {
 	}
 	ls, ok := g.AsLineString()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypeLineString,
 			actualType: g.Type(),
 		}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -292,6 +292,24 @@ func (s LineString) MarshalJSON() ([]byte, error) {
 	return dst, nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a LineString.
+func (s *LineString) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	ls, ok := g.AsLineString()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypeLineString,
+			actualType: g.Type(),
+		}
+	}
+	*s = ls
+	return nil
+}
+
 // Coordinates returns the coordinates of each point along the LineString.
 func (s LineString) Coordinates() Sequence {
 	return s.seq

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -258,7 +258,7 @@ func (s LineString) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (s *LineString) Scan(src interface{}) error {
-	return scanAsType(src, s, TypeLineString)
+	return scanAsType(src, s)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -295,19 +295,7 @@ func (s LineString) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a LineString.
 func (s *LineString) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	ls, ok := g.AsLineString()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypeLineString,
-			actualType: g.Type(),
-		}
-	}
-	*s = ls
-	return nil
+	return unmarshalGeoJSONAsType(buf, s)
 }
 
 // Coordinates returns the coordinates of each point along the LineString.

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -296,6 +296,24 @@ func (m MultiLineString) MarshalJSON() ([]byte, error) {
 	return dst, nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a MultiLineString.
+func (m *MultiLineString) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	mls, ok := g.AsMultiLineString()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypeMultiLineString,
+			actualType: g.Type(),
+		}
+	}
+	*m = mls
+	return nil
+}
+
 // Coordinates returns the coordinates of each constituent LineString in the
 // MultiLineString.
 func (m MultiLineString) Coordinates() []Sequence {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -257,7 +257,7 @@ func (m MultiLineString) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (m *MultiLineString) Scan(src interface{}) error {
-	return scanAsType(src, m, TypeMultiLineString)
+	return scanAsType(src, m)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -299,19 +299,7 @@ func (m MultiLineString) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a MultiLineString.
 func (m *MultiLineString) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	mls, ok := g.AsMultiLineString()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypeMultiLineString,
-			actualType: g.Type(),
-		}
-	}
-	*m = mls
-	return nil
+	return unmarshalGeoJSONAsType(buf, m)
 }
 
 // Coordinates returns the coordinates of each constituent LineString in the

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -305,7 +305,7 @@ func (m *MultiLineString) UnmarshalJSON(buf []byte) error {
 	}
 	mls, ok := g.AsMultiLineString()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypeMultiLineString,
 			actualType: g.Type(),
 		}

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -133,7 +133,7 @@ func (m MultiPoint) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (m *MultiPoint) Scan(src interface{}) error {
-	return scanAsType(src, m, TypeMultiPoint)
+	return scanAsType(src, m)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -185,19 +185,7 @@ func (m MultiPoint) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a MultiPoint.
 func (m *MultiPoint) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	mp, ok := g.AsMultiPoint()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypeMultiPoint,
-			actualType: g.Type(),
-		}
-	}
-	*m = mp
-	return nil
+	return unmarshalGeoJSONAsType(buf, m)
 }
 
 // Coordinates returns the coordinates of the non-empty points represented by

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -191,7 +191,7 @@ func (m *MultiPoint) UnmarshalJSON(buf []byte) error {
 	}
 	mp, ok := g.AsMultiPoint()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypeMultiPoint,
 			actualType: g.Type(),
 		}

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -182,6 +182,24 @@ func (m MultiPoint) MarshalJSON() ([]byte, error) {
 	return dst, nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a MultiPoint.
+func (mp *MultiPoint) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	multiPt, ok := g.AsMultiPoint()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypeMultiPoint,
+			actualType: g.Type(),
+		}
+	}
+	*mp = multiPt
+	return nil
+}
+
 // Coordinates returns the coordinates of the non-empty points represented by
 // the MultiPoint.
 func (m MultiPoint) Coordinates() Sequence {

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -184,19 +184,19 @@ func (m MultiPoint) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a MultiPoint.
-func (mp *MultiPoint) UnmarshalJSON(buf []byte) error {
+func (m *MultiPoint) UnmarshalJSON(buf []byte) error {
 	g, err := UnmarshalGeoJSON(buf)
 	if err != nil {
 		return err
 	}
-	multiPt, ok := g.AsMultiPoint()
+	mp, ok := g.AsMultiPoint()
 	if !ok {
 		return wrongTypeDuringUnmarshalError{
 			destType:   TypeMultiPoint,
 			actualType: g.Type(),
 		}
 	}
-	*mp = multiPt
+	*m = mp
 	return nil
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -275,7 +275,7 @@ func (m MultiPolygon) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (m *MultiPolygon) Scan(src interface{}) error {
-	return scanAsType(src, m, TypeMultiPolygon)
+	return scanAsType(src, m)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -317,19 +317,7 @@ func (m MultiPolygon) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a MultiPolygon.
 func (m *MultiPolygon) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	mp, ok := g.AsMultiPolygon()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypeMultiPolygon,
-			actualType: g.Type(),
-		}
-	}
-	*m = mp
-	return nil
+	return unmarshalGeoJSONAsType(buf, m)
 }
 
 // Coordinates returns the coordinates of each constituent Polygon of the

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -314,6 +314,24 @@ func (m MultiPolygon) MarshalJSON() ([]byte, error) {
 	return dst, nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a MultiPolygon.
+func (m *MultiPolygon) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	mp, ok := g.AsMultiPolygon()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypeMultiPolygon,
+			actualType: g.Type(),
+		}
+	}
+	*m = mp
+	return nil
+}
+
 // Coordinates returns the coordinates of each constituent Polygon of the
 // MultiPolygon.
 func (m MultiPolygon) Coordinates() [][]Sequence {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -323,7 +323,7 @@ func (m *MultiPolygon) UnmarshalJSON(buf []byte) error {
 	}
 	mp, ok := g.AsMultiPolygon()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypeMultiPolygon,
 			actualType: g.Type(),
 		}

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -194,7 +194,7 @@ func (p *Point) UnmarshalJSON(buf []byte) error {
 	}
 	pt, ok := g.AsPoint()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypePoint,
 			actualType: g.Type(),
 		}

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -185,6 +185,23 @@ func (p Point) MarshalJSON() ([]byte, error) {
 	return append(dst, '}'), nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler
+func (p *Point) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	pt, ok := g.AsPoint()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypePoint,
+			actualType: g.Type(),
+		}
+	}
+	*p = pt
+	return nil
+}
+
 // TransformXY transforms this Point into another Point according to fn.
 func (p Point) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Point, error) {
 	if !p.full {

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -142,7 +142,7 @@ func (p Point) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (p *Point) Scan(src interface{}) error {
-	return scanAsType(src, p, TypePoint)
+	return scanAsType(src, p)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -188,19 +188,7 @@ func (p Point) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a Point.
 func (p *Point) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	pt, ok := g.AsPoint()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypePoint,
-			actualType: g.Type(),
-		}
-	}
-	*p = pt
-	return nil
+	return unmarshalGeoJSONAsType(buf, p)
 }
 
 // TransformXY transforms this Point into another Point according to fn.

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -185,7 +185,8 @@ func (p Point) MarshalJSON() ([]byte, error) {
 	return append(dst, '}'), nil
 }
 
-// UnmarshalJSON implements the encoding/json.Unmarshaler
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a Point.
 func (p *Point) UnmarshalJSON(buf []byte) error {
 	g, err := UnmarshalGeoJSON(buf)
 	if err != nil {

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -316,7 +316,7 @@ func (p *Polygon) UnmarshalJSON(buf []byte) error {
 	}
 	poly, ok := g.AsPolygon()
 	if !ok {
-		return wrongTypeDuringUnmarshalError{
+		return badUnmarshalDestError{
 			destType:   TypePoint,
 			actualType: g.Type(),
 		}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -269,7 +269,7 @@ func (p Polygon) Value() (driver.Value, error) {
 // slice and then UnmarshalWKB called manually (passing in the
 // ConstructionOptions as desired).
 func (p *Polygon) Scan(src interface{}) error {
-	return scanAsType(src, p, TypePolygon)
+	return scanAsType(src, p)
 }
 
 // AsBinary returns the WKB (Well Known Text) representation of the geometry.
@@ -310,19 +310,7 @@ func (p Polygon) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
 // the GeoJSON representation of a Polygon.
 func (p *Polygon) UnmarshalJSON(buf []byte) error {
-	g, err := UnmarshalGeoJSON(buf)
-	if err != nil {
-		return err
-	}
-	poly, ok := g.AsPolygon()
-	if !ok {
-		return badUnmarshalDestError{
-			destType:   TypePoint,
-			actualType: g.Type(),
-		}
-	}
-	*p = poly
-	return nil
+	return unmarshalGeoJSONAsType(buf, p)
 }
 
 // Coordinates returns the coordinates of the rings making up the Polygon

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -307,6 +307,24 @@ func (p Polygon) MarshalJSON() ([]byte, error) {
 	return dst, nil
 }
 
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface by decoding
+// the GeoJSON representation of a Polygon.
+func (p *Polygon) UnmarshalJSON(buf []byte) error {
+	g, err := UnmarshalGeoJSON(buf)
+	if err != nil {
+		return err
+	}
+	poly, ok := g.AsPolygon()
+	if !ok {
+		return wrongTypeDuringUnmarshalError{
+			destType:   TypePoint,
+			actualType: g.Type(),
+		}
+	}
+	*p = poly
+	return nil
+}
+
 // Coordinates returns the coordinates of the rings making up the Polygon
 // (external ring first, then internal rings after).
 func (p Polygon) Coordinates() []Sequence {

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -2,6 +2,7 @@ package geom_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -28,6 +29,15 @@ func geomsFromWKTs(t testing.TB, wkts []string) []Geometry {
 		gs = append(gs, g)
 	}
 	return gs
+}
+
+func geomFromGeoJSON(t testing.TB, geojson string) Geometry {
+	t.Helper()
+	var g Geometry
+	if err := json.Unmarshal([]byte(geojson), &g); err != nil {
+		t.Fatalf("could not unmarshal GeoJSON:\n geojson: %s\n     err: %v", geojson, err)
+	}
+	return g
 }
 
 func xyCoords(x, y float64) Coordinates {


### PR DESCRIPTION
## Description

- Adds `UnmarshalJSON` methods to each concrete geometry type.

- This means that users will be able to unmarshal GeoJSON directly into a concrete geometry type if they know it's of a particular concrete type. Previously, they would have to unmarshal into the generic `Geometry` type, and then check to see if it's actually the type they expected (and extract it).

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?)

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/403

## Benchmark Results

N/A