### PR TITLE
issue-416 use %w when wrapping errors

### DIFF
--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -38,11 +38,11 @@ func convexHull(g Geometry) Geometry {
 	seq := NewSequence(floats, DimXY)
 	ring, err := NewLineString(seq)
 	if err != nil {
-		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid ring: %v", err))
+		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid ring: %w", err))
 	}
 	poly, err := NewPolygon([]LineString{ring})
 	if err != nil {
-		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid polygon: %v", err))
+		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid polygon: %w", err))
 	}
 	return poly.AsGeometry()
 }

--- a/geom/alg_set_op_test.go
+++ b/geom/alg_set_op_test.go
@@ -987,7 +987,7 @@ func TestBinaryOpNoCrash(t *testing.T) {
 			} {
 				t.Run(op.name, func(t *testing.T) {
 					if _, err := op.op(gA, gB); err != nil {
-						t.Errorf("unexpected error: %v", err)
+						t.Errorf("unexpected error: %w", err)
 					}
 				})
 			}

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -38,7 +38,7 @@ func TestDisableValidation(t *testing.T) {
 			_, err = geom.UnmarshalWKT(wkt, geom.DisableAllValidations)
 			if err != nil {
 				t.Logf("wkt: %v", wkt)
-				t.Errorf("disabling validations still gave an error: %v", err)
+				t.Errorf("disabling validations still gave an error: %w", err)
 			}
 		})
 	}

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -6,7 +6,7 @@ func wrap(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf(format+": %v", append(args, err)...)
+	return fmt.Errorf(format+": %w", append(args, err)...)
 }
 
 // wrapTransformed wraps errors to indicate that they occurred as the result of

--- a/geos/errors.go
+++ b/geos/errors.go
@@ -6,5 +6,5 @@ func wrap(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf(format+": %v", append(args, err)...)
+	return fmt.Errorf(format+": %w", append(args, err)...)
 }


### PR DESCRIPTION
## Description

Use usage of %v to %w when wrapping errors so that it will become available to `errors.Is` and `errors.As` checks.
Found some other places outside geom/errors.go where this was being used and updated those too.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/416

## Benchmark Results

N/A