### PR TITLE
Refactor simplify to be a method rather than a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ __Special thanks to Albert Teoh and Sameera Perera for contributing to this rele
 - Use the `%w` verb for wrapping errors internally. Note that simplefeatures
   does not yet currently expose any sentinel errors or error types.
 
+- **Breaking change**: Changes the `Simplify` package level function to become
+  a method on the `Geometry` type. Users upgrading can just change function
+  invocations that look like `simp, err := geom.Simplify(g, tolerance)` to
+  method invocations that look like `simp, err := g.Simplify(tolerance)`.
+
+- Adds `Simplify` methods to the concrete geometry types `LineString`,
+  `MultiLineString`, `Polygon`, `MultiPolygon`, and `GeometryCollection`. These
+  methods may be used if one of these concrete geometries is to be simplified,
+  rather than converting to a `Geometry`, calling `Simplify`, then converting
+  back to the concrete geometry type.
+
 ## v0.34.0
 
 2021-11-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ __Special thanks to Albert Teoh and Sameera Perera for contributing to this rele
   rather than converting to a `Geometry`, calling `Simplify`, then converting
   back to the concrete geometry type.
 
+- Fixes a bug in Simplify where invalid interior rings would be omitted rather
+  than producing an error.
+
 ## v0.34.0
 
 2021-11-02

--- a/geom/alg_simplify.go
+++ b/geom/alg_simplify.go
@@ -1,125 +1,6 @@
 package geom
 
-// Simplify returns a simplified version of the geometry using the
-// Ramer-Douglas-Peucker algorithm. Sometimes a simplified geometry can become
-// invalid, in which case an error is returned rather than attempting to fix
-// the geometry. Validation of the result can be skipped by making use of the
-// geometry constructor options.
-func Simplify(g Geometry, threshold float64, opts ...ConstructorOption) (Geometry, error) {
-	s := simplifier{threshold, opts}
-	switch g.gtype {
-	case TypeGeometryCollection:
-		gc, err := s.simplifyGeometryCollection(g.MustAsGeometryCollection())
-		return gc.AsGeometry(), wrapSimplified(err)
-	case TypePoint:
-		return g, nil
-	case TypeLineString:
-		ls, err := s.simplifyLineString(g.MustAsLineString())
-		return ls.AsGeometry(), wrapSimplified(err)
-	case TypePolygon:
-		poly, err := s.simplifyPolygon(g.MustAsPolygon())
-		return poly.AsGeometry(), wrapSimplified(err)
-	case TypeMultiPoint:
-		return g, nil
-	case TypeMultiLineString:
-		mls, err := s.simplifyMultiLineString(g.MustAsMultiLineString())
-		return mls.AsGeometry(), wrapSimplified(err)
-	case TypeMultiPolygon:
-		mp, err := s.simplifyMultiPolygon(g.MustAsMultiPolygon())
-		return mp.AsGeometry(), wrapSimplified(err)
-	default:
-		panic("unknown geometry: " + g.gtype.String())
-	}
-}
-
-type simplifier struct {
-	threshold float64
-	opts      []ConstructorOption
-}
-
-func (s simplifier) simplifyLineString(ls LineString) (LineString, error) {
-	seq := ls.Coordinates()
-	floats := s.ramerDouglasPeucker(nil, seq)
-	seq = NewSequence(floats, seq.CoordinatesType())
-	if seq.Length() > 0 && !hasAtLeast2DistinctPointsInSeq(seq) {
-		return LineString{}, nil
-	}
-	return NewLineString(seq, s.opts...)
-}
-
-func (s simplifier) simplifyMultiLineString(mls MultiLineString) (MultiLineString, error) {
-	n := mls.NumLineStrings()
-	lss := make([]LineString, 0, n)
-	for i := 0; i < n; i++ {
-		ls := mls.LineStringN(i)
-		ls, err := s.simplifyLineString(ls)
-		if err != nil {
-			return MultiLineString{}, err
-		}
-		if !ls.IsEmpty() {
-			lss = append(lss, ls)
-		}
-	}
-	return NewMultiLineString(lss, s.opts...), nil
-}
-
-func (s simplifier) simplifyPolygon(poly Polygon) (Polygon, error) {
-	exterior, err := s.simplifyLineString(poly.ExteriorRing())
-	if err != nil {
-		return Polygon{}, err
-	}
-
-	// If we don't have at least 4 coordinates, then we can't form a ring, and
-	// the polygon has collapsed either to a point or a single linear element.
-	// Both cases are represented by an empty polygon.
-	if exterior.Coordinates().Length() < 4 {
-		return Polygon{}, nil
-	}
-
-	n := poly.NumInteriorRings()
-	rings := make([]LineString, 0, n+1)
-	rings = append(rings, exterior)
-	for i := 0; i < n; i++ {
-		interior, err := s.simplifyLineString(poly.InteriorRingN(i))
-		if err != nil {
-			return Polygon{}, err
-		}
-		if interior.IsRing() {
-			rings = append(rings, interior)
-		}
-	}
-	return NewPolygon(rings, s.opts...)
-}
-
-func (s simplifier) simplifyMultiPolygon(mp MultiPolygon) (MultiPolygon, error) {
-	n := mp.NumPolygons()
-	polys := make([]Polygon, 0, n)
-	for i := 0; i < n; i++ {
-		poly, err := s.simplifyPolygon(mp.PolygonN(i))
-		if err != nil {
-			return MultiPolygon{}, err
-		}
-		if !poly.IsEmpty() {
-			polys = append(polys, poly)
-		}
-	}
-	return NewMultiPolygon(polys, s.opts...)
-}
-
-func (s simplifier) simplifyGeometryCollection(gc GeometryCollection) (GeometryCollection, error) {
-	n := gc.NumGeometries()
-	geoms := make([]Geometry, n)
-	for i := 0; i < n; i++ {
-		var err error
-		geoms[i], err = Simplify(gc.GeometryN(i), s.threshold)
-		if err != nil {
-			return GeometryCollection{}, err
-		}
-	}
-	return NewGeometryCollection(geoms, s.opts...), nil
-}
-
-func (s simplifier) ramerDouglasPeucker(dst []float64, seq Sequence) []float64 {
+func ramerDouglasPeucker(dst []float64, seq Sequence, threshold float64) []float64 {
 	if seq.Length() <= 2 {
 		return seq.appendAllPoints(dst)
 	}
@@ -143,7 +24,7 @@ func (s simplifier) ramerDouglasPeucker(dst []float64, seq Sequence) []float64 {
 					maxDist = d
 				}
 			}
-			if maxDist <= s.threshold {
+			if maxDist <= threshold {
 				break
 			}
 			newEnd = maxDistIdx

--- a/geom/alg_simplify_test.go
+++ b/geom/alg_simplify_test.go
@@ -123,6 +123,18 @@ func TestSimplifyErrorCases(t *testing.T) {
 			))`,
 			1e-5,
 		},
+
+		// Second case for "outer ring becomes invalid after simplification".
+		{`POLYGON((0 0,0 1,0.9 1,1 1.1,1.1 1,2 1,2 0,1 1.05,0 0))`, 0.2},
+
+		// Inner ring becomes invalid after simplification.
+		{
+			`POLYGON(
+				(-1 -1,-1 3,3 3,3 -1,-1 -1),
+				(0 0,0 1,0.9 1,1 1.1,1.1 1,2 1,2 0,1 1.05,0 0)
+			)`,
+			0.2,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			in := geomFromWKT(t, tc.wkt)

--- a/geom/alg_simplify_test.go
+++ b/geom/alg_simplify_test.go
@@ -125,6 +125,9 @@ func TestSimplifyErrorCases(t *testing.T) {
 		},
 
 		// Second case for "outer ring becomes invalid after simplification".
+		// The outer ring becomes invalid because the Ramer-Douglas-Peucker
+		// algorithm causes the ring (when considered as a LineString) to
+		// become self-intersected.
 		{`POLYGON((0 0,0 1,0.9 1,1 1.1,1.1 1,2 1,2 0,1 1.05,0 0))`, 0.2},
 
 		// Inner ring becomes invalid after simplification.

--- a/geom/alg_simplify_test.go
+++ b/geom/alg_simplify_test.go
@@ -95,7 +95,7 @@ func TestSimplify(t *testing.T) {
 			t.Logf("input:     %v", in.AsText())
 			t.Logf("threshold: %v", tc.threshold)
 			t.Logf("want:      %v", want.AsText())
-			got, err := geom.Simplify(in, tc.threshold)
+			got, err := in.Simplify(tc.threshold)
 			expectNoErr(t, err)
 			t.Logf("got:       %v", got.AsText())
 			expectGeomEq(t, got, want, geom.IgnoreOrder)
@@ -126,7 +126,7 @@ func TestSimplifyErrorCases(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			in := geomFromWKT(t, tc.wkt)
-			_, err := geom.Simplify(in, tc.threshold)
+			_, err := in.Simplify(tc.threshold)
 			expectErr(t, err)
 		})
 	}

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -922,16 +922,15 @@ func (g Geometry) Simplify(threshold float64, opts ...ConstructorOption) (Geomet
 	case TypePoint:
 		return g, nil
 	case TypeLineString:
-		c, err := g.MustAsLineString().Simplify(threshold, opts...)
-		return c.AsGeometry(), err
+		c := g.MustAsLineString().Simplify(threshold)
+		return c.AsGeometry(), nil
 	case TypePolygon:
 		c, err := g.MustAsPolygon().Simplify(threshold, opts...)
 		return c.AsGeometry(), err
 	case TypeMultiPoint:
 		return g, nil
 	case TypeMultiLineString:
-		c, err := g.MustAsMultiLineString().Simplify(threshold, opts...)
-		return c.AsGeometry(), err
+		return g.MustAsMultiLineString().Simplify(threshold).AsGeometry(), nil
 	case TypeMultiPolygon:
 		c, err := g.MustAsMultiPolygon().Simplify(threshold, opts...)
 		return c.AsGeometry(), err

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -908,3 +908,34 @@ func (g Geometry) Summary() string {
 func (g Geometry) String() string {
 	return g.Summary()
 }
+
+// Simplify returns a simplified version of the geometry using the
+// Ramer-Douglas-Peucker algorithm. Sometimes a simplified geometry can become
+// invalid, in which case an error is returned rather than attempting to fix
+// the geometry. Validation of the result can be skipped by making use of the
+// geometry constructor options.
+func (g Geometry) Simplify(threshold float64, opts ...ConstructorOption) (Geometry, error) {
+	switch g.gtype {
+	case TypeGeometryCollection:
+		c, err := g.MustAsGeometryCollection().Simplify(threshold, opts...)
+		return c.AsGeometry(), err
+	case TypePoint:
+		return g, nil
+	case TypeLineString:
+		c, err := g.MustAsLineString().Simplify(threshold, opts...)
+		return c.AsGeometry(), err
+	case TypePolygon:
+		c, err := g.MustAsPolygon().Simplify(threshold, opts...)
+		return c.AsGeometry(), err
+	case TypeMultiPoint:
+		return g, nil
+	case TypeMultiLineString:
+		c, err := g.MustAsMultiLineString().Simplify(threshold, opts...)
+		return c.AsGeometry(), err
+	case TypeMultiPolygon:
+		c, err := g.MustAsMultiPolygon().Simplify(threshold, opts...)
+		return c.AsGeometry(), err
+	default:
+		panic("unknown type: " + g.Type().String())
+	}
+}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -497,6 +497,9 @@ func (c GeometryCollection) String() string {
 	return c.Summary()
 }
 
+// Simplify returns a simplified version of the GeometryCollection by applying
+// Simplify to each child geometry. Any supplied ConstructorOptions will be
+// used when simplifying each child geometry.
 func (c GeometryCollection) Simplify(threshold float64, opts ...ConstructorOption) (GeometryCollection, error) {
 	n := c.NumGeometries()
 	geoms := make([]Geometry, n)

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -496,3 +496,16 @@ func (c GeometryCollection) Summary() string {
 func (c GeometryCollection) String() string {
 	return c.Summary()
 }
+
+func (c GeometryCollection) Simplify(threshold float64, opts ...ConstructorOption) (GeometryCollection, error) {
+	n := c.NumGeometries()
+	geoms := make([]Geometry, n)
+	for i := 0; i < n; i++ {
+		var err error
+		geoms[i], err = c.GeometryN(i).Simplify(threshold, opts...)
+		if err != nil {
+			return GeometryCollection{}, wrapSimplified(err)
+		}
+	}
+	return NewGeometryCollection(geoms, opts...), nil
+}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -39,7 +39,6 @@ func NewLineString(seq Sequence, opts ...ConstructorOption) (LineString, error) 
 
 func newLineStringWithOmitInvalid(seq Sequence) LineString {
 	if err := validateLineStringSeq(seq); err != nil {
-		// TODO: Should the coordinates type match the input seq?
 		return LineString{}
 	}
 	return LineString{seq}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -23,31 +23,40 @@ type LineString struct {
 // sequence must contain exactly 0 points, or at least 2 points with distinct
 // XY values (otherwise an error is returned).
 func NewLineString(seq Sequence, opts ...ConstructorOption) (LineString, error) {
-	n := seq.Length()
 	ctorOpts := newOptionSet(opts)
-	if ctorOpts.skipValidations || n == 0 {
+	if ctorOpts.skipValidations {
 		return LineString{seq}, nil
 	}
+	if ctorOpts.omitInvalid {
+		return newLineStringWithOmitInvalid(seq), nil
+	}
 
-	// Valid non-empty LineStrings must have at least 2 *distinct* points.
+	if err := validateLineStringSeq(seq); err != nil {
+		return LineString{}, err
+	}
+	return LineString{seq}, nil
+}
+
+func newLineStringWithOmitInvalid(seq Sequence) LineString {
+	if err := validateLineStringSeq(seq); err != nil {
+		// TODO: Should the coordinates type match the input seq?
+		return LineString{}
+	}
+	return LineString{seq}
+}
+
+func validateLineStringSeq(seq Sequence) error {
+	if seq.Length() == 0 {
+		return nil
+	}
 	if !hasAtLeast2DistinctPointsInSeq(seq) {
-		if ctorOpts.omitInvalid {
-			// TODO: Should the coordinates type match the input seq?
-			return LineString{}, nil
-		}
-		return LineString{}, validationError{
+		return validationError{
 			"non-empty linestring contains only one distinct XY value"}
 	}
-
-	// All XY values must be valid.
 	if err := seq.validate(); err != nil {
-		if ctorOpts.omitInvalid {
-			return LineString{}, nil
-		}
-		return LineString{}, validationError{err.Error()}
+		return validationError{err.Error()}
 	}
-
-	return LineString{seq}, nil
+	return nil
 }
 
 func hasAtLeast2DistinctPointsInSeq(seq Sequence) bool {
@@ -432,10 +441,5 @@ func (s LineString) Simplify(threshold float64) LineString {
 	seq := s.Coordinates()
 	floats := ramerDouglasPeucker(nil, seq, threshold)
 	seq = NewSequence(floats, seq.CoordinatesType())
-
-	simp, err := NewLineString(seq, OmitInvalid)
-	if err != nil {
-		panic("OmitInvalid used, so cannot panic: " + err.Error())
-	}
-	return simp
+	return newLineStringWithOmitInvalid(seq)
 }

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -422,3 +422,14 @@ func (s LineString) Summary() string {
 func (s LineString) String() string {
 	return s.Summary()
 }
+
+func (s LineString) Simplify(threshold float64, opts ...ConstructorOption) (LineString, error) {
+	seq := s.Coordinates()
+	floats := ramerDouglasPeucker(nil, seq, threshold)
+	seq = NewSequence(floats, seq.CoordinatesType())
+	if seq.Length() > 0 && !hasAtLeast2DistinctPointsInSeq(seq) {
+		return LineString{}, nil
+	}
+	simp, err := NewLineString(seq, opts...)
+	return simp, wrapSimplified(err)
+}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -482,3 +482,18 @@ func (m MultiLineString) Summary() string {
 func (m MultiLineString) String() string {
 	return m.Summary()
 }
+
+func (m MultiLineString) Simplify(threshold float64, opts ...ConstructorOption) (MultiLineString, error) {
+	n := m.NumLineStrings()
+	lss := make([]LineString, 0, n)
+	for i := 0; i < n; i++ {
+		ls, err := m.LineStringN(i).Simplify(threshold, opts...)
+		if err != nil {
+			return MultiLineString{}, wrapSimplified(err)
+		}
+		if !ls.IsEmpty() {
+			lss = append(lss, ls)
+		}
+	}
+	return NewMultiLineString(lss, opts...), nil
+}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -483,17 +483,19 @@ func (m MultiLineString) String() string {
 	return m.Summary()
 }
 
-func (m MultiLineString) Simplify(threshold float64, opts ...ConstructorOption) (MultiLineString, error) {
+// Simplify returns a simplified version of the MultiLineString by using the
+// Ramer-Douglas-Peucker algorithm on each of the child LineStrings. If the
+// Ramer-Douglas-Peucker were to create an invalid child LineString (i.e. one
+// having only a single distinct point), then it is omitted in the output.
+// Empty child LineStrings are also omitted from the output.
+func (m MultiLineString) Simplify(threshold float64) MultiLineString {
 	n := m.NumLineStrings()
 	lss := make([]LineString, 0, n)
 	for i := 0; i < n; i++ {
-		ls, err := m.LineStringN(i).Simplify(threshold, opts...)
-		if err != nil {
-			return MultiLineString{}, wrapSimplified(err)
-		}
+		ls := m.LineStringN(i).Simplify(threshold)
 		if !ls.IsEmpty() {
 			lss = append(lss, ls)
 		}
 	}
-	return NewMultiLineString(lss, opts...), nil
+	return NewMultiLineString(lss)
 }

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -520,6 +520,10 @@ func (m MultiPolygon) String() string {
 	return m.Summary()
 }
 
+// Simplify returns a simplified version of the MultiPolygon by applying
+// Simplify to each child Polygon and constructing a new MultiPolygon from the
+// result. Any supplied ConstructorOptions will be used when simplifying each
+// child Polygon, or constructing the final MultiPolygon output.
 func (m MultiPolygon) Simplify(threshold float64, opts ...ConstructorOption) (MultiPolygon, error) {
 	n := m.NumPolygons()
 	polys := make([]Polygon, 0, n)

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -519,3 +519,19 @@ func (m MultiPolygon) Summary() string {
 func (m MultiPolygon) String() string {
 	return m.Summary()
 }
+
+func (m MultiPolygon) Simplify(threshold float64, opts ...ConstructorOption) (MultiPolygon, error) {
+	n := m.NumPolygons()
+	polys := make([]Polygon, 0, n)
+	for i := 0; i < n; i++ {
+		poly, err := m.PolygonN(i).Simplify(threshold, opts...)
+		if err != nil {
+			return MultiPolygon{}, err
+		}
+		if !poly.IsEmpty() {
+			polys = append(polys, poly)
+		}
+	}
+	simpl, err := NewMultiPolygon(polys, opts...)
+	return simpl, wrapSimplified(err)
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -599,7 +599,7 @@ func (p Polygon) String() string {
 // returned. If any interior ring collapses to a point or a single linear
 // element, then it is omitted from the final output. The output Polygon will
 // be invalid if any rings in the input become non-rings (e.g. via self
-// intersection) in the output, or if any two rings to to interact in ways
+// intersection) in the output, or if any two rings were to interact in ways
 // prohibited by Polygon validation rules (such as intersecting at more than
 // one point). In these cases, an error is returned. Construction behaviour of
 // the output (which includes omitting errors) may be controlled via

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -610,7 +610,10 @@ func (p Polygon) Simplify(threshold float64, opts ...ConstructorOption) (Polygon
 	// If we don't have at least 4 coordinates, then we can't form a ring, and
 	// the polygon has collapsed either to a point or a single linear element.
 	// Both cases are represented by an empty polygon.
-	if exterior.Coordinates().Length() < 4 {
+	hasCollapsed := func(ring LineString) bool {
+		return ring.Coordinates().Length() < 4
+	}
+	if hasCollapsed(exterior) {
 		return Polygon{}, nil
 	}
 
@@ -619,8 +622,7 @@ func (p Polygon) Simplify(threshold float64, opts ...ConstructorOption) (Polygon
 	rings = append(rings, exterior)
 	for i := 0; i < n; i++ {
 		interior := p.InteriorRingN(i).Simplify(threshold)
-		// TODO: Should we check for collapse instead of IsRing?
-		if interior.IsRing() {
+		if !hasCollapsed(interior) {
 			rings = append(rings, interior)
 		}
 	}


### PR DESCRIPTION
## Description

- Moves the `Simplify` package level function to be a method on the `Geometry` type.

- Adds `Simplify` methods to `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, 
and `GeometryCollection`. These methods return the same concrete geometry type as the type the methods are on, which improves type safety in some scenarios.

- Fixes a bug in polygon simplification.

- See linked issue for motivating example.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/425

## Benchmark Results

N/A