### PR TITLE
Eliminate copy in ForceCW and ForceCCW

### DIFF
--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -420,4 +421,31 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkForceCWandForceCCW(b *testing.B) {
+	for i, tt := range []struct {
+		wkt     string
+		geoType GeometryType
+		isCW    bool
+		isCCW   bool
+		note    string
+	}{
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", TypePolygon, true, false, "CW"},
+		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", TypePolygon, false, true, "CCW"},
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", TypePolygon, true, false, "outer CW inner CCW"},
+		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", TypePolygon, false, true, "outer CCW inner CW"},
+		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", TypeMultiPolygon, true, false, "all CW"},
+		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, true, "all CCW"},
+		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
+	} {
+		b.Run(strconv.Itoa(i), func(b *testing.B) {
+			g := geomFromWKT(b, tt.wkt)
+			for i := 0; i < b.N; i++ {
+				g.ForceCW()
+				g.ForceCCW()
+			}
+		})
+	}
+
 }

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -423,7 +423,7 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 	}
 }
 
-func BenchmarkForceCWandForceCCWOrientedCorrectly(b *testing.B) {
+func BenchmarkForceCWandForceCCW(b *testing.B) {
 	for i, tc := range []struct {
 		wkt     string
 		geoType GeometryType
@@ -439,48 +439,21 @@ func BenchmarkForceCWandForceCCWOrientedCorrectly(b *testing.B) {
 		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, true, "all CCW"},
 		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
 	} {
-		b.Run(strconv.Itoa(i), func(b *testing.B) {
-			g := geomFromWKT(b, tc.wkt)
-
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if tc.isCW {
-					g.ForceCW()
-				} else if tc.isCCW {
-					g.ForceCCW()
+		g := geomFromWKT(b, tc.wkt)
+		for _, correct := range map[string]bool{
+			"correct":   true,
+			"incorrect": false,
+		} {
+			b.Run(strconv.Itoa(i), func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if tc.isCW && correct || tc.isCCW && !correct {
+						g.ForceCW()
+					} else if tc.isCCW && correct || tc.isCW && !correct {
+						g.ForceCCW()
+					}
 				}
-			}
-		})
-	}
-}
-
-func BenchmarkForceCWandForceCCWOrientedIncorrectly(b *testing.B) {
-	for i, tc := range []struct {
-		wkt     string
-		geoType GeometryType
-		isCW    bool
-		isCCW   bool
-		note    string
-	}{
-		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", TypePolygon, true, false, "CW"},
-		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", TypePolygon, false, true, "CCW"},
-		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", TypePolygon, true, false, "outer CW inner CCW"},
-		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", TypePolygon, false, true, "outer CCW inner CW"},
-		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", TypeMultiPolygon, true, false, "all CW"},
-		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, true, "all CCW"},
-		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
-	} {
-		b.Run(strconv.Itoa(i), func(b *testing.B) {
-			g := geomFromWKT(b, tc.wkt)
-
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if tc.isCW {
-					g.ForceCCW()
-				} else if tc.isCCW {
-					g.ForceCW()
-				}
-			}
-		})
+			})
+		}
 	}
 }

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -423,8 +423,8 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 	}
 }
 
-func BenchmarkForceCWandForceCCW(b *testing.B) {
-	for i, tt := range []struct {
+func BenchmarkForceCWandForceCCWalreadyOrientedCorrectly(b *testing.B) {
+	for i, tc := range []struct {
 		wkt     string
 		geoType GeometryType
 		isCW    bool
@@ -440,12 +440,14 @@ func BenchmarkForceCWandForceCCW(b *testing.B) {
 		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
 	} {
 		b.Run(strconv.Itoa(i), func(b *testing.B) {
-			g := geomFromWKT(b, tt.wkt)
+			g := geomFromWKT(b, tc.wkt)
 			for i := 0; i < b.N; i++ {
-				g.ForceCW()
-				g.ForceCCW()
+				if tc.isCW {
+					g.ForceCW()
+				} else if tc.isCCW {
+					g.ForceCCW()
+				}
 			}
 		})
 	}
-
 }

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -441,6 +441,8 @@ func BenchmarkForceCWandForceCCWalreadyOrientedCorrectly(b *testing.B) {
 	} {
 		b.Run(strconv.Itoa(i), func(b *testing.B) {
 			g := geomFromWKT(b, tc.wkt)
+
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if tc.isCW {
 					g.ForceCW()

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -423,7 +423,7 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 	}
 }
 
-func BenchmarkForceCWandForceCCWalreadyOrientedCorrectly(b *testing.B) {
+func BenchmarkForceCWandForceCCWOrientedCorrectly(b *testing.B) {
 	for i, tc := range []struct {
 		wkt     string
 		geoType GeometryType
@@ -448,6 +448,37 @@ func BenchmarkForceCWandForceCCWalreadyOrientedCorrectly(b *testing.B) {
 					g.ForceCW()
 				} else if tc.isCCW {
 					g.ForceCCW()
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkForceCWandForceCCWOrientedIncorrectly(b *testing.B) {
+	for i, tc := range []struct {
+		wkt     string
+		geoType GeometryType
+		isCW    bool
+		isCCW   bool
+		note    string
+	}{
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", TypePolygon, true, false, "CW"},
+		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", TypePolygon, false, true, "CCW"},
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", TypePolygon, true, false, "outer CW inner CCW"},
+		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", TypePolygon, false, true, "outer CCW inner CW"},
+		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", TypeMultiPolygon, true, false, "all CW"},
+		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, true, "all CCW"},
+		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
+	} {
+		b.Run(strconv.Itoa(i), func(b *testing.B) {
+			g := geomFromWKT(b, tc.wkt)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if tc.isCW {
+					g.ForceCCW()
+				} else if tc.isCCW {
+					g.ForceCW()
 				}
 			}
 		})

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -765,6 +765,9 @@ func (g Geometry) PointOnSurface() Point {
 // clockwise orientation and any inner rings in a counter-clockwise
 // orientation. Non-areal geometrys are returned as is.
 func (g Geometry) ForceCW() Geometry {
+	if g.IsCW() {
+		return g
+	}
 	return g.forceOrientation(true)
 }
 
@@ -772,6 +775,9 @@ func (g Geometry) ForceCW() Geometry {
 // counter-clockwise orientation and any inner rings in a clockwise
 // orientation. Non-areal geometrys are returned as is.
 func (g Geometry) ForceCCW() Geometry {
+	if g.IsCCW() {
+		return g
+	}
 	return g.forceOrientation(false)
 }
 

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -433,6 +433,9 @@ func (c GeometryCollection) PointOnSurface() Point {
 // exterior rings clockwise and interior rings counter-clockwise). Geometries
 // other that Polygons and MultiPolygons are unchanged.
 func (c GeometryCollection) ForceCW() GeometryCollection {
+	if c.IsCW() {
+		return c
+	}
 	return c.forceOrientation(true)
 }
 
@@ -441,6 +444,9 @@ func (c GeometryCollection) ForceCW() GeometryCollection {
 // exterior rings counter-clockwise and interior rings clockwise). Geometries
 // other that Polygons and MultiPolygons are unchanged.
 func (c GeometryCollection) ForceCCW() GeometryCollection {
+	if c.IsCCW() {
+		return c
+	}
 	return c.forceOrientation(false)
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -436,6 +436,9 @@ func (m MultiPolygon) PointOnSurface() Point {
 // clockwise orientation and any inner rings in a counter-clockwise
 // orientation.
 func (m MultiPolygon) ForceCW() MultiPolygon {
+	if m.IsCW() {
+		return m
+	}
 	return m.forceOrientation(true)
 }
 
@@ -443,6 +446,9 @@ func (m MultiPolygon) ForceCW() MultiPolygon {
 // a counter-clockwise orientation and any inner rings in a clockwise
 // orientation.
 func (m MultiPolygon) ForceCCW() MultiPolygon {
+	if m.IsCCW() {
+		return m
+	}
 	return m.forceOrientation(false)
 }
 

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -536,6 +536,9 @@ func (p Polygon) PointOnSurface() Point {
 // clockwise orientation and any inner rings in a counter-clockwise
 // orientation.
 func (p Polygon) ForceCW() Polygon {
+	if p.IsCW() {
+		return p
+	}
 	return p.forceOrientation(true)
 }
 
@@ -543,6 +546,9 @@ func (p Polygon) ForceCW() Polygon {
 // counter-clockwise orientation and any inner rings in a clockwise
 // orientation.
 func (p Polygon) ForceCCW() Polygon {
+	if p.IsCCW() {
+		return p
+	}
 	return p.forceOrientation(false)
 }
 


### PR DESCRIPTION
## Description

Avoid creating new geometry in ForceCW/ForceCCW when orientation is already correct.

## Check List

Have you:

- Added unit tests? No new unit tests, added benchmark tests.

- Add cmprefimpl tests? No

- Updated release notes? No

## Related Issue

https://github.com/peterstace/simplefeatures/issues/241

## Benchmark Results

- These benchmarks were produced using the `run_benchmarks.sh` script.
```
$ .ci/run_benchmarks.sh 63264d1ec1e525218cc4a27b4e18f820048029f4 1e159abedfdd9160bba45ccbe9be3aefbec027cd
```

<details>

<summary>Click to expand</summary>

```
COMPARISON
name                                                         old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-12                                              4.65ns ±12%    4.61ns ±10%      ~     (p=0.720 n=15+15)
LineEnvelope/1-12                                              4.06ns ± 0%    4.05ns ± 1%      ~     (p=0.256 n=13+15)
LineEnvelope/2-12                                              4.20ns ± 1%    4.21ns ± 2%      ~     (p=0.612 n=15+14)
LineEnvelope/3-12                                              4.20ns ± 1%    4.20ns ± 2%      ~     (p=0.399 n=13+15)
MarshalWKB/polygon/n=10-12                                      188ns ±42%     186ns ±42%      ~     (p=0.642 n=14+14)
MarshalWKB/polygon/n=100-12                                     517ns ±61%     452ns ±34%      ~     (p=0.558 n=14+13)
MarshalWKB/polygon/n=1000-12                                   2.92µs ±59%    2.63µs ±24%      ~     (p=0.677 n=14+11)
MarshalWKB/polygon/n=10000-12                                  22.2µs ±65%    19.6µs ±22%      ~     (p=0.799 n=15+11)
UnmarshalWKB/polygon/n=10-12                                    439ns ±51%     400ns ±32%      ~     (p=0.369 n=15+13)
UnmarshalWKB/polygon/n=100-12                                   877ns ±61%     835ns ±43%      ~     (p=0.846 n=15+15)
UnmarshalWKB/polygon/n=1000-12                                 4.08µs ±70%    4.10µs ±35%      ~     (p=0.744 n=15+15)
UnmarshalWKB/polygon/n=10000-12                                35.0µs ±77%    33.8µs ±41%      ~     (p=1.000 n=15+15)
IntersectsLineStringWithLineString/n=10-12                     2.52µs ±40%    2.50µs ±50%      ~     (p=0.983 n=14+15)
IntersectsLineStringWithLineString/n=100-12                    44.6µs ±53%    38.6µs ±62%      ~     (p=0.217 n=15+15)
IntersectsLineStringWithLineString/n=1000-12                    351µs ±49%     383µs ±48%      ~     (p=0.389 n=15+15)
IntersectsLineStringWithLineString/n=10000-12                  4.93ms ±56%    5.13ms ±66%      ~     (p=0.653 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20-12                     1.31µs ±44%    1.30µs ±63%      ~     (p=0.895 n=15+15)
IntersectsMultiPointWithMultiPoint/n=200-12                    11.0µs ± 8%    12.7µs ±51%   +16.02%  (p=0.020 n=13+15)
IntersectsMultiPointWithMultiPoint/n=2000-12                    110µs ± 8%     112µs ±11%      ~     (p=0.635 n=14+14)
IntersectsMultiPointWithMultiPoint/n=20000-12                  1.22ms ±14%    1.28ms ±21%      ~     (p=0.339 n=13+15)
PolygonSingleRingValidation/n=10-12                            2.61µs ±28%    2.70µs ±43%      ~     (p=0.892 n=13+15)
PolygonSingleRingValidation/n=100-12                           44.7µs ±36%    43.6µs ±31%      ~     (p=0.839 n=14+14)
PolygonSingleRingValidation/n=1000-12                           433µs ±22%     446µs ±36%      ~     (p=0.734 n=14+14)
PolygonSingleRingValidation/n=10000-12                         6.04ms ±51%    6.04ms ±68%      ~     (p=0.624 n=15+15)
PolygonMultipleRingsValidation/n=4-12                          11.0µs ±50%     9.1µs ±48%      ~     (p=0.050 n=15+15)
PolygonMultipleRingsValidation/n=36-12                         86.2µs ±42%    88.1µs ±74%      ~     (p=0.715 n=14+15)
PolygonMultipleRingsValidation/n=400-12                        1.27ms ±45%    1.23ms ±40%      ~     (p=0.775 n=15+15)
PolygonMultipleRingsValidation/n=4096-12                       14.3ms ±37%    14.0ms ±40%      ~     (p=0.653 n=15+15)
PolygonZigZagRingsValidation/n=10-12                           18.5µs ±44%    19.4µs ±41%      ~     (p=0.591 n=14+15)
PolygonZigZagRingsValidation/n=100-12                           205µs ±44%     200µs ±58%      ~     (p=0.715 n=14+15)
PolygonZigZagRingsValidation/n=1000-12                         1.62ms ±37%    1.71ms ±43%      ~     (p=0.376 n=14+14)
PolygonZigZagRingsValidation/n=10000-12                        19.3ms ±23%    20.9ms ±28%      ~     (p=0.454 n=14+14)
PolygonAnnulusValidation/n=10-12                               5.42µs ±32%    5.23µs ±35%      ~     (p=0.775 n=15+15)
PolygonAnnulusValidation/n=100-12                              53.6µs ±43%    55.5µs ±33%      ~     (p=0.713 n=15+15)
PolygonAnnulusValidation/n=1000-12                              876µs ±39%     849µs ±73%      ~     (p=0.624 n=15+15)
PolygonAnnulusValidation/n=10000-12                            9.85ms ±51%    9.75ms ±36%      ~     (p=0.967 n=15+15)
MultipolygonValidation/n=1-12                                   638ns ±36%     629ns ±31%      ~     (p=0.821 n=15+14)
MultipolygonValidation/n=4-12                                  1.58µs ±64%    1.80µs ±25%      ~     (p=0.083 n=15+15)
MultipolygonValidation/n=16-12                                 7.94µs ±45%    7.58µs ±55%      ~     (p=0.806 n=15+15)
MultipolygonValidation/n=64-12                                 34.5µs ±33%    26.9µs ±44%   -21.85%  (p=0.015 n=13+15)
MultipolygonValidation/n=256-12                                 172µs ±44%     140µs ±78%      ~     (p=0.089 n=15+15)
MultipolygonValidation/n=1024-12                                769µs ±35%     746µs ±86%      ~     (p=0.461 n=15+15)
MultiPolygonTwoCircles/n=10-12                                 5.52µs ±41%    5.65µs ±57%      ~     (p=1.000 n=15+15)
MultiPolygonTwoCircles/n=100-12                                67.6µs ±47%    69.9µs ±49%      ~     (p=0.683 n=15+15)
MultiPolygonTwoCircles/n=1000-12                                810µs ±67%     753µs ±47%      ~     (p=0.595 n=15+15)
MultiPolygonTwoCircles/n=10000-12                              9.34ms ±51%    9.28ms ±63%      ~     (p=0.870 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-12                      8.54µs ±36%    8.73µs ±50%      ~     (p=0.806 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-12                    64.2µs ±102%    61.6µs ±41%      ~     (p=0.914 n=15+14)
MultiPolygonMultipleTouchingPoints/n=100-12                     538µs ±28%     581µs ±63%      ~     (p=0.804 n=14+14)
MultiPolygonMultipleTouchingPoints/n=1000-12                   6.23ms ±41%    6.11ms ±34%      ~     (p=0.847 n=15+14)
WKTParsing/point-12                                            2.60µs ±45%    2.38µs ±45%      ~     (p=0.305 n=15+15)
DistancePolygonToPolygonOrdering/n=100_swap=false-12           83.9µs ±58%    74.2µs ±82%      ~     (p=0.106 n=15+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-12            83.6µs ±61%    80.6µs ±59%      ~     (p=0.539 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=false-12          1.17ms ±50%    1.03ms ±37%      ~     (p=0.285 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-12           1.01ms ±34%    0.94ms ±57%      ~     (p=0.250 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-12     7.33µs ±34%    8.95µs ±45%      ~     (p=0.217 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-12      9.82µs ±39%   10.29µs ±58%      ~     (p=0.775 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-12     114µs ±60%     101µs ±74%      ~     (p=0.367 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-12      107µs ±66%      84µs ±46%      ~     (p=0.102 n=15+14)
MultiLineStringIsSimpleManyLineStrings/n=100-12                91.1µs ±46%    87.5µs ±77%      ~     (p=0.683 n=15+15)
MultiLineStringIsSimpleManyLineStrings/n=1000-12               1.08ms ±55%    0.93ms ±58%      ~     (p=0.106 n=15+15)
ForceCWandForceCCWOrientedCorrectly/0-12                        176ns ±62%      36ns ± 1%   -79.45%  (p=0.000 n=15+14)
ForceCWandForceCCWOrientedCorrectly/1-12                        159ns ±59%      36ns ± 1%   -77.23%  (p=0.000 n=14+14)
ForceCWandForceCCWOrientedCorrectly/2-12                        204ns ±54%      64ns ± 1%   -68.76%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/3-12                        206ns ±64%      64ns ± 1%   -68.92%  (p=0.000 n=15+14)
ForceCWandForceCCWOrientedCorrectly/4-12                        391ns ±32%      93ns ± 2%   -76.28%  (p=0.000 n=14+13)
ForceCWandForceCCWOrientedCorrectly/5-12                        413ns ±55%      93ns ± 2%   -77.57%  (p=0.000 n=15+14)
ForceCWandForceCCWOrientedCorrectly/6-12                        682ns ±53%     137ns ± 2%   -79.90%  (p=0.000 n=15+14)
ForceCWandForceCCWOrientedIncorrectly/0-12                      225ns ±47%     205ns ±13%      ~     (p=1.000 n=15+15)
ForceCWandForceCCWOrientedIncorrectly/1-12                      272ns ±38%     206ns ±19%   -24.34%  (p=0.001 n=15+14)
ForceCWandForceCCWOrientedIncorrectly/2-12                      476ns ±64%     358ns ±29%   -24.74%  (p=0.034 n=15+14)
ForceCWandForceCCWOrientedIncorrectly/3-12                      424ns ±58%     449ns ±39%      ~     (p=0.568 n=15+14)
ForceCWandForceCCWOrientedIncorrectly/4-12                      662ns ±38%     727ns ±24%      ~     (p=0.125 n=13+14)
ForceCWandForceCCWOrientedIncorrectly/5-12                      732ns ±30%     715ns ±33%      ~     (p=0.711 n=13+14)
ForceCWandForceCCWOrientedIncorrectly/6-12                     1.27µs ±61%    1.16µs ±27%      ~     (p=0.616 n=15+15)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-12                          42.3µs ± 6%    42.0µs ± 4%      ~     (p=0.720 n=14+13)
IntersectionWithoutValidation/n=100-12                         81.6µs ± 2%    81.4µs ± 1%      ~     (p=0.400 n=14+15)
IntersectionWithoutValidation/n=1000-12                         341µs ± 6%     342µs ± 6%      ~     (p=0.880 n=15+14)
IntersectionWithoutValidation/n=10000-12                       2.97ms ± 9%    3.03ms ± 5%      ~     (p=0.377 n=15+14)
NoOp/n=10-12                                                   3.79µs ± 4%    3.82µs ± 3%      ~     (p=0.295 n=14+15)
NoOp/n=100-12                                                  11.0µs ± 3%    11.0µs ± 6%      ~     (p=0.738 n=15+14)
NoOp/n=1000-12                                                 78.8µs ± 5%    77.8µs ± 4%      ~     (p=0.400 n=15+14)
NoOp/n=10000-12                                                 725µs ± 9%     730µs ± 8%      ~     (p=0.635 n=14+14)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-12                               1.95µs ±17%    1.95µs ±28%      ~     (p=0.376 n=14+14)
LineStringIsSimpleCircle/n=100-12                              38.2µs ±43%    39.1µs ±39%      ~     (p=0.775 n=15+15)
LineStringIsSimpleCircle/n=1000-12                              389µs ±20%     364µs ± 4%    -6.35%  (p=0.046 n=14+12)
LineStringIsSimpleCircle/n=10000-12                            5.11ms ±28%    4.62ms ± 9%    -9.76%  (p=0.004 n=15+13)
LineStringIsSimpleZigZag/10-12                                 2.34µs ±40%    2.23µs ±48%      ~     (p=0.425 n=14+15)
LineStringIsSimpleZigZag/100-12                                46.6µs ±46%    46.7µs ±49%      ~     (p=0.967 n=15+15)
LineStringIsSimpleZigZag/1000-12                                374µs ±11%     407µs ±37%      ~     (p=0.755 n=12+15)
LineStringIsSimpleZigZag/10000-12                              4.86ms ±20%    4.71ms ±10%      ~     (p=0.648 n=15+12)
SetOperation/n=4/Go_Intersection-12                            46.8µs ±31%    44.8µs ±42%      ~     (p=0.252 n=15+14)
SetOperation/n=4/Go_Difference-12                              50.9µs ±26%    50.0µs ±30%      ~     (p=0.806 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-12                     64.8µs ±40%    66.8µs ±36%      ~     (p=0.653 n=15+15)
SetOperation/n=4/Go_Union-12                                   54.4µs ±35%    53.2µs ±42%      ~     (p=0.624 n=15+15)
SetOperation/n=4/GEOS_Intersection-12                          42.7µs ± 3%    42.8µs ± 4%      ~     (p=0.967 n=15+15)
SetOperation/n=4/GEOS_Difference-12                            44.2µs ± 2%    44.2µs ± 2%      ~     (p=0.949 n=15+14)
SetOperation/n=4/GEOS_SymmetricDifference-12                   63.2µs ± 1%    62.8µs ± 1%    -0.64%  (p=0.032 n=12+15)
SetOperation/n=4/GEOS_Union-12                                 45.1µs ± 4%    45.0µs ± 3%      ~     (p=0.747 n=15+14)
SetOperation/n=8/Go_Intersection-12                            51.1µs ± 8%    50.8µs ± 6%      ~     (p=0.747 n=15+14)
SetOperation/n=8/Go_Difference-12                              56.1µs ±19%    58.2µs ±24%      ~     (p=0.461 n=15+15)
SetOperation/n=8/Go_SymmetricDifference-12                     82.8µs ±32%    81.4µs ±40%      ~     (p=0.902 n=15+15)
SetOperation/n=8/Go_Union-12                                   71.2µs ±66%    64.0µs ±37%      ~     (p=0.486 n=15+15)
SetOperation/n=8/GEOS_Intersection-12                          50.6µs ± 6%    49.7µs ± 3%      ~     (p=0.061 n=14+13)
SetOperation/n=8/GEOS_Difference-12                            50.8µs ± 4%    50.9µs ± 2%      ~     (p=0.325 n=15+15)
SetOperation/n=8/GEOS_SymmetricDifference-12                   73.9µs ± 2%    73.9µs ± 1%      ~     (p=0.411 n=13+13)
SetOperation/n=8/GEOS_Union-12                                 51.5µs ± 4%    51.5µs ± 3%      ~     (p=0.683 n=15+15)
SetOperation/n=16/Go_Intersection-12                           70.0µs ± 6%    71.7µs ± 7%      ~     (p=0.058 n=13+15)
SetOperation/n=16/Go_Difference-12                             85.2µs ±34%    85.4µs ±17%      ~     (p=0.591 n=14+15)
SetOperation/n=16/Go_SymmetricDifference-12                     138µs ±30%     115µs ±23%   -16.52%  (p=0.026 n=15+14)
SetOperation/n=16/Go_Union-12                                   108µs ±39%      93µs ±26%      ~     (p=0.102 n=15+14)
SetOperation/n=16/GEOS_Intersection-12                         54.8µs ± 4%    55.5µs ± 4%      ~     (p=0.114 n=14+14)
SetOperation/n=16/GEOS_Difference-12                           60.1µs ± 4%    59.9µs ± 2%      ~     (p=0.838 n=15+15)
SetOperation/n=16/GEOS_SymmetricDifference-12                  97.0µs ± 2%    97.2µs ± 1%      ~     (p=0.373 n=15+12)
SetOperation/n=16/GEOS_Union-12                                63.2µs ± 3%    62.8µs ± 3%      ~     (p=0.104 n=15+15)
SetOperation/n=32/Go_Intersection-12                            127µs ±11%     127µs ±13%      ~     (p=0.683 n=15+15)
SetOperation/n=32/Go_Difference-12                              148µs ±23%     149µs ±36%      ~     (p=0.983 n=14+15)
SetOperation/n=32/Go_SymmetricDifference-12                     214µs ±34%     224µs ±33%      ~     (p=0.425 n=15+14)
SetOperation/n=32/Go_Union-12                                   156µs ±41%     199µs ±33%   +27.70%  (p=0.003 n=13+15)
SetOperation/n=32/GEOS_Intersection-12                         67.4µs ± 3%    66.8µs ± 4%      ~     (p=0.234 n=15+14)
SetOperation/n=32/GEOS_Difference-12                           74.4µs ± 2%    74.4µs ± 3%      ~     (p=0.935 n=15+15)
SetOperation/n=32/GEOS_SymmetricDifference-12                   134µs ± 7%     131µs ± 2%    -2.59%  (p=0.029 n=15+14)
SetOperation/n=32/GEOS_Union-12                                79.9µs ± 2%    79.2µs ± 1%      ~     (p=0.060 n=13+12)
SetOperation/n=64/Go_Intersection-12                            208µs ±11%     214µs ±10%      ~     (p=0.056 n=14+14)
SetOperation/n=64/Go_Difference-12                              280µs ±23%     256µs ±26%      ~     (p=0.161 n=15+15)
SetOperation/n=64/Go_SymmetricDifference-12                     392µs ±50%     390µs ±47%      ~     (p=0.847 n=15+14)
SetOperation/n=64/Go_Union-12                                   324µs ±49%     349µs ±38%      ~     (p=0.400 n=15+14)
SetOperation/n=64/GEOS_Intersection-12                         88.0µs ± 4%    88.4µs ± 4%      ~     (p=0.503 n=14+14)
SetOperation/n=64/GEOS_Difference-12                            109µs ± 1%     109µs ± 1%      ~     (p=0.616 n=13+14)
SetOperation/n=64/GEOS_SymmetricDifference-12                   213µs ± 8%     211µs ± 5%      ~     (p=0.567 n=15+15)
SetOperation/n=64/GEOS_Union-12                                 124µs ± 9%     123µs ± 9%      ~     (p=0.870 n=15+15)
SetOperation/n=128/Go_Intersection-12                           419µs ±24%     386µs ± 5%      ~     (p=0.053 n=15+12)
SetOperation/n=128/Go_Difference-12                             498µs ±36%     515µs ±29%      ~     (p=0.595 n=15+15)
SetOperation/n=128/Go_SymmetricDifference-12                    695µs ±50%     770µs ±39%      ~     (p=0.202 n=15+15)
SetOperation/n=128/Go_Union-12                                  536µs ±37%     623µs ±90%      ~     (p=0.389 n=15+15)
SetOperation/n=128/GEOS_Intersection-12                         140µs ±12%     138µs ± 8%      ~     (p=0.689 n=13+12)
SetOperation/n=128/GEOS_Difference-12                           163µs ± 1%     163µs ± 3%      ~     (p=0.259 n=13+14)
SetOperation/n=128/GEOS_SymmetricDifference-12                  352µs ±19%     351µs ±11%      ~     (p=0.744 n=15+15)
SetOperation/n=128/GEOS_Union-12                                181µs ± 4%     180µs ± 2%      ~     (p=0.920 n=13+13)
SetOperation/n=256/Go_Intersection-12                           748µs ±29%     711µs ± 7%      ~     (p=0.719 n=15+12)
SetOperation/n=256/Go_Difference-12                             919µs ±19%     852µs ±22%      ~     (p=0.114 n=15+12)
SetOperation/n=256/Go_SymmetricDifference-12                   1.30ms ±39%    1.29ms ±38%      ~     (p=0.983 n=15+14)
SetOperation/n=256/Go_Union-12                                  978µs ±38%    1036µs ±64%      ~     (p=0.533 n=15+14)
SetOperation/n=256/GEOS_Intersection-12                         203µs ± 4%     207µs ± 5%      ~     (p=0.155 n=13+14)
SetOperation/n=256/GEOS_Difference-12                           264µs ± 1%     265µs ± 2%      ~     (p=0.960 n=13+13)
SetOperation/n=256/GEOS_SymmetricDifference-12                  682µs ±26%     677µs ±41%      ~     (p=0.325 n=15+15)
SetOperation/n=256/GEOS_Union-12                                351µs ±39%     336µs ±28%      ~     (p=0.561 n=15+14)
SetOperation/n=512/Go_Intersection-12                          1.64ms ±29%    1.71ms ±27%      ~     (p=0.512 n=15+15)
SetOperation/n=512/Go_Difference-12                            2.03ms ±31%    1.78ms ±59%      ~     (p=0.070 n=15+14)
SetOperation/n=512/Go_SymmetricDifference-12                   3.01ms ±55%    2.37ms ±43%   -21.31%  (p=0.009 n=14+14)
SetOperation/n=512/Go_Union-12                                 1.96ms ±34%    1.99ms ±73%      ~     (p=0.813 n=15+14)
SetOperation/n=512/GEOS_Intersection-12                         364µs ± 3%     370µs ± 9%      ~     (p=0.616 n=13+14)
SetOperation/n=512/GEOS_Difference-12                           502µs ±14%     483µs ± 8%      ~     (p=0.070 n=15+14)
SetOperation/n=512/GEOS_SymmetricDifference-12                 1.19ms ±24%    1.14ms ±10%      ~     (p=0.172 n=15+14)
SetOperation/n=512/GEOS_Union-12                                564µs ± 6%     569µs ±16%      ~     (p=0.533 n=15+14)
SetOperation/n=1024/Go_Intersection-12                         2.92ms ±14%    2.95ms ±19%      ~     (p=0.847 n=14+15)
SetOperation/n=1024/Go_Difference-12                           3.37ms ±21%    3.93ms ±46%      ~     (p=0.161 n=15+15)
SetOperation/n=1024/Go_SymmetricDifference-12                  5.52ms ±64%    6.67ms ±50%      ~     (p=0.174 n=15+15)
SetOperation/n=1024/Go_Union-12                                3.91ms ±64%    4.46ms ±61%      ~     (p=0.354 n=14+15)
SetOperation/n=1024/GEOS_Intersection-12                        679µs ± 8%     678µs ±13%      ~     (p=0.650 n=14+13)
SetOperation/n=1024/GEOS_Difference-12                         1.03ms ±16%    0.96ms ± 9%      ~     (p=0.058 n=15+13)
SetOperation/n=1024/GEOS_SymmetricDifference-12                2.61ms ±16%    2.54ms ±32%      ~     (p=0.555 n=15+13)
SetOperation/n=1024/GEOS_Union-12                              1.37ms ±26%    1.29ms ±39%      ~     (p=0.285 n=15+15)
SetOperation/n=2048/Go_Intersection-12                         6.71ms ±23%    6.20ms ±27%      ~     (p=0.172 n=15+14)
SetOperation/n=2048/Go_Difference-12                           8.47ms ±54%    8.17ms ±26%      ~     (p=0.744 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference-12                  13.1ms ±35%    13.0ms ±31%      ~     (p=0.874 n=14+14)
SetOperation/n=2048/Go_Union-12                                10.8ms ±43%    11.3ms ±21%      ~     (p=0.910 n=14+14)
SetOperation/n=2048/GEOS_Intersection-12                       1.67ms ±44%    1.77ms ±74%      ~     (p=0.902 n=15+15)
SetOperation/n=2048/GEOS_Difference-12                         1.81ms ±11%    1.89ms ±16%      ~     (p=0.285 n=14+14)
SetOperation/n=2048/GEOS_SymmetricDifference-12                4.79ms ±26%    4.86ms ±43%      ~     (p=0.983 n=15+14)
SetOperation/n=2048/GEOS_Union-12                              2.40ms ±26%    2.44ms ±39%      ~     (p=0.621 n=15+14)
SetOperation/n=4096/Go_Intersection-12                         15.7ms ±31%    14.6ms ±33%      ~     (p=0.331 n=15+14)
SetOperation/n=4096/Go_Difference-12                           19.2ms ±43%    17.7ms ±23%      ~     (p=0.440 n=15+13)
SetOperation/n=4096/Go_SymmetricDifference-12                  30.6ms ±45%    27.0ms ±52%      ~     (p=0.148 n=15+15)
SetOperation/n=4096/Go_Union-12                                26.5ms ±30%    20.4ms ±36%   -22.82%  (p=0.009 n=14+14)
SetOperation/n=4096/GEOS_Intersection-12                       2.45ms ± 3%    2.58ms ±14%      ~     (p=0.054 n=13+14)
SetOperation/n=4096/GEOS_Difference-12                         4.08ms ±29%    3.71ms ± 4%      ~     (p=0.102 n=15+14)
SetOperation/n=4096/GEOS_SymmetricDifference-12                12.7ms ±40%    11.6ms ±51%      ~     (p=0.412 n=15+15)
SetOperation/n=4096/GEOS_Union-12                              5.18ms ±24%    5.68ms ±37%      ~     (p=0.170 n=13+15)
SetOperation/n=8192/Go_Intersection-12                         29.6ms ±36%    28.8ms ±25%      ~     (p=0.775 n=15+15)
SetOperation/n=8192/Go_Difference-12                           30.5ms ±26%    28.4ms ±19%      ~     (p=0.186 n=15+14)
SetOperation/n=8192/Go_SymmetricDifference-12                  43.3ms ±25%    42.4ms ±36%      ~     (p=0.331 n=14+15)
SetOperation/n=8192/Go_Union-12                                32.6ms ±35%    32.6ms ±27%      ~     (p=0.653 n=15+15)
SetOperation/n=8192/GEOS_Intersection-12                       5.04ms ± 7%    5.04ms ± 6%      ~     (p=0.747 n=15+14)
SetOperation/n=8192/GEOS_Difference-12                         7.42ms ± 8%    7.41ms ± 6%      ~     (p=0.290 n=14+15)
SetOperation/n=8192/GEOS_SymmetricDifference-12                18.7ms ±10%    19.9ms ±26%      ~     (p=0.363 n=13+15)
SetOperation/n=8192/GEOS_Union-12                              9.25ms ±10%    9.89ms ±20%      ~     (p=0.425 n=14+15)
SetOperation/n=16384/Go_Intersection-12                        51.7ms ±13%    50.0ms ± 4%      ~     (p=0.123 n=15+14)
SetOperation/n=16384/Go_Difference-12                          53.1ms ± 3%    53.3ms ± 2%      ~     (p=0.376 n=14+14)
SetOperation/n=16384/Go_SymmetricDifference-12                 74.8ms ±10%    74.6ms ± 8%      ~     (p=0.839 n=14+14)
SetOperation/n=16384/Go_Union-12                               56.2ms ± 3%    56.9ms ± 5%      ~     (p=0.505 n=14+15)
SetOperation/n=16384/GEOS_Intersection-12                      10.3ms ± 3%    10.4ms ± 6%      ~     (p=0.108 n=13+15)
SetOperation/n=16384/GEOS_Difference-12                        16.9ms ±20%    16.6ms ±22%      ~     (p=0.567 n=15+15)
SetOperation/n=16384/GEOS_SymmetricDifference-12               38.9ms ± 9%    38.7ms ± 7%      ~     (p=0.561 n=14+15)
SetOperation/n=16384/GEOS_Union-12                             18.8ms ± 8%    18.4ms ± 3%      ~     (p=0.088 n=15+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-12                                                20.6µs ± 9%    20.8µs ± 6%      ~     (p=0.412 n=15+15)
Delete/n=1000-12                                                654µs ± 2%     651µs ± 1%      ~     (p=0.217 n=15+13)
Delete/n=10000-12                                              31.0ms ± 3%    30.9ms ± 2%      ~     (p=0.477 n=15+14)
Bulk/n=10-12                                                    849ns ±37%     734ns ±31%      ~     (p=0.087 n=15+14)
Bulk/n=100-12                                                  27.7µs ±55%    24.1µs ±70%      ~     (p=0.389 n=15+15)
Bulk/n=1000-12                                                  273µs ±26%     267µs ±35%      ~     (p=0.436 n=15+15)
Bulk/n=10000-12                                                3.96ms ±23%    3.58ms ±32%    -9.59%  (p=0.045 n=15+15)
Bulk/n=100000-12                                               36.3ms ± 2%    36.6ms ± 2%      ~     (p=0.052 n=15+13)
Insert/n=10-12                                                 1.14µs ±25%    1.13µs ±30%      ~     (p=0.767 n=15+15)
Insert/n=100-12                                                27.9µs ±35%    25.1µs ±48%      ~     (p=0.137 n=15+15)
Insert/n=1000-12                                                458µs ±36%     423µs ± 5%      ~     (p=0.373 n=15+12)
Insert/n=10000-12                                              5.61ms ±40%    5.10ms ± 2%    -9.05%  (p=0.046 n=14+12)
Insert/n=100000-12                                             57.9ms ± 1%    57.8ms ± 1%      ~     (p=0.591 n=15+14)
RangeSearch/n=10-12                                            15.7ns ± 3%    15.8ns ± 1%      ~     (p=0.073 n=14+15)
RangeSearch/n=100-12                                           63.1ns ± 3%    63.2ns ± 2%      ~     (p=0.255 n=15+14)
RangeSearch/n=1000-12                                           231ns ± 1%     233ns ± 3%    +1.12%  (p=0.003 n=13+15)
RangeSearch/n=10000-12                                          762ns ± 1%     768ns ± 1%    +0.78%  (p=0.012 n=14+15)
RangeSearch/n=100000-12                                        6.85µs ± 3%    6.83µs ± 3%      ~     (p=0.567 n=15+15)

name                                                         old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-12                                                0.00           0.00           ~     (all equal)
LineEnvelope/1-12                                                0.00           0.00           ~     (all equal)
LineEnvelope/2-12                                                0.00           0.00           ~     (all equal)
LineEnvelope/3-12                                                0.00           0.00           ~     (all equal)
MarshalWKB/polygon/n=10-12                                       6.00 ± 0%      6.00 ± 0%      ~     (all equal)
MarshalWKB/polygon/n=100-12                                      6.00 ± 0%      6.00 ± 0%      ~     (all equal)
MarshalWKB/polygon/n=1000-12                                     6.00 ± 0%      6.00 ± 0%      ~     (all equal)
MarshalWKB/polygon/n=10000-12                                    6.00 ± 0%      6.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=10-12                                     7.00 ± 0%      7.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=100-12                                    7.00 ± 0%      7.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=1000-12                                   7.00 ± 0%      7.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=10000-12                                  7.00 ± 0%      7.00 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=10-12                       9.00 ± 0%      9.00 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=100-12                      73.0 ± 0%      73.0 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=1000-12                      345 ± 0%       345 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=10000-12                   5.46k ± 0%     5.46k ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-12                       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-12                      7.00 ± 0%      7.00 ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-12                     6.00 ± 0%      6.00 ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-12                    11.0 ± 0%      11.0 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=10-12                              12.0 ± 0%      12.0 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=100-12                             76.0 ± 0%      76.0 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=1000-12                             348 ± 0%       348 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=10000-12                          5.47k ± 0%     5.47k ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=4-12                            42.0 ± 0%      42.0 ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=36-12                            316 ± 0%       316 ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=400-12                         3.48k ± 0%     3.48k ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=4096-12                        36.2k ± 0%     36.2k ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=10-12                             41.0 ± 0%      41.0 ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=100-12                             233 ± 0%       233 ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=1000-12                          1.05k ± 0%     1.05k ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=10000-12                         16.4k ± 0%     16.4k ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=10-12                                 22.0 ± 0%      22.0 ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=100-12                                76.0 ± 0%      76.0 ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=1000-12                              1.00k ± 0%     1.00k ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=10000-12                             10.3k ± 0%     10.3k ± 0%      ~     (all equal)
MultipolygonValidation/n=1-12                                    8.00 ± 0%      8.00 ± 0%      ~     (all equal)
MultipolygonValidation/n=4-12                                    11.0 ± 0%      11.0 ± 0%      ~     (all equal)
MultipolygonValidation/n=16-12                                   27.0 ± 0%      27.0 ± 0%      ~     (all equal)
MultipolygonValidation/n=64-12                                   91.0 ± 0%      91.0 ± 0%      ~     (all equal)
MultipolygonValidation/n=256-12                                   347 ± 0%       347 ± 0%      ~     (all equal)
MultipolygonValidation/n=1024-12                                1.37k ± 0%     1.37k ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=10-12                                   29.0 ± 0%      29.0 ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=100-12                                   157 ± 0%       157 ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=1000-12                                  701 ± 0%       701 ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=10000-12                               10.9k ± 0%     10.9k ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-12                        51.0 ± 0%      51.0 ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-12                        298 ± 0%       298 ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-12                     2.62k ± 0%     2.62k ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-12                    26.7k ± 0%     26.7k ± 0%      ~     (p=0.406 n=14+15)
WKTParsing/point-12                                              22.0 ± 0%      22.0 ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-12              234 ± 0%       234 ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-12               234 ± 0%       234 ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-12           2.10k ± 0%     2.10k ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-12            2.10k ± 0%     2.10k ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-12       13.0 ± 0%      13.0 ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-12        13.0 ± 0%      13.0 ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-12      77.0 ± 0%      77.0 ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-12       77.0 ± 0%      77.0 ± 0%      ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-12                   371 ± 0%       371 ± 0%      ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-12                3.34k ± 0%     3.34k ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedCorrectly/0-12                         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/1-12                         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/2-12                         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/3-12                         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/4-12                         4.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/5-12                         4.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedCorrectly/6-12                         8.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ForceCWandForceCCWOrientedIncorrectly/0-12                       3.00 ± 0%      3.00 ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedIncorrectly/1-12                       3.00 ± 0%      3.00 ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedIncorrectly/2-12                       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedIncorrectly/3-12                       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedIncorrectly/4-12                       7.00 ± 0%      7.00 ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedIncorrectly/5-12                       7.00 ± 0%      7.00 ± 0%      ~     (all equal)
ForceCWandForceCCWOrientedIncorrectly/6-12                       12.0 ± 0%      12.0 ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-12                            31.0 ± 0%      31.0 ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=100-12                           31.0 ± 0%      31.0 ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=1000-12                          31.0 ± 0%      31.0 ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=10000-12                         31.0 ± 0%      31.0 ± 0%      ~     (all equal)
NoOp/n=10-12                                                     21.0 ± 0%      21.0 ± 0%      ~     (all equal)
NoOp/n=100-12                                                    21.0 ± 0%      21.0 ± 0%      ~     (all equal)
NoOp/n=1000-12                                                   21.0 ± 0%      21.0 ± 0%      ~     (all equal)
NoOp/n=10000-12                                                  21.0 ± 0%      21.0 ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-12                                 7.00 ± 0%      7.00 ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=100-12                                71.0 ± 0%      71.0 ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=1000-12                                343 ± 0%       343 ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=10000-12                             5.46k ± 0%     5.46k ± 0%    -0.01%  (p=0.026 n=13+15)
LineStringIsSimpleZigZag/10-12                                   7.00 ± 0%      7.00 ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/100-12                                  71.0 ± 0%      71.0 ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/1000-12                                  343 ± 0%       343 ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/10000-12                               5.46k ± 0%     5.46k ± 0%      ~     (all equal)
SetOperation/n=4/Go_Intersection-12                               278 ± 0%       274 ± 0%    -1.44%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference-12                                 282 ± 0%       278 ± 0%    -1.42%  (p=0.000 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-12                        380 ± 0%       376 ± 0%    -1.05%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union-12                                      289 ± 0%       285 ± 0%    -1.38%  (p=0.000 n=15+15)
SetOperation/n=4/GEOS_Intersection-12                            35.0 ± 0%      35.0 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Difference-12                              38.0 ± 0%      38.0 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-12                      131 ± 0%       131 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Union-12                                   39.0 ± 0%      39.0 ± 0%      ~     (all equal)
SetOperation/n=8/Go_Intersection-12                               294 ± 0%       290 ± 0%    -1.27%  (p=0.000 n=13+15)
SetOperation/n=8/Go_Difference-12                                 295 ± 0%       291 ± 0%    -1.36%  (p=0.000 n=12+12)
SetOperation/n=8/Go_SymmetricDifference-12                        399 ± 0%       395 ± 0%    -1.07%  (p=0.000 n=15+12)
SetOperation/n=8/Go_Union-12                                      300 ± 0%       296 ± 0%    -1.33%  (p=0.000 n=14+12)
SetOperation/n=8/GEOS_Intersection-12                            39.0 ± 0%      39.0 ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_Difference-12                              39.0 ± 0%      39.0 ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-12                      135 ± 0%       135 ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_Union-12                                   39.0 ± 0%      39.0 ± 0%      ~     (all equal)
SetOperation/n=16/Go_Intersection-12                              308 ± 0%       304 ± 0%    -1.30%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Difference-12                                318 ± 0%       314 ± 0%    -1.26%  (p=0.000 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-12                       447 ± 0%       443 ± 0%    -0.89%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Union-12                                     327 ± 0%       323 ± 0%    -1.22%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Intersection-12                           39.0 ± 0%      39.0 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Difference-12                             47.0 ± 0%      47.0 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-12                     168 ± 0%       168 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Union-12                                  51.0 ± 0%      51.0 ± 0%      ~     (all equal)
SetOperation/n=32/Go_Intersection-12                              359 ± 0%       355 ± 0%    -1.11%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Difference-12                                365 ± 0%       361 ± 0%    -1.10%  (p=0.000 n=15+15)
SetOperation/n=32/Go_SymmetricDifference-12                       518 ± 0%       514 ± 0%    -0.77%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Union-12                                     370 ± 0%       366 ± 0%    -1.08%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Intersection-12                           51.0 ± 0%      51.0 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Difference-12                             55.0 ± 0%      55.0 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-12                     199 ± 0%       199 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Union-12                                  55.0 ± 0%      55.0 ± 0%      ~     (all equal)
SetOperation/n=64/Go_Intersection-12                              400 ± 0%       396 ± 0%    -1.00%  (p=0.000 n=13+12)
SetOperation/n=64/Go_Difference-12                                434 ± 0%       430 ± 0%    -0.92%  (p=0.000 n=14+14)
SetOperation/n=64/Go_SymmetricDifference-12                       685 ± 0%       681 ± 0%    -0.55%  (p=0.000 n=13+15)
SetOperation/n=64/Go_Union-12                                     447 ± 0%       443 ± 0%    -0.84%  (p=0.000 n=12+15)
SetOperation/n=64/GEOS_Intersection-12                           55.0 ± 0%      55.0 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Difference-12                             87.0 ± 0%      87.0 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-12                     328 ± 0%       328 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Union-12                                  95.0 ± 0%      95.0 ± 0%      ~     (all equal)
SetOperation/n=128/Go_Intersection-12                             574 ± 0%       570 ± 0%    -0.70%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Difference-12                               600 ± 0%       596 ± 0%    -0.67%  (p=0.000 n=15+14)
SetOperation/n=128/Go_SymmetricDifference-12                      948 ± 0%       944 ± 0%    -0.42%  (p=0.000 n=15+14)
SetOperation/n=128/Go_Union-12                                    605 ± 0%       601 ± 0%    -0.66%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Intersection-12                          95.0 ± 0%      95.0 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Difference-12                             119 ± 0%       119 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-12                    456 ± 0%       456 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Union-12                                  119 ± 0%       119 ± 0%      ~     (all equal)
SetOperation/n=256/Go_Intersection-12                             733 ± 0%       729 ± 0%    -0.55%  (p=0.000 n=13+15)
SetOperation/n=256/Go_Difference-12                               863 ± 0%       859 ± 0%    -0.46%  (p=0.000 n=12+13)
SetOperation/n=256/Go_SymmetricDifference-12                    1.60k ± 0%     1.59k ± 0%    -0.25%  (p=0.000 n=15+12)
SetOperation/n=256/Go_Union-12                                    892 ± 0%       888 ± 0%    -0.45%  (p=0.000 n=13+14)
SetOperation/n=256/GEOS_Intersection-12                           119 ± 0%       119 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_Difference-12                             247 ± 0%       247 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-12                    968 ± 0%       968 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_Union-12                                  271 ± 0%       271 ± 0%      ~     (all equal)
SetOperation/n=512/Go_Intersection-12                           1.40k ± 0%     1.40k ± 0%    -0.27%  (p=0.000 n=13+15)
SetOperation/n=512/Go_Difference-12                             1.51k ± 0%     1.51k ± 0%    -0.28%  (p=0.000 n=15+15)
SetOperation/n=512/Go_SymmetricDifference-12                    2.63k ± 0%     2.62k ± 0%    -0.15%  (p=0.000 n=12+12)
SetOperation/n=512/Go_Union-12                                  1.51k ± 0%     1.51k ± 0%    -0.26%  (p=0.000 n=13+14)
SetOperation/n=512/GEOS_Intersection-12                           271 ± 0%       271 ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_Difference-12                             375 ± 0%       375 ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-12                  1.48k ± 0%     1.48k ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_Union-12                                  375 ± 0%       375 ± 0%      ~     (all equal)
SetOperation/n=1024/Go_Intersection-12                          2.03k ± 0%     2.03k ± 0%    -0.20%  (p=0.000 n=13+14)
SetOperation/n=1024/Go_Difference-12                            2.54k ± 0%     2.54k ± 0%    -0.16%  (p=0.000 n=12+15)
SetOperation/n=1024/Go_SymmetricDifference-12                   5.20k ± 0%     5.20k ± 0%    -0.08%  (p=0.000 n=14+14)
SetOperation/n=1024/Go_Union-12                                 2.64k ± 0%     2.63k ± 0%    -0.15%  (p=0.000 n=14+15)
SetOperation/n=1024/GEOS_Intersection-12                          375 ± 0%       375 ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_Difference-12                            887 ± 0%       887 ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-12                 3.53k ± 0%     3.53k ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_Union-12                                 975 ± 0%       975 ± 0%      ~     (all equal)
SetOperation/n=2048/Go_Intersection-12                          4.69k ± 0%     4.69k ± 0%    -0.09%  (p=0.000 n=13+15)
SetOperation/n=2048/Go_Difference-12                            5.12k ± 0%     5.11k ± 0%    -0.08%  (p=0.000 n=14+14)
SetOperation/n=2048/Go_SymmetricDifference-12                   9.31k ± 0%     9.31k ± 0%    -0.04%  (p=0.000 n=14+14)
SetOperation/n=2048/Go_Union-12                                 5.12k ± 0%     5.12k ± 0%    -0.08%  (p=0.000 n=15+13)
SetOperation/n=2048/GEOS_Intersection-12                          975 ± 0%       975 ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_Difference-12                          1.40k ± 0%     1.40k ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-12                 5.58k ± 0%     5.58k ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_Union-12                               1.40k ± 0%     1.40k ± 0%      ~     (all equal)
SetOperation/n=4096/Go_Intersection-12                          7.18k ± 0%     7.17k ± 0%    -0.05%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_Difference-12                            9.23k ± 0%     9.22k ± 0%    -0.04%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-12                   19.6k ± 0%     19.6k ± 0%    -0.02%  (p=0.000 n=10+14)
SetOperation/n=4096/Go_Union-12                                 9.58k ± 0%     9.57k ± 0%    -0.04%  (p=0.000 n=15+15)
SetOperation/n=4096/GEOS_Intersection-12                        1.40k ± 0%     1.40k ± 0%      ~     (all equal)
SetOperation/n=4096/GEOS_Difference-12                          3.45k ± 0%     3.45k ± 0%      ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-12                 13.8k ± 0%     13.8k ± 0%      ~     (all equal)
SetOperation/n=4096/GEOS_Union-12                               3.79k ± 0%     3.79k ± 0%      ~     (all equal)
SetOperation/n=8192/Go_Intersection-12                          17.8k ± 0%     17.8k ± 0%    -0.02%  (p=0.000 n=10+15)
SetOperation/n=8192/Go_Difference-12                            19.5k ± 0%     19.5k ± 0%    -0.02%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-12                   36.0k ± 0%     36.0k ± 0%    -0.01%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Union-12                                 19.5k ± 0%     19.5k ± 0%    -0.02%  (p=0.000 n=15+15)
SetOperation/n=8192/GEOS_Intersection-12                        3.79k ± 0%     3.79k ± 0%      ~     (all equal)
SetOperation/n=8192/GEOS_Difference-12                          5.50k ± 0%     5.50k ± 0%      ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-12                 22.0k ± 0%     22.0k ± 0%      ~     (all equal)
SetOperation/n=8192/GEOS_Union-12                               5.50k ± 0%     5.50k ± 0%      ~     (all equal)
SetOperation/n=16384/Go_Intersection-12                         27.7k ± 0%     27.7k ± 0%    -0.01%  (p=0.000 n=14+15)
SetOperation/n=16384/Go_Difference-12                           35.9k ± 0%     35.9k ± 0%    -0.01%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-12                  76.9k ± 0%     76.9k ± 0%    -0.01%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Union-12                                37.3k ± 0%     37.2k ± 0%    -0.01%  (p=0.000 n=15+15)
SetOperation/n=16384/GEOS_Intersection-12                       5.50k ± 0%     5.50k ± 0%      ~     (all equal)
SetOperation/n=16384/GEOS_Difference-12                         13.7k ± 0%     13.7k ± 0%      ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-12                54.7k ± 0%     54.7k ± 0%      ~     (p=0.084 n=15+14)
SetOperation/n=16384/GEOS_Union-12                              15.1k ± 0%     15.1k ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-12                                                  65.0 ± 0%      65.0 ± 0%      ~     (all equal)
Delete/n=1000-12                                                  480 ± 0%       480 ± 0%      ~     (all equal)
Delete/n=10000-12                                               7.62k ± 0%     7.62k ± 0%      ~     (all equal)
Bulk/n=10-12                                                     6.00 ± 0%      6.00 ± 0%      ~     (all equal)
Bulk/n=100-12                                                    70.0 ± 0%      70.0 ± 0%      ~     (all equal)
Bulk/n=1000-12                                                    342 ± 0%       342 ± 0%      ~     (all equal)
Bulk/n=10000-12                                                 5.46k ± 0%     5.46k ± 0%      ~     (all equal)
Bulk/n=100000-12                                                71.0k ± 0%     71.0k ± 0%      ~     (all equal)
Insert/n=10-12                                                   5.00 ± 0%      5.00 ± 0%      ~     (all equal)
Insert/n=100-12                                                  47.0 ± 0%      47.0 ± 0%      ~     (all equal)
Insert/n=1000-12                                                  457 ± 0%       457 ± 0%      ~     (all equal)
Insert/n=10000-12                                               4.65k ± 0%     4.65k ± 0%      ~     (all equal)
Insert/n=100000-12                                              46.8k ± 0%     46.8k ± 0%      ~     (all equal)
RangeSearch/n=10-12                                              0.00           0.00           ~     (all equal)
RangeSearch/n=100-12                                             0.00           0.00           ~     (all equal)
RangeSearch/n=1000-12                                            0.00           0.00           ~     (all equal)
RangeSearch/n=10000-12                                           0.00           0.00           ~     (all equal)
RangeSearch/n=100000-12                                          0.00           0.00           ~     (all equal)
```

</details>
