### PR TITLE
Fix `%w` verb in `t.Errorf` calls

### DIFF
--- a/geom/alg_set_op_test.go
+++ b/geom/alg_set_op_test.go
@@ -987,7 +987,7 @@ func TestBinaryOpNoCrash(t *testing.T) {
 			} {
 				t.Run(op.name, func(t *testing.T) {
 					if _, err := op.op(gA, gB); err != nil {
-						t.Errorf("unexpected error: %w", err)
+						t.Errorf("unexpected error: %v", err)
 					}
 				})
 			}

--- a/geom/ctor_options_test.go
+++ b/geom/ctor_options_test.go
@@ -38,7 +38,7 @@ func TestDisableValidation(t *testing.T) {
 			_, err = geom.UnmarshalWKT(wkt, geom.DisableAllValidations)
 			if err != nil {
 				t.Logf("wkt: %v", wkt)
-				t.Errorf("disabling validations still gave an error: %w", err)
+				t.Errorf("disabling validations still gave an error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This is to fix the following test build error:

    $ go test ./geom
    # github.com/peterstace/simplefeatures/geom_test
    geom/alg_set_op_test.go:990:7: (*testing.common).Errorf does not support error-wrapping directive %w
    geom/ctor_options_test.go:41:5: (*testing.common).Errorf does not support error-wrapping directive %w
    FAIL    github.com/peterstace/simplefeatures/geom [build failed]
    FAIL

Note that this error only seems to occur with go1.18. I'm not really sure why this is coming up as an actual compile error rather than a vet warning (I haven't looked into it).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

N/A