### PR TITLE
Dump Rings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add initial linear referencing methods to `LineString`. The initial methods
   are `InterpolatePoint` and `InterpolateEvenlySpacedPoints`.
 
+- Add a new `DumpRings` method to the `Polygon` type, which gives the rings of
+  the polygon as a slice of `LineString`s.
+
 ## v0.37.0
 
 2022-03-29

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -1586,3 +1586,51 @@ func TestSummary(t *testing.T) {
 		})
 	}
 }
+
+func TestPolygonDumpRings(t *testing.T) {
+	for i, tc := range []struct {
+		inputWKT     string
+		wantRingWKTs []string
+	}{
+		{
+			"POLYGON EMPTY",
+			nil,
+		},
+		{
+			"POLYGON ((0 0,0 1,1 0,0 0))",
+			[]string{"LINESTRING(0 0,0 1,1 0,0 0)"},
+		},
+		{
+			"POLYGON ((0 0,0 4,4 0,0 0),(1 1,1 2,2 1,1 1))",
+			[]string{
+				"LINESTRING(0 0,0 4,4 0,0 0)",
+				"LINESTRING(1 1,1 2,2 1,1 1)",
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			input := geomFromWKT(t, tc.inputWKT).MustAsPolygon()
+			wantRings := make([]LineString, len(tc.wantRingWKTs))
+			for j, wantRingWKT := range tc.wantRingWKTs {
+				wantRings[j] = geomFromWKT(t, wantRingWKT).MustAsLineString()
+			}
+
+			gotRings := input.DumpRings()
+
+			expectIntEq(t, len(gotRings), len(wantRings))
+			for j := range wantRings {
+				expectGeomEq(t,
+					gotRings[j].AsGeometry(),
+					wantRings[j].AsGeometry(),
+				)
+			}
+
+			// Ensure that we actually got copy of the slice's backing array
+			// rather than just a copy of its header:
+			otherRings := input.DumpRings()
+			if len(otherRings) > 0 {
+				expectTrue(t, &gotRings[0] != &otherRings[0])
+			}
+		})
+	}
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -620,6 +620,15 @@ func (p Polygon) DumpCoordinates() Sequence {
 	return seq
 }
 
+// DumpRings returns a copy of the Polygon's rings as a slice of LineStrings.
+// If the Polygon is empty, then the slice will have length zero. Otherwise,
+// the slice will consist of the exterior ring, followed by any interior rings.
+func (p Polygon) DumpRings() []LineString {
+	tmp := make([]LineString, len(p.rings))
+	copy(tmp, p.rings)
+	return tmp
+}
+
 // Summary returns a text summary of the Polygon following a similar format to https://postgis.net/docs/ST_Summary.html.
 func (p Polygon) Summary() string {
 	numPoints := p.DumpCoordinates().Length()


### PR DESCRIPTION
## Description

    Add `DumpRings` method to `Polygon` type
    
    This gives the rings in the polygon as a slice.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/379

## Benchmark Results

N/A