### PR TITLE
Add `workflow_dispatch` To GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: build
 on:
   push:
   pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,6 +2,7 @@ name: golangci-lint
 on:
   push:
   pull_request:
+  workflow_dispatch:
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
## Description

    Add workflow_dispatch to GH actions
    
    This will allow github actions to be triggered manually, rather than
    only being triggered on push (for debugging).


## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

N/A