### PR TITLE
Fix Golangci Lint Integration

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.42
+          version: v1.46

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt update && sudo sudo apt install libgdal-dev libgeos-dev libproj-dev
+        run: sudo apt update && sudo sudo apt install libgeos-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/geom/alg_relate.go
+++ b/geom/alg_relate.go
@@ -29,17 +29,18 @@ func Relate(a, b Geometry) (string, error) {
 		}
 
 		var flip bool
+		nonEmpty := b
 		if b.IsEmpty() {
-			b, a = a, b
+			nonEmpty = a
 			flip = true
 		}
-		switch b.Dimension() {
+		switch nonEmpty.Dimension() {
 		case 0:
 			im.set(imExterior, imInterior, '0')
 			im.set(imExterior, imBoundary, 'F')
 		case 1:
 			im.set(imExterior, imInterior, '1')
-			if !b.Boundary().IsEmpty() {
+			if !nonEmpty.Boundary().IsEmpty() {
 				im.set(imExterior, imBoundary, '0')
 			}
 		case 2:

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -378,7 +378,7 @@ func TestEnvelopeInvalidXYInteractions(t *testing.T) {
 			expectErr(t, err)
 		})
 		t.Run(fmt.Sprintf("extend_to_include_invalid_xy_%d", i), func(t *testing.T) {
-			_, err := NewEnvelope([]XY{{-1, -1}, {1, 1}})
+			env, err := NewEnvelope([]XY{{-1, -1}, {1, 1}})
 			expectNoErr(t, err)
 			_, err = env.ExtendToIncludeXY(tc)
 			expectErr(t, err)

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -378,9 +378,9 @@ func TestEnvelopeInvalidXYInteractions(t *testing.T) {
 			expectErr(t, err)
 		})
 		t.Run(fmt.Sprintf("extend_to_include_invalid_xy_%d", i), func(t *testing.T) {
-			env, err := NewEnvelope([]XY{{-1, -1}, {1, 1}})
+			_, err := NewEnvelope([]XY{{-1, -1}, {1, 1}})
 			expectNoErr(t, err)
-			env, err = env.ExtendToIncludeXY(tc)
+			_, err = env.ExtendToIncludeXY(tc)
 			expectErr(t, err)
 		})
 		t.Run(fmt.Sprintf("contains_invalid_xy_%d", i), func(t *testing.T) {


### PR DESCRIPTION
## Description

Golangci-lint was reporting some false positives, e.g. https://github.com/peterstace/simplefeatures/actions/runs/2316868808

I'm not really sure why that started happening all of a sudden (if anyone has any theories, I'd love to know).

This PR upgrades to the latest golangci-lint version, and fixes some new lint problems identified. That seems to get the build green again.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

N/A

## Benchmark Results

N/A