### PR TITLE
#411 use safer method when converting between byte and float slices

### DIFF
--- a/.ci/docker-compose-cmppg.yml
+++ b/.ci/docker-compose-cmppg.yml
@@ -8,7 +8,7 @@ services:
       timeout: '1s'
       retries: 50
   tests:
-    image: golang:1.14
+    image: golang:1.17
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./internal/cmprefimpl/cmppg
     volumes:

--- a/.ci/docker-compose-pgscan.yml
+++ b/.ci/docker-compose-pgscan.yml
@@ -8,7 +8,7 @@ services:
       timeout: '1s'
       retries: 50
   tests:
-    image: golang:1.14
+    image: golang:1.17
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./internal/pgscan
     volumes:

--- a/.ci/docker-compose-unit.yml
+++ b/.ci/docker-compose-unit.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   tests:
-    image: golang:1.15
+    image: golang:1.17
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: go test -covermode=count -coverprofile=coverage.out -test.count=1 -test.run=. ./geom ./rtree
     volumes:

--- a/.ci/geos.Dockerfile
+++ b/.ci/geos.Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.17
+FROM golang:1.17-buster
 RUN apt-get -y update && \
 	apt-get install -y libgeos-dev=3.7.1-1 && \
 	rm -rf /var/lib/apt/lists/*
-ENV PATH=/usr/lib/go-1.15/bin:${PATH}
+ENV PATH=/usr/lib/go-1.17/bin:${PATH}

--- a/.ci/geos.Dockerfile
+++ b/.ci/geos.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.17
 RUN apt-get -y update && \
 	apt-get install -y libgeos-dev=3.7.1-1 && \
 	rm -rf /var/lib/apt/lists/*

--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,2 +1,2 @@
-FROM golang:1.14
+FROM golang:1.17
 RUN go get -u golang.org/x/lint/golint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Add a new `DumpRings` method to the `Polygon` type, which gives the rings of
   the polygon as a slice of `LineString`s.
 
+- Uses `unsafe.Slice` for internal WKB conversions. This increases the minimum
+  Go version required to use simplefeatures from 1.14 to 1.17.
+
 ## v0.37.0
 
 2022-03-29

--- a/geom/wkb_marshal.go
+++ b/geom/wkb_marshal.go
@@ -86,5 +86,8 @@ func (m *wkbMarshaler) writeSequence(seq Sequence) {
 // floatsAsBytes reinterprets the floats slice as a bytes slice in a similar
 // manner to reinterpret_cast in C++.
 func floatsAsBytes(floats []float64) []byte {
+	if len(floats) == 0 {
+		return nil
+	}
 	return unsafe.Slice((*byte)(unsafe.Pointer(&floats[0])), 8*len(floats))
 }

--- a/geom/wkb_marshal.go
+++ b/geom/wkb_marshal.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"reflect"
 	"unsafe"
 )
 
@@ -87,10 +86,5 @@ func (m *wkbMarshaler) writeSequence(seq Sequence) {
 // floatsAsBytes reinterprets the floats slice as a bytes slice in a similar
 // manner to reinterpret_cast in C++.
 func floatsAsBytes(floats []float64) []byte {
-	var byts []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&byts))
-	hdr.Data = (*reflect.SliceHeader)(unsafe.Pointer(&floats)).Data
-	hdr.Len = 8 * len(floats)
-	hdr.Cap = 8 * cap(floats)
-	return byts
+	return unsafe.Slice((*byte)(unsafe.Pointer(&floats[0])), 8*len(floats))
 }

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"reflect"
 	"unsafe"
 )
 
@@ -224,12 +223,7 @@ func (p *wkbParser) parseLineString(ctype CoordinatesType) (LineString, error) {
 // bytesAsFloats reinterprets the bytes slice as a float64 slice in a similar
 // manner to reinterpret_cast in C++.
 func bytesAsFloats(byts []byte) []float64 {
-	var floats []float64
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&floats))
-	hdr.Data = (*reflect.SliceHeader)(unsafe.Pointer(&byts)).Data
-	hdr.Len = len(byts) / 8
-	hdr.Cap = cap(byts) / 8
-	return floats
+	return unsafe.Slice((*float64)(unsafe.Pointer(&byts[0])), len(byts)/8)
 }
 
 // flipEndianessStride8 flips the endianess of the input bytes, assuming that

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -223,6 +223,9 @@ func (p *wkbParser) parseLineString(ctype CoordinatesType) (LineString, error) {
 // bytesAsFloats reinterprets the bytes slice as a float64 slice in a similar
 // manner to reinterpret_cast in C++.
 func bytesAsFloats(byts []byte) []float64 {
+	if len(byts) == 0 {
+		return nil
+	}
 	return unsafe.Slice((*float64)(unsafe.Pointer(&byts[0])), len(byts)/8)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/peterstace/simplefeatures
 
-go 1.14
+go 1.17
 
 require github.com/lib/pq v1.1.1


### PR DESCRIPTION
## Description

We want to move away from editing slice headers when converting between byte and float slices. And to use the "safer"  unsafe.slice method available in golang 1.17.

Benchmark comparisons current approach vs the new one
```
Benchmark_FloatAsBytes_SliceHeaders-12                   1000000000               0.3534 ns/op
Benchmark_FloatAsBytes_UnsafeSlice-12                    437308378                2.538 ns/op
Benchmark_FloatAsBytesUsingStandardLibrary-12            2905132                  395.0 ns/op

```
Using the new method while slower than the existing edit header approach is still considerably faster than using the standard library.

## Check List

Have you:

- Added unit tests?

- Add cmprefimpl tests? (if appropriate?)

- Updated release notes? (if appropriate?)

## Related Issue

#411 

## Benchmark Results

- Please paste benchmark results here. The benchmarks can be run using the
  `run_benchmarks.sh` script.

<details>

<summary>Click to expand</summary>

```
RISON
name                                                         old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-12                                              3.56ns ±25%    3.50ns ±18%      ~     (p=0.715 n=15+14)
LineEnvelope/1-12                                              3.82ns ±20%    3.49ns ±22%    -8.74%  (p=0.028 n=15+14)
LineEnvelope/2-12                                              3.71ns ±25%    3.35ns ±10%    -9.74%  (p=0.032 n=15+12)
LineEnvelope/3-12                                              3.36ns ±25%    3.38ns ±25%      ~     (p=0.949 n=15+14)
MarshalWKB/polygon/n=10-12                                      290ns ±14%     290ns ±20%      ~     (p=0.967 n=15+15)
MarshalWKB/polygon/n=100-12                                     560ns ±10%     549ns ± 7%      ~     (p=0.252 n=15+14)
MarshalWKB/polygon/n=1000-12                                   2.93µs ± 7%    2.92µs ± 7%      ~     (p=0.974 n=15+13)
MarshalWKB/polygon/n=10000-12                                  19.7µs ± 2%    20.2µs ±14%      ~     (p=0.399 n=12+15)
UnmarshalWKB/polygon/n=10-12                                    457ns ±12%     440ns ±18%      ~     (p=0.270 n=15+14)
UnmarshalWKB/polygon/n=100-12                                   756ns ± 9%     788ns ±17%      ~     (p=0.270 n=14+15)
UnmarshalWKB/polygon/n=1000-12                                 3.31µs ± 8%    3.34µs ± 7%      ~     (p=0.323 n=14+14)
UnmarshalWKB/polygon/n=10000-12                                26.8µs ±11%    25.8µs ± 4%      ~     (p=0.427 n=15+12)
IntersectsLineStringWithLineString/n=10-12                     1.97µs ±13%    1.87µs ± 3%    -5.14%  (p=0.025 n=15+12)
IntersectsLineStringWithLineString/n=100-12                    26.7µs ±17%    26.6µs ±15%      ~     (p=0.839 n=14+14)
IntersectsLineStringWithLineString/n=1000-12                    281µs ±22%     285µs ±21%      ~     (p=0.683 n=14+15)
IntersectsLineStringWithLineString/n=10000-12                  4.25ms ±13%    4.12ms ± 9%      ~     (p=0.270 n=15+14)
IntersectsMultiPointWithMultiPoint/n=20-12                     1.20µs ±27%    1.19µs ±16%      ~     (p=0.705 n=15+15)
IntersectsMultiPointWithMultiPoint/n=200-12                    13.2µs ±12%    13.2µs ± 7%      ~     (p=0.979 n=13+12)
IntersectsMultiPointWithMultiPoint/n=2000-12                    125µs ± 4%     123µs ± 8%      ~     (p=0.118 n=12+14)
IntersectsMultiPointWithMultiPoint/n=20000-12                  1.46ms ±16%    1.43ms ± 6%      ~     (p=0.616 n=14+13)
PolygonSingleRingValidation/n=10-12                            3.33µs ±14%    3.41µs ±11%      ~     (p=0.310 n=14+15)
PolygonSingleRingValidation/n=100-12                           43.9µs ± 9%    44.9µs ±15%      ~     (p=0.331 n=14+15)
PolygonSingleRingValidation/n=1000-12                           562µs ±26%     559µs ±18%      ~     (p=0.910 n=14+14)
PolygonSingleRingValidation/n=10000-12                         7.31ms ±12%    7.49ms ±15%      ~     (p=0.285 n=15+15)
PolygonMultipleRingsValidation/n=4-12                          10.4µs ±27%     9.9µs ±13%      ~     (p=0.345 n=15+15)
PolygonMultipleRingsValidation/n=36-12                         80.4µs ±22%    83.9µs ±23%      ~     (p=0.187 n=15+15)
PolygonMultipleRingsValidation/n=400-12                        1.06ms ±11%    1.07ms ±14%      ~     (p=0.914 n=14+15)
PolygonMultipleRingsValidation/n=4096-12                       12.2ms ± 6%    12.2ms ±24%      ~     (p=0.290 n=14+15)
PolygonZigZagRingsValidation/n=10-12                           15.0µs ±10%    15.8µs ±19%      ~     (p=0.098 n=13+15)
PolygonZigZagRingsValidation/n=100-12                           176µs ±10%     180µs ±18%      ~     (p=0.545 n=13+13)
PolygonZigZagRingsValidation/n=1000-12                         2.06ms ±14%    2.06ms ± 9%      ~     (p=0.949 n=15+14)
PolygonZigZagRingsValidation/n=10000-12                        26.1ms ±13%    25.4ms ± 9%      ~     (p=0.403 n=14+12)
PolygonAnnulusValidation/n=10-12                               5.10µs ±22%    5.31µs ±18%      ~     (p=0.178 n=14+14)
PolygonAnnulusValidation/n=100-12                              45.3µs ±12%    45.5µs ±24%      ~     (p=0.683 n=15+15)
PolygonAnnulusValidation/n=1000-12                              791µs ±17%     783µs ±14%      ~     (p=0.914 n=15+14)
PolygonAnnulusValidation/n=10000-12                            9.35ms ±12%    9.18ms ±10%      ~     (p=0.454 n=14+14)
MultipolygonValidation/n=1-12                                   606ns ±18%     575ns ±16%      ~     (p=0.051 n=15+14)
MultipolygonValidation/n=4-12                                  1.37µs ±23%    1.36µs ±14%      ~     (p=0.744 n=15+15)
MultipolygonValidation/n=16-12                                 5.64µs ±25%    5.26µs ±13%      ~     (p=0.252 n=15+14)
MultipolygonValidation/n=64-12                                 24.5µs ±15%    24.5µs ±12%      ~     (p=0.976 n=15+15)
MultipolygonValidation/n=256-12                                 158µs ± 9%     162µs ±15%      ~     (p=0.325 n=15+15)
MultipolygonValidation/n=1024-12                                716µs ±14%     719µs ±12%      ~     (p=1.000 n=15+15)
MultiPolygonTwoCircles/n=10-12                                 4.97µs ±26%    5.08µs ±10%      ~     (p=0.964 n=15+13)
MultiPolygonTwoCircles/n=100-12                                52.0µs ±19%    54.0µs ±17%      ~     (p=0.233 n=15+15)
MultiPolygonTwoCircles/n=1000-12                                551µs ±15%     565µs ±13%      ~     (p=0.254 n=13+15)
MultiPolygonTwoCircles/n=10000-12                              7.82ms ±16%    8.29ms ±10%    +6.00%  (p=0.026 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1-12                      6.94µs ±22%    6.84µs ±18%      ~     (p=0.806 n=15+15)
MultiPolygonMultipleTouchingPoints/n=10-12                     53.3µs ±20%    53.0µs ±15%      ~     (p=0.967 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-12                     625µs ±17%     643µs ±23%      ~     (p=0.486 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-12                   7.54ms ±14%    7.53ms ±13%      ~     (p=0.870 n=15+15)
WKTParsing/point-12                                            2.31µs ± 6%    2.35µs ±17%      ~     (p=0.563 n=11+14)
DistancePolygonToPolygonOrdering/n=100_swap=false-12           67.4µs ±15%    68.6µs ±15%      ~     (p=0.713 n=15+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-12            65.7µs ±19%    68.1µs ±23%      ~     (p=0.539 n=15+15)
DistancePolygonToPolygonOrdering/n=1000_swap=false-12          1.12ms ±21%    1.05ms ±10%      ~     (p=0.062 n=14+14)
DistancePolygonToPolygonOrdering/n=1000_swap=true-12           1.03ms ±15%    1.05ms ±17%      ~     (p=0.525 n=13+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-12     7.12µs ±23%    6.81µs ± 7%      ~     (p=0.234 n=14+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-12      7.33µs ±25%    6.81µs ±19%      ~     (p=0.069 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-12    78.3µs ±11%    75.5µs ±20%      ~     (p=0.146 n=15+14)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-12     76.2µs ±25%    75.7µs ±12%      ~     (p=1.000 n=15+15)
MultiLineStringIsSimpleManyLineStrings/n=100-12                75.3µs ±20%    69.4µs ± 9%    -7.86%  (p=0.012 n=14+13)
MultiLineStringIsSimpleManyLineStrings/n=1000-12                765µs ±20%     770µs ±15%      ~     (p=0.687 n=13+13)
ForceCWandForceCCW/0-12                                        45.8ns ±21%    44.9ns ±21%      ~     (p=0.488 n=14+13)
ForceCWandForceCCW/0#01-12                                      317ns ±19%     325ns ±19%      ~     (p=0.760 n=14+14)
ForceCWandForceCCW/1-12                                        46.3ns ±22%    45.2ns ±13%      ~     (p=0.631 n=14+12)
ForceCWandForceCCW/1#01-12                                      318ns ±13%     310ns ±16%      ~     (p=0.185 n=13+14)
ForceCWandForceCCW/2-12                                        86.2ns ±25%    87.6ns ±33%      ~     (p=0.981 n=13+14)
ForceCWandForceCCW/2#01-12                                      496ns ±14%     516ns ±15%      ~     (p=0.347 n=12+14)
ForceCWandForceCCW/3-12                                        95.4ns ±26%    88.2ns ±22%      ~     (p=0.186 n=13+13)
ForceCWandForceCCW/3#01-12                                      536ns ±19%     508ns ±15%      ~     (p=0.133 n=12+13)
ForceCWandForceCCW/4-12                                        350ns ±132%     129ns ±34%   -63.10%  (p=0.049 n=15+15)
ForceCWandForceCCW/4#01-12                                      612ns ±82%     843ns ±25%      ~     (p=0.161 n=15+15)
ForceCWandForceCCW/5-12                                        422ns ±149%     121ns ± 6%   -71.26%  (p=0.001 n=15+12)
ForceCWandForceCCW/5#01-12                                      572ns ±80%     769ns ±15%      ~     (p=0.895 n=15+12)
ForceCWandForceCCW/6-12                                         176ns ±11%     184ns ±32%      ~     (p=0.667 n=12+14)
ForceCWandForceCCW/6#01-12                                     1.33µs ±15%    1.25µs ±17%      ~     (p=0.151 n=13+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-12                          54.9µs ± 7%    54.4µs ±13%      ~     (p=0.586 n=13+15)
IntersectionWithoutValidation/n=100-12                          109µs ±21%     109µs ±19%      ~     (p=0.621 n=14+15)
IntersectionWithoutValidation/n=1000-12                         485µs ±23%     466µs ±18%      ~     (p=0.486 n=15+15)
IntersectionWithoutValidation/n=10000-12                       4.18ms ±17%    4.17ms ±16%      ~     (p=0.621 n=15+14)
NoOp/n=10-12                                                   6.86µs ±23%    6.39µs ±17%      ~     (p=0.067 n=15+15)
NoOp/n=100-12                                                  18.3µs ±16%    17.8µs ±15%      ~     (p=0.345 n=15+15)
NoOp/n=1000-12                                                  123µs ±23%     118µs ±20%      ~     (p=0.202 n=15+15)
NoOp/n=10000-12                                                1.34ms ±10%    1.38ms ±14%      ~     (p=0.316 n=13+15)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-12                               2.88µs ±20%    2.85µs ±25%      ~     (p=0.645 n=15+15)
LineStringIsSimpleCircle/n=100-12                              41.3µs ±20%    38.9µs ± 5%      ~     (p=0.200 n=15+12)
LineStringIsSimpleCircle/n=1000-12                              526µs ±22%     516µs ±25%      ~     (p=0.412 n=15+15)
LineStringIsSimpleCircle/n=10000-12                            7.18ms ±15%    7.17ms ±16%      ~     (p=1.000 n=15+15)
LineStringIsSimpleZigZag/10-12                                 2.57µs ±15%    2.49µs ± 7%      ~     (p=0.168 n=12+13)
LineStringIsSimpleZigZag/100-12                                43.9µs ±26%    42.2µs ±20%      ~     (p=0.389 n=15+15)
LineStringIsSimpleZigZag/1000-12                                519µs ±29%     487µs ±17%      ~     (p=0.285 n=15+15)
LineStringIsSimpleZigZag/10000-12                              6.92ms ±16%    6.57ms ±17%      ~     (p=0.150 n=14+14)
SetOperation/n=4/Go_Intersection-12                            56.5µs ±19%    53.8µs ±22%      ~     (p=0.161 n=15+15)
SetOperation/n=4/Go_Difference-12                              59.1µs ±13%    57.0µs ±26%      ~     (p=0.116 n=13+14)
SetOperation/n=4/Go_SymmetricDifference-12                     75.9µs ±14%    74.7µs ±14%      ~     (p=1.000 n=14+13)
SetOperation/n=4/Go_Union-12                                   59.5µs ±16%    60.2µs ±23%      ~     (p=0.847 n=14+15)
SetOperation/n=4/GEOS_Intersection-12                          52.4µs ±22%    47.0µs ±28%      ~     (p=0.134 n=14+15)
SetOperation/n=4/GEOS_Difference-12                            53.6µs ±23%    51.9µs ±34%      ~     (p=0.539 n=15+15)
SetOperation/n=4/GEOS_SymmetricDifference-12                   77.5µs ± 9%    69.7µs ±25%   -10.06%  (p=0.027 n=14+14)
SetOperation/n=4/GEOS_Union-12                                 53.8µs ±14%    51.9µs ±34%      ~     (p=0.561 n=14+15)
SetOperation/n=8/Go_Intersection-12                            72.9µs ±20%    68.1µs ±10%      ~     (p=0.254 n=15+13)
SetOperation/n=8/Go_Difference-12                              73.5µs ±12%    70.0µs ±23%      ~     (p=0.467 n=13+15)
SetOperation/n=8/Go_SymmetricDifference-12                     98.4µs ±26%    91.7µs ±24%      ~     (p=0.116 n=15+15)
SetOperation/n=8/Go_Union-12                                   76.6µs ±22%    71.8µs ±24%      ~     (p=0.250 n=15+15)
SetOperation/n=8/GEOS_Intersection-12                          60.2µs ±22%    58.9µs ±22%      ~     (p=0.701 n=14+14)
SetOperation/n=8/GEOS_Difference-12                            63.6µs ±37%    58.0µs ±34%      ~     (p=0.250 n=15+15)
SetOperation/n=8/GEOS_SymmetricDifference-12                   86.3µs ±24%    82.3µs ±27%      ~     (p=0.345 n=15+15)
SetOperation/n=8/GEOS_Union-12                                 60.3µs ±32%    55.5µs ±48%      ~     (p=0.217 n=15+15)
SetOperation/n=16/Go_Intersection-12                           94.4µs ±31%    89.9µs ±27%      ~     (p=0.285 n=15+15)
SetOperation/n=16/Go_Difference-12                              104µs ±40%      99µs ±19%      ~     (p=0.653 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-12                     137µs ±29%     143µs ±28%      ~     (p=0.400 n=15+14)
SetOperation/n=16/Go_Union-12                                   105µs ±21%     101µs ±20%      ~     (p=0.571 n=14+14)
SetOperation/n=16/GEOS_Intersection-12                         62.5µs ±40%    63.5µs ±43%      ~     (p=0.567 n=15+15)
SetOperation/n=16/GEOS_Difference-12                           64.0µs ±45%    64.1µs ±33%      ~     (p=0.967 n=15+15)
SetOperation/n=16/GEOS_SymmetricDifference-12                  92.5µs ±14%   103.5µs ±23%      ~     (p=0.088 n=13+15)
SetOperation/n=16/GEOS_Union-12                                60.9µs ±28%    62.6µs ±36%      ~     (p=0.511 n=14+14)
SetOperation/n=32/Go_Intersection-12                            156µs ±28%     153µs ±27%      ~     (p=0.806 n=15+15)
SetOperation/n=32/Go_Difference-12                              164µs ±30%     181µs ±24%   +10.59%  (p=0.033 n=14+15)
SetOperation/n=32/Go_SymmetricDifference-12                     221µs ±24%     233µs ±19%      ~     (p=0.217 n=15+15)
SetOperation/n=32/Go_Union-12                                   163µs ±19%     174µs ±16%      ~     (p=0.186 n=14+15)
SetOperation/n=32/GEOS_Intersection-12                         70.9µs ±36%    78.8µs ±45%      ~     (p=0.250 n=15+15)
SetOperation/n=32/GEOS_Difference-12                           71.7µs ±13%    71.7µs ±17%      ~     (p=0.943 n=14+13)
SetOperation/n=32/GEOS_SymmetricDifference-12                   131µs ±15%     132µs ±24%      ~     (p=0.813 n=15+14)
SetOperation/n=32/GEOS_Union-12                                76.3µs ±31%    77.4µs ±25%      ~     (p=0.838 n=15+15)
SetOperation/n=64/Go_Intersection-12                            256µs ±18%     250µs ±22%      ~     (p=0.325 n=15+15)
SetOperation/n=64/Go_Difference-12                              265µs ±19%     274µs ±20%      ~     (p=0.591 n=14+15)
SetOperation/n=64/Go_SymmetricDifference-12                     438µs ±36%     436µs ±39%      ~     (p=1.000 n=15+15)
SetOperation/n=64/Go_Union-12                                   277µs ±27%     288µs ±17%      ~     (p=0.246 n=14+14)
SetOperation/n=64/GEOS_Intersection-12                         87.4µs ± 9%    89.7µs ±14%      ~     (p=0.413 n=13+15)
SetOperation/n=64/GEOS_Difference-12                            111µs ±19%     105µs ± 6%    -5.69%  (p=0.029 n=15+14)
SetOperation/n=64/GEOS_SymmetricDifference-12                   226µs ±14%     215µs ± 9%      ~     (p=0.051 n=15+14)
SetOperation/n=64/GEOS_Union-12                                 118µs ±17%     115µs ± 8%      ~     (p=0.683 n=15+14)
SetOperation/n=128/Go_Intersection-12                           527µs ±39%     451µs ±18%   -14.33%  (p=0.041 n=15+14)
SetOperation/n=128/Go_Difference-12                             498µs ±28%     557µs ±36%      ~     (p=0.185 n=13+15)
SetOperation/n=128/Go_SymmetricDifference-12                    851µs ±66%     749µs ±19%      ~     (p=0.914 n=15+14)
SetOperation/n=128/Go_Union-12                                  588µs ±48%     544µs ±19%      ~     (p=0.496 n=15+13)
SetOperation/n=128/GEOS_Intersection-12                         146µs ±17%     144µs ±16%      ~     (p=0.624 n=15+15)
SetOperation/n=128/GEOS_Difference-12                           171µs ±12%     173µs ±18%      ~     (p=1.000 n=15+15)
SetOperation/n=128/GEOS_SymmetricDifference-12                  370µs ±19%     346µs ±14%      ~     (p=0.067 n=15+15)
SetOperation/n=128/GEOS_Union-12                                183µs ±22%     182µs ±15%      ~     (p=0.838 n=15+15)
SetOperation/n=256/Go_Intersection-12                           935µs ±33%     875µs ±25%      ~     (p=0.331 n=15+14)
SetOperation/n=256/Go_Difference-12                             986µs ±30%    1010µs ±37%      ~     (p=0.683 n=15+14)
SetOperation/n=256/Go_SymmetricDifference-12                   1.43ms ±24%    1.61ms ±56%      ~     (p=0.233 n=15+15)
SetOperation/n=256/Go_Union-12                                 1.00ms ±33%    1.24ms ±78%      ~     (p=0.158 n=14+15)
SetOperation/n=256/GEOS_Intersection-12                         229µs ±30%     225µs ±18%      ~     (p=0.870 n=15+15)
SetOperation/n=256/GEOS_Difference-12                           309µs ±27%     289µs ±11%      ~     (p=0.148 n=15+15)
SetOperation/n=256/GEOS_SymmetricDifference-12                  761µs ±38%     728µs ±26%      ~     (p=0.486 n=15+15)
SetOperation/n=256/GEOS_Union-12                                312µs ±13%     312µs ±10%      ~     (p=0.780 n=14+15)
SetOperation/n=512/Go_Intersection-12                          1.75ms ±19%    1.71ms ±18%      ~     (p=0.769 n=14+14)
SetOperation/n=512/Go_Difference-12                            2.16ms ±80%    1.86ms ±38%      ~     (p=0.591 n=15+14)
SetOperation/n=512/Go_SymmetricDifference-12                   2.76ms ±43%    2.67ms ±41%      ~     (p=0.252 n=14+15)
SetOperation/n=512/Go_Union-12                                 1.83ms ±19%    1.82ms ±19%      ~     (p=1.000 n=12+12)
SetOperation/n=512/GEOS_Intersection-12                         401µs ±23%     385µs ±14%      ~     (p=0.451 n=15+14)
SetOperation/n=512/GEOS_Difference-12                           501µs ±29%     484µs ±18%      ~     (p=0.902 n=15+15)
SetOperation/n=512/GEOS_SymmetricDifference-12                 1.26ms ±25%    1.19ms ±16%      ~     (p=0.148 n=15+15)
SetOperation/n=512/GEOS_Union-12                                551µs ±20%     530µs ±14%      ~     (p=0.246 n=14+14)
SetOperation/n=1024/Go_Intersection-12                         3.32ms ±28%    3.13ms ±23%      ~     (p=0.125 n=14+14)
SetOperation/n=1024/Go_Difference-12                           3.96ms ±51%    3.91ms ±41%      ~     (p=0.652 n=14+15)
SetOperation/n=1024/Go_SymmetricDifference-12                  6.53ms ±44%    5.25ms ±36%   -19.59%  (p=0.041 n=15+14)
SetOperation/n=1024/Go_Union-12                                3.93ms ±39%    3.65ms ±24%      ~     (p=0.246 n=14+14)
SetOperation/n=1024/GEOS_Intersection-12                        715µs ±15%     725µs ±11%      ~     (p=0.571 n=14+14)
SetOperation/n=1024/GEOS_Difference-12                         1.03ms ±10%    1.07ms ±17%      ~     (p=0.146 n=15+14)
SetOperation/n=1024/GEOS_SymmetricDifference-12                2.85ms ±32%    2.83ms ±25%      ~     (p=1.000 n=15+15)
SetOperation/n=1024/GEOS_Union-12                              1.24ms ±31%    1.18ms ±21%      ~     (p=0.652 n=15+14)
SetOperation/n=2048/Go_Intersection-12                         7.50ms ±36%    7.65ms ±36%      ~     (p=0.713 n=15+15)
SetOperation/n=2048/Go_Difference-12                           8.61ms ±43%    7.89ms ±19%      ~     (p=0.329 n=14+14)
SetOperation/n=2048/Go_SymmetricDifference-12                  13.6ms ±67%    12.7ms ±45%      ~     (p=0.412 n=15+15)
SetOperation/n=2048/Go_Union-12                                8.67ms ±31%    9.30ms ±40%      ~     (p=0.402 n=13+14)
SetOperation/n=2048/GEOS_Intersection-12                       1.61ms ±26%    1.52ms ±29%      ~     (p=0.234 n=14+15)
SetOperation/n=2048/GEOS_Difference-12                         1.96ms ±14%    1.97ms ±23%      ~     (p=0.715 n=14+15)
SetOperation/n=2048/GEOS_SymmetricDifference-12                4.97ms ±25%    4.97ms ±25%      ~     (p=0.935 n=15+15)
SetOperation/n=2048/GEOS_Union-12                              2.44ms ±36%    2.22ms ±12%      ~     (p=0.316 n=15+13)
SetOperation/n=4096/Go_Intersection-12                         15.6ms ±16%    15.3ms ±34%      ~     (p=0.425 n=15+14)
SetOperation/n=4096/Go_Difference-12                           17.1ms ±31%    16.3ms ±33%      ~     (p=0.425 n=15+14)
SetOperation/n=4096/Go_SymmetricDifference-12                  25.1ms ±24%    22.1ms ±28%   -12.12%  (p=0.024 n=14+14)
SetOperation/n=4096/Go_Union-12                                18.5ms ±23%    17.7ms ±17%      ~     (p=0.505 n=15+14)
SetOperation/n=4096/GEOS_Intersection-12                       2.90ms ±40%    2.77ms ±21%      ~     (p=1.000 n=15+15)
SetOperation/n=4096/GEOS_Difference-12                         4.10ms ±11%    4.02ms ±21%      ~     (p=0.274 n=13+15)
SetOperation/n=4096/GEOS_SymmetricDifference-12                12.1ms ±44%    11.5ms ±43%      ~     (p=0.400 n=14+15)
SetOperation/n=4096/GEOS_Union-12                              4.78ms ±28%    5.05ms ±32%      ~     (p=0.425 n=14+15)
SetOperation/n=8192/Go_Intersection-12                         28.9ms ±27%    28.4ms ±10%      ~     (p=0.583 n=14+13)
SetOperation/n=8192/Go_Difference-12                           31.6ms ±18%    32.1ms ±30%      ~     (p=0.967 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-12                  44.2ms ±17%    44.2ms ±21%      ~     (p=0.621 n=14+15)
SetOperation/n=8192/Go_Union-12                                33.0ms ±16%    32.9ms ±16%      ~     (p=0.847 n=14+15)
SetOperation/n=8192/GEOS_Intersection-12                       5.77ms ±19%    5.64ms ±19%      ~     (p=0.870 n=15+15)
SetOperation/n=8192/GEOS_Difference-12                         8.25ms ±22%    8.33ms ±15%      ~     (p=0.683 n=15+14)
SetOperation/n=8192/GEOS_SymmetricDifference-12                19.5ms ±13%    21.2ms ±25%    +8.63%  (p=0.041 n=13+15)
SetOperation/n=8192/GEOS_Union-12                              8.67ms ± 7%    9.28ms ±21%    +6.97%  (p=0.021 n=12+15)
SetOperation/n=16384/Go_Intersection-12                        56.1ms ±17%    54.0ms ±10%      ~     (p=0.202 n=15+15)
SetOperation/n=16384/Go_Difference-12                          58.0ms ± 9%    58.1ms ±15%      ~     (p=0.838 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-12                 83.7ms ±17%    81.1ms ± 9%      ~     (p=0.451 n=15+14)
SetOperation/n=16384/Go_Union-12                               61.8ms ±12%    62.2ms ±15%      ~     (p=0.914 n=14+15)
SetOperation/n=16384/GEOS_Intersection-12                      11.6ms ±12%    12.0ms ±13%      ~     (p=0.210 n=14+14)
SetOperation/n=16384/GEOS_Difference-12                        16.8ms ±24%    16.9ms ±18%      ~     (p=0.983 n=15+14)
SetOperation/n=16384/GEOS_SymmetricDifference-12               40.7ms ±13%    40.2ms ±10%      ~     (p=0.964 n=15+13)
SetOperation/n=16384/GEOS_Union-12                             18.8ms ±19%    19.1ms ± 8%      ~     (p=0.239 n=14+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-12                                                16.1µs ±20%    17.7µs ±42%      ~     (p=0.525 n=13+15)
Delete/n=1000-12                                                671µs ±14%     672µs ±18%      ~     (p=0.467 n=15+13)
Delete/n=10000-12                                              32.3ms ±15%    34.2ms ±22%      ~     (p=0.325 n=15+15)
Bulk/n=10-12                                                    928ns ±22%     950ns ±24%      ~     (p=0.635 n=14+14)
Bulk/n=100-12                                                  17.7µs ±23%    21.1µs ±51%      ~     (p=0.142 n=13+15)
Bulk/n=1000-12                                                  279µs ±14%     278µs ±17%      ~     (p=0.982 n=14+14)
Bulk/n=10000-12                                                4.27ms ±35%    3.98ms ±15%      ~     (p=0.595 n=15+15)
Bulk/n=100000-12                                               40.8ms ±12%    44.7ms ±38%      ~     (p=0.290 n=14+15)
Insert/n=10-12                                                 1.47µs ±29%    1.60µs ±45%      ~     (p=0.348 n=14+15)
Insert/n=100-12                                                25.6µs ±37%    25.3µs ±28%      ~     (p=0.839 n=14+14)
Insert/n=1000-12                                                471µs ±15%     471µs ±16%      ~     (p=0.910 n=14+14)
Insert/n=10000-12                                              5.97ms ±14%    5.91ms ±14%      ~     (p=0.780 n=15+14)
Insert/n=100000-12                                             60.0ms ±10%    61.8ms ±13%      ~     (p=0.252 n=14+15)
RangeSearch/n=10-12                                            14.2ns ±15%    14.2ns ±14%      ~     (p=0.498 n=15+14)
RangeSearch/n=100-12                                           59.4ns ± 8%    62.3ns ±19%      ~     (p=0.062 n=15+14)
RangeSearch/n=1000-12                                           223ns ±11%     234ns ±15%      ~     (p=0.057 n=14+15)
RangeSearch/n=10000-12                                          775ns ± 8%     787ns ±11%      ~     (p=0.270 n=14+14)
RangeSearch/n=100000-12                                        6.87µs ±10%    6.85µs ± 5%      ~     (p=0.968 n=13+12)

name                                                         old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-12                                               0.00B          0.00B           ~     (all equal)
LineEnvelope/1-12                                               0.00B          0.00B           ~     (all equal)
LineEnvelope/2-12                                               0.00B          0.00B           ~     (all equal)
LineEnvelope/3-12                                               0.00B          0.00B           ~     (all equal)
MarshalWKB/polygon/n=10-12                                       232B ± 0%      232B ± 0%      ~     (all equal)
MarshalWKB/polygon/n=100-12                                    1.83kB ± 0%    1.83kB ± 0%      ~     (all equal)
MarshalWKB/polygon/n=1000-12                                   16.4kB ± 0%    16.4kB ± 0%      ~     (all equal)
MarshalWKB/polygon/n=10000-12                                   164kB ± 0%     164kB ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=10-12                                     284B ± 0%      284B ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=100-12                                  1.90kB ± 0%    1.90kB ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=1000-12                                 16.5kB ± 0%    16.5kB ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=10000-12                                 164kB ± 0%     164kB ± 0%      ~     (p=0.710 n=15+15)
IntersectsLineStringWithLineString/n=10-12                     2.42kB ± 0%    2.42kB ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=100-12                    30.4kB ± 0%    30.4kB ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=1000-12                    205kB ± 0%     205kB ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=10000-12                  2.63MB ± 0%    2.63MB ± 0%    -0.00%  (p=0.040 n=10+15)
IntersectsMultiPointWithMultiPoint/n=20-12                       324B ± 0%      324B ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-12                    3.06kB ± 0%    3.07kB ± 0%      ~     (p=0.860 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000-12                   49.3kB ± 0%    49.3kB ± 0%      ~     (p=0.383 n=15+14)
IntersectsMultiPointWithMultiPoint/n=20000-12                   339kB ± 0%     339kB ± 0%      ~     (p=0.290 n=15+15)
PolygonSingleRingValidation/n=10-12                            2.29kB ± 0%    2.29kB ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=100-12                           24.4kB ± 0%    24.4kB ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=1000-12                           140kB ± 0%     140kB ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=10000-12                         1.97MB ± 0%    1.97MB ± 0%    +0.00%  (p=0.032 n=13+15)
PolygonMultipleRingsValidation/n=4-12                          6.61kB ± 0%    6.61kB ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=36-12                         53.2kB ± 0%    53.2kB ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=400-12                         597kB ± 0%     597kB ± 0%      ~     (p=0.451 n=15+15)
PolygonMultipleRingsValidation/n=4096-12                       6.28MB ± 0%    6.28MB ± 0%      ~     (p=0.062 n=14+14)
PolygonZigZagRingsValidation/n=10-12                           9.62kB ± 0%    9.62kB ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=100-12                          88.0kB ± 0%    88.0kB ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=1000-12                          551kB ± 0%     551kB ± 0%      ~     (p=0.777 n=14+13)
PolygonZigZagRingsValidation/n=10000-12                        7.24MB ± 0%    7.24MB ± 0%      ~     (p=0.934 n=13+14)
PolygonAnnulusValidation/n=10-12                               4.10kB ± 0%    4.10kB ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=100-12                              28.4kB ± 0%    28.4kB ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=1000-12                              379kB ± 0%     379kB ± 0%      ~     (p=1.000 n=14+14)
PolygonAnnulusValidation/n=10000-12                            3.89MB ± 0%    3.89MB ± 0%      ~     (p=0.311 n=14+14)
MultipolygonValidation/n=1-12                                    481B ± 0%      481B ± 0%      ~     (all equal)
MultipolygonValidation/n=4-12                                    980B ± 0%      980B ± 0%      ~     (all equal)
MultipolygonValidation/n=16-12                                 4.16kB ± 0%    4.16kB ± 0%      ~     (all equal)
MultipolygonValidation/n=64-12                                 17.0kB ± 0%    17.0kB ± 0%      ~     (all equal)
MultipolygonValidation/n=256-12                                67.8kB ± 0%    67.8kB ± 0%      ~     (all equal)
MultipolygonValidation/n=1024-12                                271kB ± 0%     271kB ± 0%      ~     (p=0.918 n=15+14)
MultiPolygonTwoCircles/n=10-12                                 5.15kB ± 0%    5.15kB ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=100-12                                55.1kB ± 0%    55.1kB ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=1000-12                                345kB ± 0%     345kB ± 0%      ~     (p=0.655 n=15+15)
MultiPolygonTwoCircles/n=10000-12                              4.60MB ± 0%    4.60MB ± 0%      ~     (p=0.706 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1-12                      4.16kB ± 0%    4.16kB ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-12                     23.9kB ± 0%    23.9kB ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-12                     182kB ± 0%     182kB ± 0%      ~     (p=0.959 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-12                   2.10MB ± 0%    2.10MB ± 0%    +0.01%  (p=0.022 n=15+15)
WKTParsing/point-12                                            1.89kB ± 0%    1.89kB ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-12           40.7kB ± 0%    40.7kB ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-12            40.7kB ± 0%    40.7kB ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-12           369kB ± 0%     369kB ± 0%      ~     (p=0.283 n=12+15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-12            369kB ± 0%     369kB ± 0%      ~     (p=0.642 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-12     5.52kB ± 0%    5.52kB ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-12      5.52kB ± 0%    5.52kB ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-12    60.1kB ± 0%    60.1kB ± 0%      ~     (p=0.855 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-12     60.1kB ± 0%    60.1kB ± 0%      ~     (p=0.969 n=12+14)
MultiLineStringIsSimpleManyLineStrings/n=100-12                59.2kB ± 0%    59.2kB ± 0%      ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-12                491kB ± 0%     491kB ± 0%      ~     (p=0.319 n=15+15)
ForceCWandForceCCW/0-12                                         0.00B          0.00B           ~     (all equal)
ForceCWandForceCCW/0#01-12                                       144B ± 0%      144B ± 0%      ~     (all equal)
ForceCWandForceCCW/1-12                                         0.00B          0.00B           ~     (all equal)
ForceCWandForceCCW/1#01-12                                       144B ± 0%      144B ± 0%      ~     (all equal)
ForceCWandForceCCW/2-12                                         0.00B          0.00B           ~     (all equal)
ForceCWandForceCCW/2#01-12                                       256B ± 0%      256B ± 0%      ~     (all equal)
ForceCWandForceCCW/3-12                                         0.00B          0.00B           ~     (all equal)
ForceCWandForceCCW/3#01-12                                       256B ± 0%      256B ± 0%      ~     (all equal)
ForceCWandForceCCW/4-12                                         139B ±200%        0B       -100.00%  (p=0.042 n=15+15)
ForceCWandForceCCW/4#01-12                                      277B ±100%      416B ± 0%   +50.00%  (p=0.042 n=15+15)
ForceCWandForceCCW/5-12                                         166B ±150%        0B       -100.00%  (p=0.009 n=15+13)
ForceCWandForceCCW/5#01-12                                      250B ±100%      416B ± 0%   +66.67%  (p=0.027 n=15+13)
ForceCWandForceCCW/6-12                                         0.00B          0.00B           ~     (all equal)
ForceCWandForceCCW/6#01-12                                       624B ± 0%      624B ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-12                          1.32kB ± 0%    1.32kB ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=100-12                         6.46kB ± 0%    6.46kB ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=1000-12                        55.1kB ± 0%    55.1kB ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=10000-12                        558kB ± 0%     558kB ± 0%      ~     (p=0.529 n=15+15)
NoOp/n=10-12                                                     952B ± 0%      952B ± 0%      ~     (all equal)
NoOp/n=100-12                                                  5.77kB ± 0%    5.77kB ± 0%      ~     (all equal)
NoOp/n=1000-12                                                 49.5kB ± 0%    49.5kB ± 0%      ~     (all equal)
NoOp/n=10000-12                                                 492kB ± 0%     492kB ± 0%      ~     (p=0.565 n=14+13)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-12                               1.87kB ± 0%    1.87kB ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=100-12                              24.0kB ± 0%    24.0kB ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=1000-12                              139kB ± 0%     139kB ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=10000-12                            1.97MB ± 0%    1.97MB ± 0%      ~     (p=0.456 n=10+11)
LineStringIsSimpleZigZag/10-12                                 1.84kB ± 0%    1.84kB ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/100-12                                24.0kB ± 0%    24.0kB ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/1000-12                                139kB ± 0%     139kB ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/10000-12                              1.97MB ± 0%    1.97MB ± 0%      ~     (p=0.100 n=12+15)
SetOperation/n=4/Go_Intersection-12                            20.3kB ± 0%    20.3kB ± 0%      ~     (p=0.846 n=15+15)
SetOperation/n=4/Go_Difference-12                              21.3kB ± 0%    21.3kB ± 0%      ~     (p=0.277 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-12                     29.3kB ± 0%    29.3kB ± 0%      ~     (p=0.798 n=15+15)
SetOperation/n=4/Go_Union-12                                   22.0kB ± 0%    22.0kB ± 0%    -0.03%  (p=0.003 n=15+14)
SetOperation/n=4/GEOS_Intersection-12                          1.77kB ± 0%    1.77kB ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Difference-12                            2.78kB ± 0%    2.78kB ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-12                   10.8kB ± 0%    10.8kB ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Union-12                                 3.21kB ± 0%    3.21kB ± 0%      ~     (all equal)
SetOperation/n=8/Go_Intersection-12                            27.0kB ± 0%    27.0kB ± 0%      ~     (p=0.070 n=15+12)
SetOperation/n=8/Go_Difference-12                              27.1kB ± 0%    27.1kB ± 0%      ~     (p=0.167 n=14+15)
SetOperation/n=8/Go_SymmetricDifference-12                     37.2kB ± 0%    37.2kB ± 0%      ~     (p=0.196 n=13+12)
SetOperation/n=8/Go_Union-12                                   27.3kB ± 0%    27.3kB ± 0%      ~     (p=0.071 n=15+14)
SetOperation/n=8/GEOS_Intersection-12                          3.34kB ± 0%    3.34kB ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_Difference-12                            3.50kB ± 0%    3.50kB ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-12                   13.3kB ± 0%    13.3kB ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_Union-12                                 3.62kB ± 0%    3.62kB ± 0%      ~     (all equal)
SetOperation/n=16/Go_Intersection-12                           37.3kB ± 0%    37.3kB ± 0%      ~     (p=0.284 n=14+15)
SetOperation/n=16/Go_Difference-12                             40.4kB ± 0%    40.4kB ± 0%      ~     (p=0.083 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-12                    59.5kB ± 0%    59.5kB ± 0%      ~     (p=0.290 n=15+15)
SetOperation/n=16/Go_Union-12                                  41.9kB ± 0%    41.9kB ± 0%      ~     (p=0.197 n=15+15)
SetOperation/n=16/GEOS_Intersection-12                         3.88kB ± 0%    3.88kB ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Difference-12                           6.68kB ± 0%    6.68kB ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-12                  25.3kB ± 0%    25.3kB ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Union-12                                8.28kB ± 0%    8.28kB ± 0%      ~     (all equal)
SetOperation/n=32/Go_Intersection-12                           67.8kB ± 0%    67.8kB ± 0%      ~     (p=0.693 n=14+13)
SetOperation/n=32/Go_Difference-12                             70.4kB ± 0%    70.4kB ± 0%    +0.01%  (p=0.042 n=14+15)
SetOperation/n=32/Go_SymmetricDifference-12                     100kB ± 0%     100kB ± 0%    +0.01%  (p=0.027 n=15+15)
SetOperation/n=32/Go_Union-12                                  70.9kB ± 0%    70.9kB ± 0%      ~     (p=0.128 n=12+15)
SetOperation/n=32/GEOS_Intersection-12                         8.86kB ± 0%    8.86kB ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Difference-12                           10.7kB ± 0%    10.7kB ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-12                  39.9kB ± 0%    39.9kB ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Union-12                                11.5kB ± 0%    11.5kB ± 0%      ~     (all equal)
SetOperation/n=64/Go_Intersection-12                            113kB ± 0%     113kB ± 0%      ~     (p=0.659 n=14+15)
SetOperation/n=64/Go_Difference-12                              125kB ± 0%     125kB ± 0%      ~     (p=0.151 n=13+15)
SetOperation/n=64/Go_SymmetricDifference-12                     191kB ± 0%     191kB ± 0%      ~     (p=0.602 n=15+15)
SetOperation/n=64/Go_Union-12                                   129kB ± 0%     129kB ± 0%      ~     (p=0.176 n=15+15)
SetOperation/n=64/GEOS_Intersection-12                         12.6kB ± 0%    12.6kB ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Difference-12                           23.5kB ± 0%    23.5kB ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-12                  87.5kB ± 0%    87.5kB ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Union-12                                28.0kB ± 0%    28.0kB ± 0%      ~     (all equal)
SetOperation/n=128/Go_Intersection-12                           230kB ± 0%     230kB ± 0%      ~     (p=0.857 n=15+12)
SetOperation/n=128/Go_Difference-12                             242kB ± 0%     242kB ± 0%      ~     (p=0.162 n=12+15)
SetOperation/n=128/Go_SymmetricDifference-12                    353kB ± 0%     353kB ± 0%      ~     (p=0.361 n=15+15)
SetOperation/n=128/Go_Union-12                                  244kB ± 0%     244kB ± 0%      ~     (p=0.073 n=12+14)
SetOperation/n=128/GEOS_Intersection-12                        30.3kB ± 0%    30.3kB ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Difference-12                          40.0kB ± 0%    40.0kB ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-12                  147kB ± 0%     147kB ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Union-12                               43.1kB ± 0%    43.1kB ± 0%      ~     (all equal)
SetOperation/n=256/Go_Intersection-12                           417kB ± 0%     417kB ± 0%      ~     (p=0.104 n=15+15)
SetOperation/n=256/Go_Difference-12                             466kB ± 0%     466kB ± 0%      ~     (p=0.767 n=15+15)
SetOperation/n=256/Go_SymmetricDifference-12                    722kB ± 0%     722kB ± 0%      ~     (p=0.100 n=15+15)
SetOperation/n=256/Go_Union-12                                  477kB ± 0%     477kB ± 0%      ~     (p=0.430 n=15+15)
SetOperation/n=256/GEOS_Intersection-12                        48.2kB ± 0%    48.2kB ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_Difference-12                          92.6kB ± 0%    92.6kB ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-12                  341kB ± 0%     341kB ± 0%    +0.00%  (p=0.020 n=13+14)
SetOperation/n=256/GEOS_Union-12                                106kB ± 0%     106kB ± 0%      ~     (all equal)
SetOperation/n=512/Go_Intersection-12                           858kB ± 0%     858kB ± 0%      ~     (p=0.177 n=15+15)
SetOperation/n=512/Go_Difference-12                             905kB ± 0%     905kB ± 0%      ~     (p=0.814 n=15+15)
SetOperation/n=512/Go_SymmetricDifference-12                   1.33MB ± 0%    1.33MB ± 0%      ~     (p=0.879 n=15+15)
SetOperation/n=512/Go_Union-12                                  926kB ± 0%     926kB ± 0%      ~     (p=0.068 n=15+14)
SetOperation/n=512/GEOS_Intersection-12                         115kB ± 0%     115kB ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_Difference-12                           159kB ± 0%     159kB ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-12                  577kB ± 0%     577kB ± 0%      ~     (p=0.178 n=15+13)
SetOperation/n=512/GEOS_Union-12                                171kB ± 0%     171kB ± 0%      ~     (all equal)
SetOperation/n=1024/Go_Intersection-12                         1.58MB ± 0%    1.58MB ± 0%      ~     (p=0.078 n=15+13)
SetOperation/n=1024/Go_Difference-12                           1.77MB ± 0%    1.77MB ± 0%      ~     (p=0.767 n=15+15)
SetOperation/n=1024/Go_SymmetricDifference-12                  2.80MB ± 0%    2.80MB ± 0%      ~     (p=0.333 n=15+13)
SetOperation/n=1024/Go_Union-12                                1.83MB ± 0%    1.83MB ± 0%      ~     (p=0.628 n=15+14)
SetOperation/n=1024/GEOS_Intersection-12                        189kB ± 0%     189kB ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_Difference-12                          369kB ± 0%     369kB ± 0%      ~     (p=0.600 n=14+15)
SetOperation/n=1024/GEOS_SymmetricDifference-12                1.38MB ± 0%    1.38MB ± 0%      ~     (p=0.310 n=13+15)
SetOperation/n=1024/GEOS_Union-12                               415kB ± 0%     415kB ± 0%      ~     (p=0.412 n=15+15)
SetOperation/n=2048/Go_Intersection-12                         3.64MB ± 0%    3.64MB ± 0%      ~     (p=0.052 n=15+14)
SetOperation/n=2048/Go_Difference-12                           3.87MB ± 0%    3.87MB ± 0%    -0.00%  (p=0.008 n=12+14)
SetOperation/n=2048/Go_SymmetricDifference-12                  5.63MB ± 0%    5.63MB ± 0%    +0.00%  (p=0.029 n=15+12)
SetOperation/n=2048/Go_Union-12                                3.95MB ± 0%    3.95MB ± 0%      ~     (p=0.659 n=15+14)
SetOperation/n=2048/GEOS_Intersection-12                        460kB ± 0%     460kB ± 0%      ~     (p=0.294 n=14+15)
SetOperation/n=2048/GEOS_Difference-12                          648kB ± 0%     648kB ± 0%      ~     (p=0.054 n=15+14)
SetOperation/n=2048/GEOS_SymmetricDifference-12                2.32MB ± 0%    2.32MB ± 0%      ~     (p=0.279 n=15+15)
SetOperation/n=2048/GEOS_Union-12                               689kB ± 0%     689kB ± 0%      ~     (p=0.254 n=15+15)
SetOperation/n=4096/Go_Intersection-12                         6.82MB ± 0%    6.82MB ± 0%      ~     (p=0.546 n=15+15)
SetOperation/n=4096/Go_Difference-12                           7.54MB ± 0%    7.54MB ± 0%      ~     (p=0.443 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-12                  11.6MB ± 0%    11.6MB ± 0%      ~     (p=0.813 n=14+15)
SetOperation/n=4096/Go_Union-12                                7.79MB ± 0%    7.79MB ± 0%      ~     (p=0.512 n=14+15)
SetOperation/n=4096/GEOS_Intersection-12                        755kB ± 0%     755kB ± 0%      ~     (p=0.812 n=15+15)
SetOperation/n=4096/GEOS_Difference-12                         1.45MB ± 0%    1.45MB ± 0%    +0.00%  (p=0.018 n=15+14)
SetOperation/n=4096/GEOS_SymmetricDifference-12                5.34MB ± 0%    5.34MB ± 0%      ~     (p=0.689 n=15+15)
SetOperation/n=4096/GEOS_Union-12                              1.63MB ± 0%    1.63MB ± 0%      ~     (p=0.943 n=15+15)
SetOperation/n=8192/Go_Intersection-12                         14.9MB ± 0%    14.9MB ± 0%      ~     (p=0.165 n=13+14)
SetOperation/n=8192/Go_Difference-12                           15.8MB ± 0%    15.8MB ± 0%      ~     (p=0.798 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-12                  22.7MB ± 0%    22.7MB ± 0%    -0.00%  (p=0.013 n=14+15)
SetOperation/n=8192/Go_Union-12                                16.1MB ± 0%    16.1MB ± 0%      ~     (p=0.959 n=15+15)
SetOperation/n=8192/GEOS_Intersection-12                       1.76MB ± 0%    1.76MB ± 0%      ~     (p=0.150 n=15+15)
SetOperation/n=8192/GEOS_Difference-12                         2.47MB ± 0%    2.47MB ± 0%      ~     (p=0.392 n=13+14)
SetOperation/n=8192/GEOS_SymmetricDifference-12                9.01MB ± 0%    9.01MB ± 0%      ~     (p=0.059 n=15+15)
SetOperation/n=8192/GEOS_Union-12                              2.66MB ± 0%    2.66MB ± 0%      ~     (p=0.519 n=15+14)
SetOperation/n=16384/Go_Intersection-12                        27.9MB ± 0%    27.9MB ± 0%      ~     (p=0.645 n=15+15)
SetOperation/n=16384/Go_Difference-12                          31.0MB ± 0%    31.0MB ± 0%      ~     (p=0.862 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-12                 47.3MB ± 0%    47.3MB ± 0%      ~     (p=0.271 n=15+15)
SetOperation/n=16384/Go_Union-12                               32.0MB ± 0%    32.0MB ± 0%    +0.00%  (p=0.028 n=15+15)
SetOperation/n=16384/GEOS_Intersection-12                      2.92MB ± 0%    2.92MB ± 0%      ~     (p=0.706 n=14+15)
SetOperation/n=16384/GEOS_Difference-12                        5.68MB ± 0%    5.68MB ± 0%      ~     (p=0.819 n=14+15)
SetOperation/n=16384/GEOS_SymmetricDifference-12               21.1MB ± 0%    21.1MB ± 0%      ~     (p=0.114 n=15+15)
SetOperation/n=16384/GEOS_Union-12                             6.45MB ± 0%    6.45MB ± 0%      ~     (p=0.337 n=15+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-12                                                  712B ± 0%      712B ± 0%      ~     (all equal)
Delete/n=1000-12                                               26.1kB ± 0%    26.1kB ± 0%      ~     (all equal)
Delete/n=10000-12                                               412kB ± 0%     412kB ± 0%      ~     (p=1.000 n=15+15)
Bulk/n=10-12                                                   1.46kB ± 0%    1.46kB ± 0%      ~     (all equal)
Bulk/n=100-12                                                  19.9kB ± 0%    19.9kB ± 0%      ~     (all equal)
Bulk/n=1000-12                                                 98.2kB ± 0%    98.2kB ± 0%      ~     (all equal)
Bulk/n=10000-12                                                1.57MB ± 0%    1.57MB ± 0%      ~     (p=0.904 n=15+14)
Bulk/n=100000-12                                               20.4MB ± 0%    20.4MB ± 0%      ~     (p=0.051 n=12+15)
Insert/n=10-12                                                 1.44kB ± 0%    1.44kB ± 0%      ~     (all equal)
Insert/n=100-12                                                13.5kB ± 0%    13.5kB ± 0%      ~     (all equal)
Insert/n=1000-12                                                132kB ± 0%     132kB ± 0%      ~     (all equal)
Insert/n=10000-12                                              1.34MB ± 0%    1.34MB ± 0%      ~     (p=0.387 n=14+15)
Insert/n=100000-12                                             13.5MB ± 0%    13.5MB ± 0%      ~     (p=0.932 n=15+13)
RangeSearch/n=10-12                                             0.00B          0.00B           ~     (all equal)
RangeSearch/n=100-12                                            0.00B          0.00B           ~     (all equal)
RangeSearch/n=1000-12                                           0.00B          0.00B           ~     (all equal)
RangeSearch/n=10000-12                                          0.00B          0.00B           ~     (all equal)
RangeSearch/n=100000-12                                         0.00B          0.00B           ~     (all equal)

name                                                         old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-12                                                0.00           0.00           ~     (all equal)
LineEnvelope/1-12                                                0.00           0.00           ~     (all equal)
LineEnvelope/2-12                                                0.00           0.00           ~     (all equal)
LineEnvelope/3-12                                                0.00           0.00           ~     (all equal)
MarshalWKB/polygon/n=10-12                                       6.00 ± 0%      6.00 ± 0%      ~     (all equal)
MarshalWKB/polygon/n=100-12                                      6.00 ± 0%      6.00 ± 0%      ~     (all equal)
MarshalWKB/polygon/n=1000-12                                     6.00 ± 0%      6.00 ± 0%      ~     (all equal)
MarshalWKB/polygon/n=10000-12                                    6.00 ± 0%      6.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=10-12                                     7.00 ± 0%      7.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=100-12                                    7.00 ± 0%      7.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=1000-12                                   7.00 ± 0%      7.00 ± 0%      ~     (all equal)
UnmarshalWKB/polygon/n=10000-12                                  7.00 ± 0%      7.00 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=10-12                       9.00 ± 0%      9.00 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=100-12                      73.0 ± 0%      73.0 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=1000-12                      345 ± 0%       345 ± 0%      ~     (all equal)
IntersectsLineStringWithLineString/n=10000-12                   5.46k ± 0%     5.46k ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-12                       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-12                      7.00 ± 0%      7.00 ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-12                     6.00 ± 0%      6.00 ± 0%      ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-12                    11.0 ± 0%      11.0 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=10-12                              12.0 ± 0%      12.0 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=100-12                             76.0 ± 0%      76.0 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=1000-12                             348 ± 0%       348 ± 0%      ~     (all equal)
PolygonSingleRingValidation/n=10000-12                          5.47k ± 0%     5.47k ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=4-12                            42.0 ± 0%      42.0 ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=36-12                            316 ± 0%       316 ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=400-12                         3.48k ± 0%     3.48k ± 0%      ~     (all equal)
PolygonMultipleRingsValidation/n=4096-12                        36.2k ± 0%     36.2k ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=10-12                             41.0 ± 0%      41.0 ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=100-12                             233 ± 0%       233 ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=1000-12                          1.05k ± 0%     1.05k ± 0%      ~     (all equal)
PolygonZigZagRingsValidation/n=10000-12                         16.4k ± 0%     16.4k ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=10-12                                 22.0 ± 0%      22.0 ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=100-12                                76.0 ± 0%      76.0 ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=1000-12                              1.00k ± 0%     1.00k ± 0%      ~     (all equal)
PolygonAnnulusValidation/n=10000-12                             10.3k ± 0%     10.3k ± 0%      ~     (all equal)
MultipolygonValidation/n=1-12                                    8.00 ± 0%      8.00 ± 0%      ~     (all equal)
MultipolygonValidation/n=4-12                                    11.0 ± 0%      11.0 ± 0%      ~     (all equal)
MultipolygonValidation/n=16-12                                   27.0 ± 0%      27.0 ± 0%      ~     (all equal)
MultipolygonValidation/n=64-12                                   91.0 ± 0%      91.0 ± 0%      ~     (all equal)
MultipolygonValidation/n=256-12                                   347 ± 0%       347 ± 0%      ~     (all equal)
MultipolygonValidation/n=1024-12                                1.37k ± 0%     1.37k ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=10-12                                   29.0 ± 0%      29.0 ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=100-12                                   157 ± 0%       157 ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=1000-12                                  701 ± 0%       701 ± 0%      ~     (all equal)
MultiPolygonTwoCircles/n=10000-12                               10.9k ± 0%     10.9k ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-12                        51.0 ± 0%      51.0 ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-12                        298 ± 0%       298 ± 0%      ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-12                     2.61k ± 0%     2.62k ± 0%      ~     (p=0.115 n=15+14)
MultiPolygonMultipleTouchingPoints/n=1000-12                    26.7k ± 0%     26.7k ± 0%      ~     (p=0.243 n=14+15)
WKTParsing/point-12                                              22.0 ± 0%      22.0 ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-12              234 ± 0%       234 ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-12               234 ± 0%       234 ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-12           2.10k ± 0%     2.10k ± 0%      ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-12            2.10k ± 0%     2.10k ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-12       13.0 ± 0%      13.0 ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-12        13.0 ± 0%      13.0 ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-12      77.0 ± 0%      77.0 ± 0%      ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-12       77.0 ± 0%      77.0 ± 0%      ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-12                   371 ± 0%       371 ± 0%      ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-12                3.34k ± 0%     3.34k ± 0%      ~     (all equal)
ForceCWandForceCCW/0-12                                          0.00           0.00           ~     (all equal)
ForceCWandForceCCW/0#01-12                                       3.00 ± 0%      3.00 ± 0%      ~     (all equal)
ForceCWandForceCCW/1-12                                          0.00           0.00           ~     (all equal)
ForceCWandForceCCW/1#01-12                                       3.00 ± 0%      3.00 ± 0%      ~     (all equal)
ForceCWandForceCCW/2-12                                          0.00           0.00           ~     (all equal)
ForceCWandForceCCW/2#01-12                                       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
ForceCWandForceCCW/3-12                                          0.00           0.00           ~     (all equal)
ForceCWandForceCCW/3#01-12                                       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
ForceCWandForceCCW/4-12                                         2.33 ±200%      0.00       -100.00%  (p=0.042 n=15+15)
ForceCWandForceCCW/4#01-12                                      4.67 ±100%      7.00 ± 0%   +50.00%  (p=0.042 n=15+15)
ForceCWandForceCCW/5-12                                         2.80 ±150%      0.00       -100.00%  (p=0.009 n=15+13)
ForceCWandForceCCW/5#01-12                                      4.20 ±100%      7.00 ± 0%   +66.67%  (p=0.027 n=15+13)
ForceCWandForceCCW/6-12                                          0.00           0.00           ~     (all equal)
ForceCWandForceCCW/6#01-12                                       12.0 ± 0%      12.0 ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-12                            48.0 ± 0%      48.0 ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=100-12                           48.0 ± 0%      48.0 ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=1000-12                          48.0 ± 0%      48.0 ± 0%      ~     (all equal)
IntersectionWithoutValidation/n=10000-12                         48.0 ± 0%      48.0 ± 0%      ~     (all equal)
NoOp/n=10-12                                                     33.0 ± 0%      33.0 ± 0%      ~     (all equal)
NoOp/n=100-12                                                    33.0 ± 0%      33.0 ± 0%      ~     (all equal)
NoOp/n=1000-12                                                   33.0 ± 0%      33.0 ± 0%      ~     (all equal)
NoOp/n=10000-12                                                  33.0 ± 0%      33.0 ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-12                                 7.00 ± 0%      7.00 ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=100-12                                71.0 ± 0%      71.0 ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=1000-12                                343 ± 0%       343 ± 0%      ~     (all equal)
LineStringIsSimpleCircle/n=10000-12                             5.46k ± 0%     5.46k ± 0%      ~     (p=0.074 n=12+15)
LineStringIsSimpleZigZag/10-12                                   7.00 ± 0%      7.00 ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/100-12                                  71.0 ± 0%      71.0 ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/1000-12                                  343 ± 0%       343 ± 0%      ~     (all equal)
LineStringIsSimpleZigZag/10000-12                               5.46k ± 0%     5.46k ± 0%      ~     (all equal)
SetOperation/n=4/Go_Intersection-12                               272 ± 0%       272 ± 0%      ~     (all equal)
SetOperation/n=4/Go_Difference-12                                 276 ± 0%       276 ± 0%      ~     (all equal)
SetOperation/n=4/Go_SymmetricDifference-12                        374 ± 0%       374 ± 0%      ~     (all equal)
SetOperation/n=4/Go_Union-12                                      283 ± 0%       283 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Intersection-12                            52.0 ± 0%      52.0 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Difference-12                              55.0 ± 0%      55.0 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-12                      148 ± 0%       148 ± 0%      ~     (all equal)
SetOperation/n=4/GEOS_Union-12                                   56.0 ± 0%      56.0 ± 0%      ~     (all equal)
SetOperation/n=8/Go_Intersection-12                               288 ± 0%       288 ± 0%      ~     (p=0.051 n=14+15)
SetOperation/n=8/Go_Difference-12                                 289 ± 0%       289 ± 0%      ~     (p=0.074 n=12+15)
SetOperation/n=8/Go_SymmetricDifference-12                        393 ± 0%       393 ± 0%      ~     (p=0.700 n=15+15)
SetOperation/n=8/Go_Union-12                                      294 ± 0%       294 ± 0%    -0.11%  (p=0.020 n=15+12)
SetOperation/n=8/GEOS_Intersection-12                            56.0 ± 0%      56.0 ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_Difference-12                              56.0 ± 0%      56.0 ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-12                      152 ± 0%       152 ± 0%      ~     (all equal)
SetOperation/n=8/GEOS_Union-12                                   56.0 ± 0%      56.0 ± 0%      ~     (all equal)
SetOperation/n=16/Go_Intersection-12                              302 ± 0%       302 ± 0%      ~     (all equal)
SetOperation/n=16/Go_Difference-12                                312 ± 0%       312 ± 0%      ~     (all equal)
SetOperation/n=16/Go_SymmetricDifference-12                       441 ± 0%       441 ± 0%      ~     (all equal)
SetOperation/n=16/Go_Union-12                                     321 ± 0%       321 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Intersection-12                           56.0 ± 0%      56.0 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Difference-12                             64.0 ± 0%      64.0 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-12                     185 ± 0%       185 ± 0%      ~     (all equal)
SetOperation/n=16/GEOS_Union-12                                  68.0 ± 0%      68.0 ± 0%      ~     (all equal)
SetOperation/n=32/Go_Intersection-12                              353 ± 0%       353 ± 0%      ~     (all equal)
SetOperation/n=32/Go_Difference-12                                359 ± 0%       359 ± 0%      ~     (all equal)
SetOperation/n=32/Go_SymmetricDifference-12                       512 ± 0%       512 ± 0%      ~     (all equal)
SetOperation/n=32/Go_Union-12                                     364 ± 0%       364 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Intersection-12                           68.0 ± 0%      68.0 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Difference-12                             72.0 ± 0%      72.0 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-12                     216 ± 0%       216 ± 0%      ~     (all equal)
SetOperation/n=32/GEOS_Union-12                                  72.0 ± 0%      72.0 ± 0%      ~     (all equal)
SetOperation/n=64/Go_Intersection-12                              394 ± 0%       394 ± 0%      ~     (all equal)
SetOperation/n=64/Go_Difference-12                                428 ± 0%       428 ± 0%      ~     (p=0.115 n=14+15)
SetOperation/n=64/Go_SymmetricDifference-12                       679 ± 0%       679 ± 0%      ~     (p=0.074 n=12+15)
SetOperation/n=64/Go_Union-12                                     441 ± 0%       441 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Intersection-12                           72.0 ± 0%      72.0 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Difference-12                              104 ± 0%       104 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-12                     345 ± 0%       345 ± 0%      ~     (all equal)
SetOperation/n=64/GEOS_Union-12                                   112 ± 0%       112 ± 0%      ~     (all equal)
SetOperation/n=128/Go_Intersection-12                             568 ± 0%       568 ± 0%      ~     (all equal)
SetOperation/n=128/Go_Difference-12                               594 ± 0%       594 ± 0%      ~     (all equal)
SetOperation/n=128/Go_SymmetricDifference-12                      942 ± 0%       942 ± 0%      ~     (all equal)
SetOperation/n=128/Go_Union-12                                    599 ± 0%       599 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Intersection-12                           112 ± 0%       112 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Difference-12                             136 ± 0%       136 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-12                    473 ± 0%       473 ± 0%      ~     (all equal)
SetOperation/n=128/GEOS_Union-12                                  136 ± 0%       136 ± 0%      ~     (all equal)
SetOperation/n=256/Go_Intersection-12                             727 ± 0%       727 ± 0%      ~     (all equal)
SetOperation/n=256/Go_Difference-12                               857 ± 0%       857 ± 0%      ~     (all equal)
SetOperation/n=256/Go_SymmetricDifference-12                    1.59k ± 0%     1.59k ± 0%      ~     (all equal)
SetOperation/n=256/Go_Union-12                                    886 ± 0%       886 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_Intersection-12                           136 ± 0%       136 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_Difference-12                             264 ± 0%       264 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-12                    985 ± 0%       985 ± 0%      ~     (all equal)
SetOperation/n=256/GEOS_Union-12                                  288 ± 0%       288 ± 0%      ~     (all equal)
SetOperation/n=512/Go_Intersection-12                           1.40k ± 0%     1.40k ± 0%      ~     (p=0.084 n=15+14)
SetOperation/n=512/Go_Difference-12                             1.50k ± 0%     1.50k ± 0%      ~     (all equal)
SetOperation/n=512/Go_SymmetricDifference-12                    2.62k ± 0%     2.62k ± 0%      ~     (p=1.000 n=15+15)
SetOperation/n=512/Go_Union-12                                  1.51k ± 0%     1.51k ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_Intersection-12                           288 ± 0%       288 ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_Difference-12                             392 ± 0%       392 ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-12                  1.50k ± 0%     1.50k ± 0%      ~     (all equal)
SetOperation/n=512/GEOS_Union-12                                  392 ± 0%       392 ± 0%      ~     (all equal)
SetOperation/n=1024/Go_Intersection-12                          2.02k ± 0%     2.02k ± 0%      ~     (all equal)
SetOperation/n=1024/Go_Difference-12                            2.54k ± 0%     2.54k ± 0%      ~     (all equal)
SetOperation/n=1024/Go_SymmetricDifference-12                   5.19k ± 0%     5.19k ± 0%      ~     (all equal)
SetOperation/n=1024/Go_Union-12                                 2.63k ± 0%     2.63k ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_Intersection-12                          392 ± 0%       392 ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_Difference-12                            904 ± 0%       904 ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-12                 3.54k ± 0%     3.54k ± 0%      ~     (all equal)
SetOperation/n=1024/GEOS_Union-12                                 992 ± 0%       992 ± 0%      ~     (all equal)
SetOperation/n=2048/Go_Intersection-12                          4.68k ± 0%     4.68k ± 0%      ~     (all equal)
SetOperation/n=2048/Go_Difference-12                            5.11k ± 0%     5.11k ± 0%      ~     (all equal)
SetOperation/n=2048/Go_SymmetricDifference-12                   9.31k ± 0%     9.31k ± 0%      ~     (p=0.074 n=12+15)
SetOperation/n=2048/Go_Union-12                                 5.12k ± 0%     5.12k ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_Intersection-12                          992 ± 0%       992 ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_Difference-12                          1.42k ± 0%     1.42k ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-12                 5.59k ± 0%     5.59k ± 0%      ~     (all equal)
SetOperation/n=2048/GEOS_Union-12                               1.42k ± 0%     1.42k ± 0%      ~     (all equal)
SetOperation/n=4096/Go_Intersection-12                          7.17k ± 0%     7.17k ± 0%      ~     (p=0.272 n=15+15)
SetOperation/n=4096/Go_Difference-12                            9.22k ± 0%     9.22k ± 0%      ~     (p=0.521 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-12                   19.6k ± 0%     19.6k ± 0%      ~     (p=0.971 n=15+15)
SetOperation/n=4096/Go_Union-12                                 9.57k ± 0%     9.57k ± 0%      ~     (p=1.000 n=15+15)
SetOperation/n=4096/GEOS_Intersection-12                        1.42k ± 0%     1.42k ± 0%      ~     (all equal)
SetOperation/n=4096/GEOS_Difference-12                          3.46k ± 0%     3.46k ± 0%      ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-12                 13.8k ± 0%     13.8k ± 0%      ~     (all equal)
SetOperation/n=4096/GEOS_Union-12                               3.81k ± 0%     3.81k ± 0%      ~     (all equal)
SetOperation/n=8192/Go_Intersection-12                          17.8k ± 0%     17.8k ± 0%      ~     (p=0.751 n=15+15)
SetOperation/n=8192/Go_Difference-12                            19.5k ± 0%     19.5k ± 0%      ~     (all equal)
SetOperation/n=8192/Go_SymmetricDifference-12                   36.0k ± 0%     36.0k ± 0%      ~     (p=0.129 n=14+15)
SetOperation/n=8192/Go_Union-12                                 19.5k ± 0%     19.5k ± 0%    +0.00%  (p=0.035 n=15+11)
SetOperation/n=8192/GEOS_Intersection-12                        3.81k ± 0%     3.81k ± 0%      ~     (all equal)
SetOperation/n=8192/GEOS_Difference-12                          5.51k ± 0%     5.51k ± 0%      ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-12                 22.0k ± 0%     22.0k ± 0%      ~     (all equal)
SetOperation/n=8192/GEOS_Union-12                               5.51k ± 0%     5.51k ± 0%      ~     (all equal)
SetOperation/n=16384/Go_Intersection-12                         27.7k ± 0%     27.7k ± 0%      ~     (p=0.707 n=15+15)
SetOperation/n=16384/Go_Difference-12                           35.9k ± 0%     35.9k ± 0%      ~     (p=1.000 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-12                  76.9k ± 0%     76.9k ± 0%      ~     (p=0.098 n=15+15)
SetOperation/n=16384/Go_Union-12                                37.2k ± 0%     37.2k ± 0%      ~     (p=0.193 n=15+15)
SetOperation/n=16384/GEOS_Intersection-12                       5.51k ± 0%     5.51k ± 0%      ~     (all equal)
SetOperation/n=16384/GEOS_Difference-12                         13.7k ± 0%     13.7k ± 0%      ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-12                54.7k ± 0%     54.7k ± 0%    +0.00%  (p=0.004 n=13+15)
SetOperation/n=16384/GEOS_Union-12                              15.1k ± 0%     15.1k ± 0%      ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-12                                                  65.0 ± 0%      65.0 ± 0%      ~     (all equal)
Delete/n=1000-12                                                  480 ± 0%       480 ± 0%      ~     (all equal)
Delete/n=10000-12                                               7.62k ± 0%     7.62k ± 0%      ~     (all equal)
Bulk/n=10-12                                                     6.00 ± 0%      6.00 ± 0%      ~     (all equal)
Bulk/n=100-12                                                    70.0 ± 0%      70.0 ± 0%      ~     (all equal)
Bulk/n=1000-12                                                    342 ± 0%       342 ± 0%      ~     (all equal)
Bulk/n=10000-12                                                 5.46k ± 0%     5.46k ± 0%      ~     (all equal)
Bulk/n=100000-12                                                71.0k ± 0%     71.0k ± 0%      ~     (all equal)
Insert/n=10-12                                                   5.00 ± 0%      5.00 ± 0%      ~     (all equal)
Insert/n=100-12                                                  47.0 ± 0%      47.0 ± 0%      ~     (all equal)
Insert/n=1000-12                                                  457 ± 0%       457 ± 0%      ~     (all equal)
Insert/n=10000-12                                               4.65k ± 0%     4.65k ± 0%      ~     (all equal)
Insert/n=100000-12                                              46.8k ± 0%     46.8k ± 0%      ~     (all equal)
RangeSearch/n=10-12                                              0.00           0.00           ~     (all equal)
RangeSearch/n=100-12                                             0.00           0.00           ~     (all equal)
RangeSearch/n=1000-12                                            0.00           0.00           ~     (all equal)
RangeSearch/n=10000-12                                           0.00           0.00           ~     (all equal)
RangeSearch/n=100000-12                                          0.00           0.00           ~     (all equal)
```

</details>
