### PR TITLE
Don't Label Faces When Inputs Are Lines

### DIFF
--- a/geom/dcel.go
+++ b/geom/dcel.go
@@ -266,7 +266,7 @@ func newDCELFromMultiLineString(mls MultiLineString, operand operand, interactio
 				prev:         nil, // set later
 				intermediate: intermediateFwd,
 				edgeLabels:   newHalfPopulatedLabels(operand, true),
-				faceLabels:   newHalfPopulatedLabels(operand, false),
+				faceLabels:   newUnpopulatedLabels(),
 			}
 			rev := &halfEdgeRecord{
 				origin:       vDestin,
@@ -276,7 +276,7 @@ func newDCELFromMultiLineString(mls MultiLineString, operand operand, interactio
 				prev:         fwd,
 				intermediate: intermediateRev,
 				edgeLabels:   newHalfPopulatedLabels(operand, true),
-				faceLabels:   newHalfPopulatedLabels(operand, false),
+				faceLabels:   newUnpopulatedLabels(),
 			}
 			fwd.twin = rev
 			fwd.next = rev

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -20,6 +20,10 @@ type label struct {
 	inSet bool
 }
 
+func newUnpopulatedLabels() [2]label {
+	return [2]label{}
+}
+
 func newHalfPopulatedLabels(operand operand, inSet bool) [2]label {
 	var labels [2]label
 	labels[operand].populated = true

--- a/geom/dcel_test.go
+++ b/geom/dcel_test.go
@@ -562,22 +562,22 @@ func TestGraphMultiLineString(t *testing.T) {
 		Edges: []EdgeSpec{
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v0, v1, v2},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v2, v1, v0},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v3, v4, v5},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v5, v4, v3},
 			},
 		},
@@ -618,42 +618,42 @@ func TestGraphSelfOverlappingLineString(t *testing.T) {
 		Edges: []EdgeSpec{
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v0, v1},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v1, v0},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v1, v2},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v2, v1},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v1, v3, v2},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v2, v3, v1},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v2, v4},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v4, v2},
 			},
 		},
@@ -698,12 +698,12 @@ func TestGraphGhostDeduplication(t *testing.T) {
 		Edges: []EdgeSpec{
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v0, v1},
 			},
 			{
 				EdgeLabels: []LabelOption{OperandA(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 				Sequence:   []XY{v1, v0},
 			},
 			{
@@ -1695,22 +1695,22 @@ func TestGraphOverlayTwoLineStringsIntersectingAtEndpoints(t *testing.T) {
 			{
 				Sequence:   []XY{v1, v2},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(false)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v2, v1},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(false)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v0, v1},
 				EdgeLabels: []LabelOption{OperandA(false), OperandB(true)},
-				FaceLabels: []LabelOption{OperandB(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v1, v0},
 				EdgeLabels: []LabelOption{OperandA(false), OperandB(true)},
-				FaceLabels: []LabelOption{OperandB(false)},
+				FaceLabels: nil,
 			},
 		},
 		Faces: []FaceSpec{{
@@ -1768,12 +1768,12 @@ func TestGraphOverlayReproduceFaceAllocationBug(t *testing.T) {
 			{
 				Sequence:   []XY{v1, v3},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v3, v1},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(true)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v0, v1},
@@ -1926,22 +1926,22 @@ func TestGraphOverlayReproducePointOnLineStringPrecisionBug(t *testing.T) {
 			{
 				Sequence:   []XY{v0, v1},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(false)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v1, v2},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(false)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v2, v1},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(false)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 			{
 				Sequence:   []XY{v1, v0},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(false)},
-				FaceLabels: []LabelOption{OperandA(false)},
+				FaceLabels: nil,
 			},
 		},
 		Faces: []FaceSpec{
@@ -1993,12 +1993,12 @@ func TestGraphOverlayReproduceGhostOnGeometryBug(t *testing.T) {
 			{
 				Sequence:   []XY{v0, v1},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(true)},
-				FaceLabels: []LabelOption{OperandA(false), OperandB(true)},
+				FaceLabels: []LabelOption{OperandB(true)},
 			},
 			{
 				Sequence:   []XY{v1, v0},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(true)},
-				FaceLabels: []LabelOption{OperandA(false), OperandB(false)},
+				FaceLabels: []LabelOption{OperandB(false)},
 			},
 			{
 				Sequence:   []XY{v1, v2, v3},
@@ -2013,12 +2013,12 @@ func TestGraphOverlayReproduceGhostOnGeometryBug(t *testing.T) {
 			{
 				Sequence:   []XY{v3, v4, v0},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(true)},
-				FaceLabels: []LabelOption{OperandA(false), OperandB(true)},
+				FaceLabels: []LabelOption{OperandB(true)},
 			},
 			{
 				Sequence:   []XY{v0, v4, v3},
 				EdgeLabels: []LabelOption{OperandA(true), OperandB(true)},
-				FaceLabels: []LabelOption{OperandA(false), OperandB(false)},
+				FaceLabels: []LabelOption{OperandB(false)},
 			},
 		},
 		Faces: []FaceSpec{


### PR DESCRIPTION
## Description

The original behaviour when constructing a DCEL from a LineString (or MultiLineString) was to populate the face labels for half edges. They were populated with the face being marked as "absent".

The assumption was that because LineStrings are not areal, there is never a face for the that geometry in the final output. This was a valid assumption because the input disallowed GeometryCollections (i.e. a mix between areal and non-areal geometries).

If we allow GeometryCollection inputs, then the assumption is no longer valid. This is because the face may need to be included in the geometry by virtue of another (areal) part of the geometry collection (i.e. a Polygon or a MultiPolygon).

The solution in this PR is to simply not populate face labels when adding MultiLineStrings to a DCEL. If a Polygon is added to the DCEL as a later step (as we're iterating over a GeometryCollection), then that step will update the face labels accordingly.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

This is a preliminary step for https://github.com/peterstace/simplefeatures/issues/271

## Benchmark Results

<details>

<summary>Click to expand</summary>

```
LineEnvelope/0-4                                              2.33ns ± 4%    2.36ns ±10%     ~     (p=0.709 n=14+14)
LineEnvelope/1-4                                              2.31ns ± 3%    2.34ns ± 7%     ~     (p=0.223 n=14+14)
LineEnvelope/2-4                                              2.10ns ± 3%    2.12ns ± 4%     ~     (p=0.458 n=14+15)
LineEnvelope/3-4                                              2.08ns ± 3%    2.09ns ± 5%     ~     (p=0.371 n=14+15)
MarshalWKB/polygon/n=10-4                                      164ns ±17%     180ns ±41%     ~     (p=0.310 n=14+15)
MarshalWKB/polygon/n=100-4                                     426ns ±38%     448ns ±31%     ~     (p=0.186 n=14+15)
MarshalWKB/polygon/n=1000-4                                   2.79µs ±40%    2.67µs ±14%     ~     (p=0.981 n=14+13)
MarshalWKB/polygon/n=10000-4                                  21.8µs ±52%   24.2µs ±110%     ~     (p=0.683 n=15+13)
UnmarshalWKB/polygon/n=10-4                                    279ns ±14%     277ns ±10%     ~     (p=0.862 n=13+12)
UnmarshalWKB/polygon/n=100-4                                   505ns ±25%     503ns ±11%     ~     (p=0.611 n=13+12)
UnmarshalWKB/polygon/n=1000-4                                 3.45µs ±69%    3.17µs ±43%     ~     (p=0.847 n=15+14)
UnmarshalWKB/polygon/n=10000-4                                21.0µs ±20%    22.6µs ±32%     ~     (p=0.123 n=12+13)
IntersectsLineStringWithLineString/n=10-4                     1.20µs ±19%    1.26µs ±21%     ~     (p=0.054 n=14+13)
IntersectsLineStringWithLineString/n=100-4                    17.9µs ±13%    17.8µs ±14%     ~     (p=0.949 n=15+14)
IntersectsLineStringWithLineString/n=1000-4                    187µs ±21%     189µs ±34%     ~     (p=0.880 n=13+13)
IntersectsLineStringWithLineString/n=10000-4                  2.85ms ±12%    2.95ms ±16%     ~     (p=0.402 n=14+13)
IntersectsMultiPointWithMultiPoint/n=20-4                      754ns ± 9%     864ns ±60%     ~     (p=0.068 n=13+14)
IntersectsMultiPointWithMultiPoint/n=200-4                    8.90µs ±19%    8.71µs ± 6%     ~     (p=0.780 n=13+12)
IntersectsMultiPointWithMultiPoint/n=2000-4                   88.9µs ±14%    95.7µs ±33%     ~     (p=0.106 n=12+14)
IntersectsMultiPointWithMultiPoint/n=20000-4                  1.11ms ±46%    1.06ms ±25%     ~     (p=0.376 n=14+14)
PolygonSingleRingValidation/n=10-4                            2.16µs ± 8%    2.30µs ±11%   +6.57%  (p=0.006 n=13+14)
PolygonSingleRingValidation/n=100-4                           29.0µs ±11%    28.8µs ± 7%     ~     (p=1.000 n=14+15)
PolygonSingleRingValidation/n=1000-4                           362µs ±11%     367µs ±10%     ~     (p=0.362 n=13+13)
PolygonSingleRingValidation/n=10000-4                         4.59ms ± 7%    4.91ms ±17%   +6.95%  (p=0.046 n=13+15)
PolygonMultipleRingsValidation/n=4-4                          8.42µs ±73%    6.33µs ±20%  -24.80%  (p=0.008 n=15+12)
PolygonMultipleRingsValidation/n=36-4                         53.5µs ±25%    51.3µs ± 5%     ~     (p=0.830 n=14+13)
PolygonMultipleRingsValidation/n=400-4                         852µs ±60%     722µs ±22%     ~     (p=0.440 n=15+13)
PolygonMultipleRingsValidation/n=4096-4                       7.93ms ±11%    8.00ms ±12%     ~     (p=0.856 n=13+15)
PolygonZigZagRingsValidation/n=10-4                           10.2µs ±15%    10.9µs ±37%     ~     (p=0.114 n=14+14)
PolygonZigZagRingsValidation/n=100-4                           118µs ±10%     117µs ±10%     ~     (p=0.905 n=13+14)
PolygonZigZagRingsValidation/n=1000-4                         1.35ms ± 7%    1.31ms ± 4%   -2.81%  (p=0.014 n=14+14)
PolygonZigZagRingsValidation/n=10000-4                        18.0ms ± 8%    18.4ms ±12%     ~     (p=0.325 n=13+14)
PolygonAnnulusValidation/n=10-4                               3.56µs ±25%    3.46µs ±15%     ~     (p=0.889 n=15+14)
PolygonAnnulusValidation/n=100-4                              31.1µs ±18%    29.7µs ± 8%     ~     (p=0.239 n=14+13)
PolygonAnnulusValidation/n=1000-4                              501µs ± 5%     496µs ± 7%     ~     (p=0.538 n=12+13)
PolygonAnnulusValidation/n=10000-4                            6.01ms ±16%    5.65ms ± 4%   -6.01%  (p=0.012 n=13+13)
MultipolygonValidation/n=1-4                                   432ns ±42%     386ns ±11%     ~     (p=0.511 n=14+13)
MultipolygonValidation/n=4-4                                   882ns ±15%    1012ns ±45%     ~     (p=0.202 n=13+14)
MultipolygonValidation/n=16-4                                 3.69µs ±28%    3.72µs ±24%     ~     (p=0.720 n=14+13)
MultipolygonValidation/n=64-4                                 17.0µs ±36%    15.7µs ±23%     ~     (p=0.865 n=14+14)
MultipolygonValidation/n=256-4                                 104µs ±26%     104µs ±43%     ~     (p=0.720 n=14+13)
MultipolygonValidation/n=1024-4                                434µs ± 4%     441µs ± 4%     ~     (p=0.088 n=13+15)
MultiPolygonTwoCircles/n=10-4                                 3.81µs ±29%    3.36µs ±18%     ~     (p=0.085 n=14+13)
MultiPolygonTwoCircles/n=100-4                                38.2µs ±33%    33.3µs ± 7%  -12.81%  (p=0.003 n=14+13)
MultiPolygonTwoCircles/n=1000-4                                405µs ±35%     431µs ±62%     ~     (p=1.000 n=13+14)
MultiPolygonTwoCircles/n=10000-4                              6.10ms ±11%    5.90ms ± 4%     ~     (p=0.064 n=13+13)
MultiPolygonMultipleTouchingPoints/n=1-4                      4.81µs ±31%    4.35µs ±11%   -9.59%  (p=0.004 n=14+15)
MultiPolygonMultipleTouchingPoints/n=10-4                     35.9µs ±20%    35.7µs ±11%     ~     (p=0.880 n=14+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     426µs ±11%     412µs ± 6%     ~     (p=0.185 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1000-4                   4.72ms ± 8%    4.68ms ±10%     ~     (p=0.339 n=13+15)
WKTParsing/point-4                                            1.72µs ±42%    1.57µs ±13%     ~     (p=0.451 n=13+14)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           48.7µs ±47%    46.7µs ±29%     ~     (p=0.780 n=14+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            50.0µs ±42%    44.0µs ± 8%     ~     (p=0.059 n=14+13)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           690µs ±31%     692µs ±16%     ~     (p=0.810 n=12+13)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            676µs ± 5%     671µs ± 4%     ~     (p=0.667 n=12+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     4.86µs ±29%    4.67µs ±14%     ~     (p=0.692 n=14+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      4.63µs ± 8%    5.23µs ±41%     ~     (p=0.054 n=14+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    51.3µs ±14%    54.1µs ±24%     ~     (p=0.399 n=12+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     51.4µs ±11%    54.7µs ±30%     ~     (p=0.650 n=14+13)
MultiLineStringIsSimpleManyLineStrings/n=100-4                50.1µs ±21%    48.5µs ±22%     ~     (p=0.150 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                657µs ±86%     513µs ±20%     ~     (p=0.085 n=14+13)
ForceCWandForceCCW/0-4                                        30.8ns ± 4%    30.4ns ± 5%     ~     (p=0.458 n=13+14)
ForceCWandForceCCW/0#01-4                                      225ns ±41%     201ns ± 8%     ~     (p=0.650 n=13+12)
ForceCWandForceCCW/1-4                                       75.7ns ±188%    31.1ns ± 6%     ~     (p=0.100 n=15+13)
ForceCWandForceCCW/1#01-4                                      166ns ±86%     198ns ± 5%     ~     (p=0.306 n=15+12)
ForceCWandForceCCW/2-4                                        56.4ns ±10%    56.8ns ±34%     ~     (p=0.560 n=14+12)
ForceCWandForceCCW/2#01-4                                      328ns ±12%     339ns ±20%     ~     (p=0.497 n=12+10)
ForceCWandForceCCW/3-4                                        56.0ns ± 2%    57.3ns ± 6%     ~     (p=0.095 n=12+14)
ForceCWandForceCCW/3#01-4                                      319ns ± 9%     341ns ±18%   +6.85%  (p=0.009 n=13+11)
ForceCWandForceCCW/4-4                                        82.2ns ± 9%    81.3ns ± 5%     ~     (p=0.462 n=12+14)
ForceCWandForceCCW/4#01-4                                      505ns ±14%     522ns ±10%     ~     (p=0.156 n=12+13)
ForceCWandForceCCW/5-4                                        189ns ±168%      82ns ± 8%     ~     (p=0.643 n=15+14)
ForceCWandForceCCW/5#01-4                                      403ns ±80%     527ns ±16%  +30.58%  (p=0.025 n=15+14)
ForceCWandForceCCW/6-4                                         115ns ± 2%     118ns ± 6%     ~     (p=0.106 n=12+13)
ForceCWandForceCCW/6#01-4                                      789ns ±16%     814ns ±10%     ~     (p=0.186 n=11+13)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-4                          38.9µs ± 7%    39.5µs ± 8%     ~     (p=0.310 n=15+14)
IntersectionWithoutValidation/n=100-4                         72.4µs ± 5%    74.5µs ± 8%     ~     (p=0.061 n=13+14)
IntersectionWithoutValidation/n=1000-4                         325µs ±11%     324µs ± 7%     ~     (p=0.949 n=15+14)
IntersectionWithoutValidation/n=10000-4                       2.91ms ± 8%    2.89ms ±12%     ~     (p=0.683 n=15+13)
NoOp/n=10-4                                                   3.78µs ± 9%    3.78µs ±12%     ~     (p=0.964 n=15+13)
NoOp/n=100-4                                                  10.6µs ± 3%    10.9µs ± 6%   +3.68%  (p=0.008 n=13+12)
NoOp/n=1000-4                                                 76.6µs ± 8%    83.7µs ±30%     ~     (p=0.054 n=14+13)
NoOp/n=10000-4                                                 909µs ± 5%     896µs ±13%     ~     (p=0.424 n=11+13)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-4                               1.82µs ±16%    1.81µs ± 5%     ~     (p=0.643 n=14+14)
LineStringIsSimpleCircle/n=100-4                              25.7µs ±10%    27.5µs ±15%     ~     (p=0.056 n=14+14)
LineStringIsSimpleCircle/n=1000-4                              342µs ± 2%     345µs ± 5%     ~     (p=0.687 n=13+13)
LineStringIsSimpleCircle/n=10000-4                            4.45ms ± 7%    4.54ms ± 5%     ~     (p=0.105 n=14+13)
LineStringIsSimpleZigZag/10-4                                 1.57µs ± 6%    1.63µs ± 8%   +3.90%  (p=0.026 n=13+12)
LineStringIsSimpleZigZag/100-4                                26.5µs ± 8%    26.9µs ±12%     ~     (p=0.550 n=14+13)
LineStringIsSimpleZigZag/1000-4                                327µs ±12%     327µs ± 7%     ~     (p=0.631 n=14+12)
LineStringIsSimpleZigZag/10000-4                              4.40ms ± 5%    4.46ms ±15%     ~     (p=0.905 n=14+13)
SetOperation/n=4/Go_Intersection-4                            36.0µs ± 2%    36.6µs ± 4%     ~     (p=0.101 n=12+13)
SetOperation/n=4/Go_Difference-4                              37.7µs ± 6%    38.0µs ±11%     ~     (p=0.820 n=14+13)
SetOperation/n=4/Go_SymmetricDifference-4                     49.2µs ± 6%    52.0µs ±23%     ~     (p=0.621 n=14+15)
SetOperation/n=4/Go_Union-4                                   38.4µs ± 5%    40.5µs ±19%     ~     (p=0.104 n=14+14)
SetOperation/n=4/GEOS_Intersection-4                          34.9µs ± 5%    36.7µs ±17%   +5.22%  (p=0.050 n=14+14)
SetOperation/n=4/GEOS_Difference-4                            36.6µs ±10%    37.2µs ±10%     ~     (p=0.505 n=15+14)
SetOperation/n=4/GEOS_SymmetricDifference-4                   51.6µs ± 5%    52.8µs ± 9%     ~     (p=0.541 n=14+14)
SetOperation/n=4/GEOS_Union-4                                 36.5µs ± 6%    37.1µs ±15%     ~     (p=0.914 n=14+15)
SetOperation/n=8/Go_Intersection-4                            47.5µs ±18%    49.3µs ±20%     ~     (p=0.142 n=13+15)
SetOperation/n=8/Go_Difference-4                              46.6µs ± 5%    46.0µs ± 3%     ~     (p=0.479 n=13+13)
SetOperation/n=8/Go_SymmetricDifference-4                     63.0µs ± 8%    63.4µs ±18%     ~     (p=0.701 n=14+14)
SetOperation/n=8/Go_Union-4                                   49.6µs ±11%    48.9µs ±14%     ~     (p=0.519 n=14+13)
SetOperation/n=8/GEOS_Intersection-4                          43.7µs ± 6%    43.8µs ±12%     ~     (p=0.734 n=14+14)
SetOperation/n=8/GEOS_Difference-4                            43.2µs ± 4%    44.3µs ±14%     ~     (p=0.583 n=13+14)
SetOperation/n=8/GEOS_SymmetricDifference-4                   60.7µs ± 6%    62.3µs ±15%     ~     (p=0.496 n=15+13)
SetOperation/n=8/GEOS_Union-4                                 42.0µs ± 6%    41.6µs ± 8%     ~     (p=0.525 n=15+13)
SetOperation/n=16/Go_Intersection-4                           66.0µs ± 8%    66.5µs ±10%     ~     (p=0.635 n=14+14)
SetOperation/n=16/Go_Difference-4                             70.0µs ± 7%    69.5µs ± 7%     ~     (p=0.667 n=14+12)
SetOperation/n=16/Go_SymmetricDifference-4                    97.0µs ± 9%    97.6µs ±15%     ~     (p=0.650 n=13+13)
SetOperation/n=16/Go_Union-4                                  73.6µs ±18%    73.9µs ±13%     ~     (p=0.511 n=14+14)
SetOperation/n=16/GEOS_Intersection-4                         48.0µs ± 5%    48.0µs ± 8%     ~     (p=0.756 n=13+14)
SetOperation/n=16/GEOS_Difference-4                           50.1µs ± 6%    51.6µs ±13%     ~     (p=0.056 n=14+13)
SetOperation/n=16/GEOS_SymmetricDifference-4                  77.8µs ±10%    77.4µs ± 9%     ~     (p=0.775 n=15+15)
SetOperation/n=16/GEOS_Union-4                                50.3µs ± 5%    51.2µs ± 9%     ~     (p=0.382 n=14+13)
SetOperation/n=32/Go_Intersection-4                            113µs ± 6%     113µs ±12%     ~     (p=0.840 n=13+13)
SetOperation/n=32/Go_Difference-4                              117µs ± 8%     122µs ±32%     ~     (p=0.254 n=15+13)
SetOperation/n=32/Go_SymmetricDifference-4                     161µs ±11%     170µs ±28%     ~     (p=0.150 n=14+14)
SetOperation/n=32/Go_Union-4                                   121µs ± 4%     126µs ±24%     ~     (p=0.781 n=12+14)
SetOperation/n=32/GEOS_Intersection-4                         59.5µs ± 8%    59.3µs ± 6%     ~     (p=0.928 n=15+13)
SetOperation/n=32/GEOS_Difference-4                           63.5µs ± 9%    62.9µs ±12%     ~     (p=0.511 n=14+14)
SetOperation/n=32/GEOS_SymmetricDifference-4                   108µs ±14%     104µs ± 6%     ~     (p=0.155 n=14+13)
SetOperation/n=32/GEOS_Union-4                                61.3µs ± 5%    62.8µs ±10%     ~     (p=0.376 n=14+14)
SetOperation/n=64/Go_Intersection-4                            187µs ±11%     196µs ±13%     ~     (p=0.139 n=13+13)
SetOperation/n=64/Go_Difference-4                              205µs ±12%     207µs ±12%     ~     (p=0.910 n=14+14)
SetOperation/n=64/Go_SymmetricDifference-4                     282µs ± 6%     279µs ± 6%     ~     (p=0.336 n=13+13)
SetOperation/n=64/Go_Union-4                                   214µs ±10%     213µs ± 6%     ~     (p=0.856 n=15+13)
SetOperation/n=64/GEOS_Intersection-4                         78.5µs ± 8%    76.7µs ± 8%     ~     (p=0.186 n=15+14)
SetOperation/n=64/GEOS_Difference-4                           94.8µs ± 9%    92.8µs ± 9%     ~     (p=0.339 n=15+13)
SetOperation/n=64/GEOS_SymmetricDifference-4                   204µs ±58%     207µs ±58%     ~     (p=0.786 n=13+15)
SetOperation/n=64/GEOS_Union-4                                97.5µs ± 6%    97.3µs ± 8%     ~     (p=0.960 n=13+13)
SetOperation/n=128/Go_Intersection-4                           367µs ±14%     355µs ± 6%     ~     (p=0.320 n=13+12)
SetOperation/n=128/Go_Difference-4                             361µs ± 4%     371µs ± 6%     ~     (p=0.064 n=13+13)
SetOperation/n=128/Go_SymmetricDifference-4                    492µs ±16%     501µs ± 5%   +1.86%  (p=0.026 n=12+13)
SetOperation/n=128/Go_Union-4                                  380µs ± 8%     393µs ±12%     ~     (p=0.085 n=13+14)
SetOperation/n=128/GEOS_Intersection-4                         120µs ± 3%     124µs ± 6%   +3.60%  (p=0.003 n=12+14)
SetOperation/n=128/GEOS_Difference-4                           148µs ±15%     147µs ±10%     ~     (p=0.720 n=14+13)
SetOperation/n=128/GEOS_SymmetricDifference-4                  287µs ±13%     286µs ± 5%     ~     (p=0.830 n=14+13)
SetOperation/n=128/GEOS_Union-4                                148µs ± 9%     153µs ±10%     ~     (p=0.201 n=13+15)
SetOperation/n=256/Go_Intersection-4                           629µs ±12%     635µs ±10%     ~     (p=0.302 n=14+13)
SetOperation/n=256/Go_Difference-4                             682µs ± 7%     763µs ±47%     ~     (p=0.077 n=12+13)
SetOperation/n=256/Go_SymmetricDifference-4                    951µs ± 8%    1057µs ±18%  +11.23%  (p=0.000 n=13+15)
SetOperation/n=256/Go_Union-4                                  710µs ± 9%     724µs ± 8%     ~     (p=0.110 n=13+12)
SetOperation/n=256/GEOS_Intersection-4                         192µs ± 7%     195µs ±14%     ~     (p=0.477 n=14+15)
SetOperation/n=256/GEOS_Difference-4                           239µs ± 6%     242µs ±11%     ~     (p=0.430 n=14+13)
SetOperation/n=256/GEOS_SymmetricDifference-4                  531µs ± 9%     550µs ±30%     ~     (p=0.830 n=13+14)
SetOperation/n=256/GEOS_Union-4                                269µs ±18%     259µs ± 7%     ~     (p=0.060 n=14+12)
SetOperation/n=512/Go_Intersection-4                          1.28ms ± 3%    1.29ms ± 8%     ~     (p=0.894 n=12+13)
SetOperation/n=512/Go_Difference-4                            1.37ms ± 5%    1.36ms ±15%     ~     (p=0.494 n=12+14)
SetOperation/n=512/Go_SymmetricDifference-4                   1.93ms ± 8%    1.86ms ± 9%     ~     (p=0.067 n=14+12)
SetOperation/n=512/Go_Union-4                                 1.47ms ±22%    1.50ms ±30%     ~     (p=0.430 n=14+13)
SetOperation/n=512/GEOS_Intersection-4                         338µs ± 8%     334µs ± 7%     ~     (p=0.720 n=13+14)
SetOperation/n=512/GEOS_Difference-4                           414µs ± 9%     409µs ± 9%     ~     (p=0.246 n=14+14)
SetOperation/n=512/GEOS_SymmetricDifference-4                  951µs ± 8%    1143µs ±59%     ~     (p=0.054 n=13+14)
SetOperation/n=512/GEOS_Union-4                                447µs ± 9%     454µs ±19%     ~     (p=0.689 n=13+12)
SetOperation/n=1024/Go_Intersection-4                         2.58ms ±19%    2.49ms ±10%     ~     (p=0.376 n=13+12)
SetOperation/n=1024/Go_Difference-4                           2.70ms ± 8%    3.01ms ±30%     ~     (p=0.300 n=12+15)
SetOperation/n=1024/Go_SymmetricDifference-4                  4.13ms ±20%    3.88ms ± 7%     ~     (p=0.300 n=15+12)
SetOperation/n=1024/Go_Union-4                                2.85ms ±13%    3.00ms ±19%     ~     (p=0.178 n=14+14)
SetOperation/n=1024/GEOS_Intersection-4                        613µs ± 7%     623µs ± 8%     ~     (p=0.525 n=15+13)
SetOperation/n=1024/GEOS_Difference-4                          918µs ±33%     842µs ±31%     ~     (p=0.202 n=14+13)
SetOperation/n=1024/GEOS_SymmetricDifference-4                1.96ms ± 9%    2.05ms ±19%     ~     (p=0.051 n=14+15)
SetOperation/n=1024/GEOS_Union-4                               959µs ±10%     942µs ±13%     ~     (p=0.616 n=14+13)
SetOperation/n=2048/Go_Intersection-4                         5.47ms ±19%    5.30ms ± 7%     ~     (p=0.511 n=13+13)
SetOperation/n=2048/Go_Difference-4                           5.93ms ±14%    5.70ms ± 7%     ~     (p=0.060 n=13+12)
SetOperation/n=2048/Go_SymmetricDifference-4                  8.52ms ±13%    8.17ms ±16%     ~     (p=0.128 n=14+13)
SetOperation/n=2048/Go_Union-4                                6.05ms ± 8%    6.06ms ±18%     ~     (p=0.603 n=14+14)
SetOperation/n=2048/GEOS_Intersection-4                       1.29ms ±13%    1.30ms ± 8%     ~     (p=0.350 n=14+13)
SetOperation/n=2048/GEOS_Difference-4                         1.58ms ± 7%    1.55ms ± 6%     ~     (p=0.378 n=12+12)
SetOperation/n=2048/GEOS_SymmetricDifference-4                3.74ms ± 7%    3.81ms ± 7%     ~     (p=0.270 n=12+13)
SetOperation/n=2048/GEOS_Union-4                              1.76ms ± 5%    1.80ms ± 8%     ~     (p=0.320 n=12+13)
SetOperation/n=4096/Go_Intersection-4                         12.0ms ±18%    13.0ms ±32%     ~     (p=0.088 n=13+15)
SetOperation/n=4096/Go_Difference-4                           13.4ms ±15%    13.8ms ±17%     ~     (p=0.306 n=14+14)
SetOperation/n=4096/Go_SymmetricDifference-4                  19.0ms ±14%    18.1ms ±16%   -4.51%  (p=0.048 n=14+13)
SetOperation/n=4096/Go_Union-4                                14.5ms ±30%    13.6ms ± 8%     ~     (p=0.425 n=15+14)
SetOperation/n=4096/GEOS_Intersection-4                       2.39ms ± 6%    2.38ms ±20%     ~     (p=0.185 n=14+13)
SetOperation/n=4096/GEOS_Difference-4                         3.30ms ± 9%    3.50ms ±29%     ~     (p=0.571 n=14+14)
SetOperation/n=4096/GEOS_SymmetricDifference-4                8.51ms ±16%    8.67ms ±14%     ~     (p=0.285 n=14+14)
SetOperation/n=4096/GEOS_Union-4                              3.72ms ± 5%    3.94ms ±23%     ~     (p=0.295 n=12+13)
SetOperation/n=8192/Go_Intersection-4                         30.5ms ±29%    25.9ms ± 5%  -14.91%  (p=0.002 n=15+12)
SetOperation/n=8192/Go_Difference-4                           28.5ms ±13%    27.6ms ± 6%     ~     (p=0.068 n=13+12)
SetOperation/n=8192/Go_SymmetricDifference-4                  37.3ms ± 9%    37.9ms ±19%     ~     (p=0.801 n=13+13)
SetOperation/n=8192/Go_Union-4                                30.1ms ±24%    29.2ms ±16%     ~     (p=0.603 n=14+14)
SetOperation/n=8192/GEOS_Intersection-4                       5.28ms ±20%    5.08ms ± 7%     ~     (p=0.331 n=15+14)
SetOperation/n=8192/GEOS_Difference-4                         7.00ms ±11%    6.61ms ± 5%   -5.64%  (p=0.023 n=14+12)
SetOperation/n=8192/GEOS_SymmetricDifference-4                17.7ms ± 4%    18.7ms ±13%   +5.87%  (p=0.004 n=12+14)
SetOperation/n=8192/GEOS_Union-4                              7.72ms ±11%    7.47ms ± 6%     ~     (p=0.156 n=15+13)
SetOperation/n=16384/Go_Intersection-4                        54.7ms ±19%    52.9ms ± 7%     ~     (p=0.511 n=14+14)
SetOperation/n=16384/Go_Difference-4                          57.8ms ±15%    56.2ms ±10%     ~     (p=0.511 n=13+13)
SetOperation/n=16384/Go_SymmetricDifference-4                 77.1ms ±10%    78.2ms ±11%     ~     (p=0.538 n=13+12)
SetOperation/n=16384/Go_Union-4                               62.1ms ±23%    58.5ms ± 7%     ~     (p=0.217 n=15+13)
SetOperation/n=16384/GEOS_Intersection-4                      11.2ms ±19%    10.9ms ±18%     ~     (p=0.505 n=15+14)
SetOperation/n=16384/GEOS_Difference-4                        15.2ms ±10%    15.2ms ±12%     ~     (p=0.724 n=13+13)
SetOperation/n=16384/GEOS_SymmetricDifference-4               35.7ms ± 5%    36.7ms ± 7%     ~     (p=0.128 n=13+14)
SetOperation/n=16384/GEOS_Union-4                             17.4ms ±12%    17.6ms ±15%     ~     (p=0.801 n=13+13)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                17.8µs ±15%    17.5µs ±10%     ~     (p=0.880 n=15+14)
Delete/n=1000-4                                                602µs ± 9%     602µs ± 9%     ~     (p=0.683 n=15+14)
Delete/n=10000-4                                              28.6ms ± 5%    28.7ms ± 6%     ~     (p=0.756 n=14+13)
Bulk/n=10-4                                                    707ns ±12%     713ns ±20%     ~     (p=0.667 n=14+14)
Bulk/n=100-4                                                  11.8µs ± 9%    12.2µs ±15%     ~     (p=0.151 n=14+13)
Bulk/n=1000-4                                                  233µs ±40%     210µs ± 7%     ~     (p=0.103 n=15+12)
Bulk/n=10000-4                                                2.97ms ±11%    2.99ms ±25%     ~     (p=0.427 n=14+14)
Bulk/n=100000-4                                               36.9ms ± 7%    36.3ms ± 3%     ~     (p=0.185 n=14+13)
Insert/n=10-4                                                 1.16µs ±43%    1.06µs ±13%     ~     (p=0.131 n=14+12)
Insert/n=100-4                                                18.2µs ±13%    18.7µs ±17%     ~     (p=0.793 n=13+14)
Insert/n=1000-4                                                384µs ± 4%     384µs ± 7%     ~     (p=0.560 n=12+14)
Insert/n=10000-4                                              4.59ms ± 5%    4.62ms ± 8%     ~     (p=0.804 n=14+14)
Insert/n=100000-4                                             54.3ms ± 3%    55.2ms ± 5%     ~     (p=0.220 n=14+13)
RangeSearch/n=10-4                                            12.3ns ± 3%    12.4ns ± 3%     ~     (p=0.290 n=14+14)
RangeSearch/n=100-4                                           53.6ns ± 2%    53.8ns ± 5%     ~     (p=0.919 n=14+14)
RangeSearch/n=1000-4                                           195ns ± 6%     196ns ± 8%     ~     (p=0.721 n=15+15)
RangeSearch/n=10000-4                                          680ns ± 6%     683ns ± 5%     ~     (p=0.533 n=14+14)
RangeSearch/n=100000-4                                        6.72µs ± 6%    6.85µs ± 5%     ~     (p=0.057 n=14+14)

name                                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/1-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/2-4                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/3-4                                               0.00B          0.00B          ~     (all equal)
MarshalWKB/polygon/n=10-4                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                   164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                 164kB ± 0%     164kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4                     2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                    205kB ± 0%     205kB ± 0%     ~     (p=0.310 n=15+15)
IntersectsLineStringWithLineString/n=10000-4                  2.63MB ± 0%    2.63MB ± 0%     ~     (p=0.299 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20-4                       324B ± 0%      324B ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-4                    3.07kB ± 0%    3.07kB ± 0%     ~     (p=0.715 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000-4                   49.3kB ± 0%    49.3kB ± 0%     ~     (p=0.301 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000-4                   339kB ± 0%     339kB ± 0%     ~     (p=0.372 n=15+15)
PolygonSingleRingValidation/n=10-4                            2.29kB ± 0%    2.29kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                           24.4kB ± 0%    24.4kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                           140kB ± 0%     140kB ± 0%     ~     (p=0.070 n=15+13)
PolygonSingleRingValidation/n=10000-4                         1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.957 n=15+14)
PolygonMultipleRingsValidation/n=4-4                          6.61kB ± 0%    6.61kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                         53.2kB ± 0%    53.2kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         597kB ± 0%     597kB ± 0%     ~     (p=0.110 n=15+15)
PolygonMultipleRingsValidation/n=4096-4                       6.28MB ± 0%    6.28MB ± 0%     ~     (p=0.093 n=14+15)
PolygonZigZagRingsValidation/n=10-4                           9.62kB ± 0%    9.62kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                          88.0kB ± 0%    88.0kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          551kB ± 0%     551kB ± 0%     ~     (p=0.393 n=15+14)
PolygonZigZagRingsValidation/n=10000-4                        7.24MB ± 0%    7.24MB ± 0%   +0.00%  (p=0.012 n=13+15)
PolygonAnnulusValidation/n=10-4                               4.10kB ± 0%    4.10kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                              28.4kB ± 0%    28.4kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              379kB ± 0%     379kB ± 0%     ~     (p=0.725 n=15+15)
PolygonAnnulusValidation/n=10000-4                            3.89MB ± 0%    3.89MB ± 0%     ~     (p=0.170 n=15+15)
MultipolygonValidation/n=1-4                                    481B ± 0%      481B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                                    980B ± 0%      980B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                                 4.16kB ± 0%    4.16kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                 17.0kB ± 0%    17.0kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                                67.8kB ± 0%    67.8kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                                271kB ± 0%     271kB ± 0%     ~     (p=0.198 n=15+15)
MultiPolygonTwoCircles/n=10-4                                 5.15kB ± 0%    5.15kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                                55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                                345kB ± 0%     345kB ± 0%     ~     (p=0.620 n=15+13)
MultiPolygonTwoCircles/n=10000-4                              4.60MB ± 0%    4.60MB ± 0%   +0.00%  (p=0.016 n=14+15)
MultiPolygonMultipleTouchingPoints/n=1-4                      4.16kB ± 0%    4.16kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4                     23.9kB ± 0%    23.9kB ± 0%     ~     (p=0.700 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-4                     182kB ± 0%     182kB ± 0%     ~     (p=0.095 n=15+13)
MultiPolygonMultipleTouchingPoints/n=1000-4                   2.16MB ± 0%    2.16MB ± 0%     ~     (p=0.201 n=13+15)
WKTParsing/point-4                                            1.89kB ± 0%    1.89kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4           40.7kB ± 0%    40.7kB ± 0%     ~     (p=0.084 n=14+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-4            40.7kB ± 0%    40.7kB ± 0%     ~     (p=0.070 n=13+15)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           369kB ± 0%     369kB ± 0%     ~     (p=0.876 n=13+14)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            369kB ± 0%     369kB ± 0%     ~     (p=0.517 n=14+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4     5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4      5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4    60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.802 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4     60.1kB ± 0%    60.1kB ± 0%     ~     (p=0.869 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=100-4                59.2kB ± 0%    59.2kB ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                491kB ± 0%     491kB ± 0%     ~     (p=0.325 n=15+15)
ForceCWandForceCCW/0-4                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/0#01-4                                       144B ± 0%      144B ± 0%     ~     (all equal)
ForceCWandForceCCW/1-4                                        38.4B ±275%      0.0B          ~     (p=0.084 n=15+14)
ForceCWandForceCCW/1#01-4                                      106B ±100%      144B ± 0%     ~     (p=0.115 n=15+14)
ForceCWandForceCCW/2-4                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/2#01-4                                       256B ± 0%      256B ± 0%     ~     (all equal)
ForceCWandForceCCW/3-4                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/3#01-4                                       256B ± 0%      256B ± 0%     ~     (all equal)
ForceCWandForceCCW/4-4                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/4#01-4                                       416B ± 0%      416B ± 0%     ~     (all equal)
ForceCWandForceCCW/5-4                                         111B ±275%        0B          ~     (p=0.084 n=15+14)
ForceCWandForceCCW/5#01-4                                      305B ±100%      416B ± 0%     ~     (p=0.115 n=15+14)
ForceCWandForceCCW/6-4                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/6#01-4                                       624B ± 0%      624B ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-4                          1.32kB ± 0%    1.32kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100-4                         6.46kB ± 0%    6.46kB ± 0%     ~     (p=0.070 n=15+13)
IntersectionWithoutValidation/n=1000-4                        55.1kB ± 0%    55.1kB ± 0%   +0.00%  (p=0.011 n=13+15)
IntersectionWithoutValidation/n=10000-4                        558kB ± 0%     558kB ± 0%     ~     (p=0.472 n=14+14)
NoOp/n=10-4                                                     952B ± 0%      952B ± 0%     ~     (all equal)
NoOp/n=100-4                                                  5.77kB ± 0%    5.77kB ± 0%     ~     (all equal)
NoOp/n=1000-4                                                 49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-4                                                 492kB ± 0%     492kB ± 0%     ~     (p=0.327 n=15+15)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-4                               1.87kB ± 0%    1.87kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100-4                              24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000-4                              139kB ± 0%     139kB ± 0%     ~     (p=1.000 n=15+15)
LineStringIsSimpleCircle/n=10000-4                            1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.057 n=15+14)
LineStringIsSimpleZigZag/10-4                                 1.84kB ± 0%    1.84kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                139kB ± 0%     139kB ± 0%     ~     (p=1.081 n=14+15)
LineStringIsSimpleZigZag/10000-4                              1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.478 n=15+15)
SetOperation/n=4/Go_Intersection-4                            20.3kB ± 0%    20.3kB ± 0%     ~     (p=0.558 n=15+15)
SetOperation/n=4/Go_Difference-4                              21.3kB ± 0%    21.3kB ± 0%     ~     (p=0.085 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-4                     29.3kB ± 0%    29.3kB ± 0%     ~     (p=0.596 n=14+15)
SetOperation/n=4/Go_Union-4                                   22.0kB ± 0%    22.0kB ± 0%     ~     (p=0.393 n=15+15)
SetOperation/n=4/GEOS_Intersection-4                          1.77kB ± 0%    1.77kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference-4                            2.78kB ± 0%    2.78kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-4                   10.8kB ± 0%    10.8kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Union-4                                 3.21kB ± 0%    3.21kB ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection-4                            27.0kB ± 0%    27.0kB ± 0%     ~     (p=0.814 n=15+15)
SetOperation/n=8/Go_Difference-4                              27.1kB ± 0%    27.1kB ± 0%     ~     (p=0.771 n=14+15)
SetOperation/n=8/Go_SymmetricDifference-4                     37.2kB ± 0%    37.2kB ± 0%   -0.01%  (p=0.002 n=14+14)
SetOperation/n=8/Go_Union-4                                   27.3kB ± 0%    27.3kB ± 0%     ~     (p=0.645 n=15+15)
SetOperation/n=8/GEOS_Intersection-4                          3.34kB ± 0%    3.34kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference-4                            3.50kB ± 0%    3.50kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-4                   13.3kB ± 0%    13.3kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Union-4                                 3.62kB ± 0%    3.62kB ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection-4                           37.3kB ± 0%    37.3kB ± 0%     ~     (p=0.510 n=15+14)
SetOperation/n=16/Go_Difference-4                             40.4kB ± 0%    40.4kB ± 0%     ~     (p=0.429 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-4                    59.5kB ± 0%    59.5kB ± 0%     ~     (p=0.927 n=15+15)
SetOperation/n=16/Go_Union-4                                  41.9kB ± 0%    41.9kB ± 0%     ~     (p=0.798 n=15+15)
SetOperation/n=16/GEOS_Intersection-4                         3.88kB ± 0%    3.88kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference-4                           6.68kB ± 0%    6.68kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-4                  25.3kB ± 0%    25.3kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Union-4                                8.28kB ± 0%    8.28kB ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection-4                           67.8kB ± 0%    67.8kB ± 0%     ~     (p=0.441 n=15+15)
SetOperation/n=32/Go_Difference-4                             70.4kB ± 0%    70.4kB ± 0%     ~     (p=0.309 n=15+15)
SetOperation/n=32/Go_SymmetricDifference-4                     100kB ± 0%     100kB ± 0%     ~     (p=0.383 n=15+15)
SetOperation/n=32/Go_Union-4                                  70.9kB ± 0%    70.9kB ± 0%   -0.01%  (p=0.004 n=14+14)
SetOperation/n=32/GEOS_Intersection-4                         8.86kB ± 0%    8.86kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference-4                           10.7kB ± 0%    10.7kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-4                  39.9kB ± 0%    39.9kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Union-4                                11.5kB ± 0%    11.5kB ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection-4                            113kB ± 0%     113kB ± 0%     ~     (p=0.959 n=15+15)
SetOperation/n=64/Go_Difference-4                              125kB ± 0%     125kB ± 0%     ~     (p=0.751 n=15+15)
SetOperation/n=64/Go_SymmetricDifference-4                     191kB ± 0%     191kB ± 0%     ~     (p=0.394 n=15+15)
SetOperation/n=64/Go_Union-4                                   129kB ± 0%     129kB ± 0%     ~     (p=0.079 n=15+15)
SetOperation/n=64/GEOS_Intersection-4                         12.6kB ± 0%    12.6kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference-4                           23.5kB ± 0%    23.5kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-4                  87.5kB ± 0%    87.5kB ± 0%     ~     (p=0.363 n=15+14)
SetOperation/n=64/GEOS_Union-4                                28.0kB ± 0%    28.0kB ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection-4                           230kB ± 0%     230kB ± 0%   -0.01%  (p=0.005 n=15+15)
SetOperation/n=128/Go_Difference-4                             242kB ± 0%     242kB ± 0%     ~     (p=0.690 n=15+15)
SetOperation/n=128/Go_SymmetricDifference-4                    353kB ± 0%     353kB ± 0%     ~     (p=0.079 n=14+15)
SetOperation/n=128/Go_Union-4                                  244kB ± 0%     244kB ± 0%     ~     (p=0.830 n=15+15)
SetOperation/n=128/GEOS_Intersection-4                        30.3kB ± 0%    30.3kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference-4                          40.0kB ± 0%    40.0kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-4                  147kB ± 0%     147kB ± 0%     ~     (p=0.236 n=15+15)
SetOperation/n=128/GEOS_Union-4                               43.1kB ± 0%    43.1kB ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection-4                           409kB ± 0%     409kB ± 0%     ~     (p=0.959 n=15+15)
SetOperation/n=256/Go_Difference-4                             456kB ± 0%     456kB ± 0%     ~     (p=0.446 n=13+15)
SetOperation/n=256/Go_SymmetricDifference-4                    710kB ± 0%     710kB ± 0%     ~     (p=0.432 n=15+14)
SetOperation/n=256/Go_Union-4                                  467kB ± 0%     467kB ± 0%     ~     (p=0.798 n=15+15)
SetOperation/n=256/GEOS_Intersection-4                        48.2kB ± 0%    48.2kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference-4                          92.6kB ± 0%    92.6kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-4                  341kB ± 0%     341kB ± 0%     ~     (p=0.187 n=15+15)
SetOperation/n=256/GEOS_Union-4                                106kB ± 0%     106kB ± 0%   +0.00%  (p=0.050 n=14+15)
SetOperation/n=512/Go_Intersection-4                           848kB ± 0%     848kB ± 0%     ~     (p=0.910 n=15+15)
SetOperation/n=512/Go_Difference-4                             896kB ± 0%     896kB ± 0%     ~     (p=0.054 n=12+15)
SetOperation/n=512/Go_SymmetricDifference-4                   1.32MB ± 0%    1.32MB ± 0%     ~     (p=0.721 n=15+15)
SetOperation/n=512/Go_Union-4                                  917kB ± 0%     917kB ± 0%     ~     (p=0.079 n=14+15)
SetOperation/n=512/GEOS_Intersection-4                         115kB ± 0%     115kB ± 0%     ~     (p=0.070 n=15+13)
SetOperation/n=512/GEOS_Difference-4                           159kB ± 0%     159kB ± 0%     ~     (p=0.133 n=13+15)
SetOperation/n=512/GEOS_SymmetricDifference-4                  577kB ± 0%     577kB ± 0%     ~     (p=0.765 n=15+15)
SetOperation/n=512/GEOS_Union-4                                171kB ± 0%     171kB ± 0%   -0.00%  (p=0.020 n=15+12)
SetOperation/n=1024/Go_Intersection-4                         1.59MB ± 0%    1.59MB ± 0%     ~     (p=0.455 n=15+15)
SetOperation/n=1024/Go_Difference-4                           1.78MB ± 0%    1.78MB ± 0%     ~     (p=0.493 n=15+15)
SetOperation/n=1024/Go_SymmetricDifference-4                  2.81MB ± 0%    2.81MB ± 0%     ~     (p=0.747 n=15+14)
SetOperation/n=1024/Go_Union-4                                1.84MB ± 0%    1.84MB ± 0%     ~     (p=0.372 n=15+15)
SetOperation/n=1024/GEOS_Intersection-4                        189kB ± 0%     189kB ± 0%   -0.00%  (p=0.034 n=15+14)
SetOperation/n=1024/GEOS_Difference-4                          369kB ± 0%     369kB ± 0%   +0.00%  (p=0.000 n=12+15)
SetOperation/n=1024/GEOS_SymmetricDifference-4                1.38MB ± 0%    1.38MB ± 0%     ~     (p=0.131 n=15+15)
SetOperation/n=1024/GEOS_Union-4                               415kB ± 0%     415kB ± 0%     ~     (p=0.051 n=13+15)
SetOperation/n=2048/Go_Intersection-4                         3.49MB ± 0%    3.49MB ± 0%     ~     (p=0.395 n=15+15)
SetOperation/n=2048/Go_Difference-4                           3.68MB ± 0%    3.68MB ± 0%     ~     (p=0.690 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference-4                  5.41MB ± 0%    5.41MB ± 0%     ~     (p=0.871 n=14+15)
SetOperation/n=2048/Go_Union-4                                3.76MB ± 0%    3.76MB ± 0%     ~     (p=0.376 n=14+14)
SetOperation/n=2048/GEOS_Intersection-4                        460kB ± 0%     460kB ± 0%     ~     (p=0.990 n=15+15)
SetOperation/n=2048/GEOS_Difference-4                          648kB ± 0%     648kB ± 0%     ~     (p=0.570 n=15+15)
SetOperation/n=2048/GEOS_SymmetricDifference-4                2.32MB ± 0%    2.32MB ± 0%     ~     (p=0.926 n=15+15)
SetOperation/n=2048/GEOS_Union-4                               689kB ± 0%     689kB ± 0%     ~     (p=0.586 n=15+15)
SetOperation/n=4096/Go_Intersection-4                         6.68MB ± 0%    6.68MB ± 0%     ~     (p=0.736 n=15+15)
SetOperation/n=4096/Go_Difference-4                           7.40MB ± 0%    7.40MB ± 0%     ~     (p=0.241 n=15+12)
SetOperation/n=4096/Go_SymmetricDifference-4                  11.4MB ± 0%    11.4MB ± 0%     ~     (p=0.720 n=15+15)
SetOperation/n=4096/Go_Union-4                                7.64MB ± 0%    7.64MB ± 0%     ~     (p=0.272 n=15+15)
SetOperation/n=4096/GEOS_Intersection-4                        755kB ± 0%     755kB ± 0%     ~     (p=0.658 n=15+15)
SetOperation/n=4096/GEOS_Difference-4                         1.45MB ± 0%    1.45MB ± 0%     ~     (p=0.820 n=15+14)
SetOperation/n=4096/GEOS_SymmetricDifference-4                5.34MB ± 0%    5.34MB ± 0%     ~     (p=0.189 n=15+15)
SetOperation/n=4096/GEOS_Union-4                              1.63MB ± 0%    1.63MB ± 0%     ~     (p=0.195 n=15+14)
SetOperation/n=8192/Go_Intersection-4                         14.3MB ± 0%    14.3MB ± 0%     ~     (p=0.118 n=15+15)
SetOperation/n=8192/Go_Difference-4                           15.2MB ± 0%    15.2MB ± 0%     ~     (p=0.690 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-4                  22.1MB ± 0%    22.1MB ± 0%   +0.00%  (p=0.023 n=15+14)
SetOperation/n=8192/Go_Union-4                                15.5MB ± 0%    15.5MB ± 0%     ~     (p=0.798 n=15+15)
SetOperation/n=8192/GEOS_Intersection-4                       1.76MB ± 0%    1.76MB ± 0%     ~     (p=0.401 n=15+15)
SetOperation/n=8192/GEOS_Difference-4                         2.47MB ± 0%    2.47MB ± 0%     ~     (p=0.909 n=15+15)
SetOperation/n=8192/GEOS_SymmetricDifference-4                9.01MB ± 0%    9.01MB ± 0%     ~     (p=0.817 n=15+14)
SetOperation/n=8192/GEOS_Union-4                              2.66MB ± 0%    2.66MB ± 0%     ~     (p=0.195 n=15+15)
SetOperation/n=16384/Go_Intersection-4                        26.5MB ± 0%    26.5MB ± 0%     ~     (p=0.674 n=15+15)
SetOperation/n=16384/Go_Difference-4                          29.4MB ± 0%    29.4MB ± 0%     ~     (p=0.329 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-4                 45.4MB ± 0%    45.4MB ± 0%     ~     (p=0.689 n=15+15)
SetOperation/n=16384/Go_Union-4                               30.3MB ± 0%    30.3MB ± 0%     ~     (p=0.190 n=15+15)
SetOperation/n=16384/GEOS_Intersection-4                      2.92MB ± 0%    2.92MB ± 0%     ~     (p=0.320 n=15+14)
SetOperation/n=16384/GEOS_Difference-4                        5.68MB ± 0%    5.68MB ± 0%     ~     (p=0.950 n=15+13)
SetOperation/n=16384/GEOS_SymmetricDifference-4               21.1MB ± 0%    21.1MB ± 0%     ~     (p=0.480 n=15+15)
SetOperation/n=16384/GEOS_Union-4                             6.45MB ± 0%    6.45MB ± 0%     ~     (p=0.716 n=15+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-4                                               26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-4                                               412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10-4                                                   1.46kB ± 0%    1.46kB ± 0%     ~     (all equal)
Bulk/n=100-4                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-4                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (all equal)
Bulk/n=10000-4                                                1.57MB ± 0%    1.57MB ± 0%     ~     (p=0.728 n=14+13)
Bulk/n=100000-4                                               20.4MB ± 0%    20.4MB ± 0%     ~     (p=0.996 n=15+15)
Insert/n=10-4                                                 1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-4                                                13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-4                                                132kB ± 0%     132kB ± 0%     ~     (all equal)
Insert/n=10000-4                                              1.34MB ± 0%    1.34MB ± 0%     ~     (p=0.619 n=14+15)
Insert/n=100000-4                                             13.5MB ± 0%    13.5MB ± 0%     ~     (p=1.000 n=15+15)
RangeSearch/n=10-4                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-4                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-4                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-4                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-4                                         0.00B          0.00B          ~     (all equal)

name                                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:amd64
LineEnvelope/0-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/1-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/2-4                                                0.00           0.00          ~     (all equal)
LineEnvelope/3-4                                                0.00           0.00          ~     (all equal)
MarshalWKB/polygon/n=10-4                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-4                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-4                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-4                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-4                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-4                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-4                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-4                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-4                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-4                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-4                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-4                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-4                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-4                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-4                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-4                              12.0 ± 0%      12.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-4                             76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-4                             348 ± 0%       348 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-4                          5.47k ± 0%     5.47k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-4                            42.0 ± 0%      42.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-4                            316 ± 0%       316 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-4                         3.48k ± 0%     3.48k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-4                        36.2k ± 0%     36.2k ± 0%   +0.00%  (p=0.004 n=13+15)
PolygonZigZagRingsValidation/n=10-4                             41.0 ± 0%      41.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-4                             233 ± 0%       233 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-4                          1.05k ± 0%     1.05k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-4                         16.4k ± 0%     16.4k ± 0%     ~     (p=0.156 n=12+15)
PolygonAnnulusValidation/n=10-4                                 22.0 ± 0%      22.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-4                                76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-4                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000-4                             10.3k ± 0%     10.3k ± 0%     ~     (all equal)
MultipolygonValidation/n=1-4                                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-4                                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-4                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-4                                   91.0 ± 0%      91.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-4                                   347 ± 0%       347 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-4                                1.37k ± 0%     1.37k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-4                                   29.0 ± 0%      29.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-4                                   157 ± 0%       157 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-4                                  701 ± 0%       701 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-4                               10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-4                        51.0 ± 0%      51.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-4                        298 ± 0%       298 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-4                     2.62k ± 0%     2.62k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1000-4                    26.7k ± 0%     26.7k ± 0%     ~     (p=0.206 n=13+15)
WKTParsing/point-4                                              22.0 ± 0%      22.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-4              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-4               234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-4           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-4            2.10k ± 0%     2.10k ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-4       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-4        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-4      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-4       77.0 ± 0%      77.0 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-4                   371 ± 0%       371 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-4                3.34k ± 0%     3.34k ± 0%     ~     (all equal)
ForceCWandForceCCW/0-4                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/0#01-4                                       3.00 ± 0%      3.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/1-4                                         0.80 ±275%      0.00          ~     (p=0.084 n=15+14)
ForceCWandForceCCW/1#01-4                                      2.20 ±100%      3.00 ± 0%     ~     (p=0.115 n=15+14)
ForceCWandForceCCW/2-4                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/2#01-4                                       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/3-4                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/3#01-4                                       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/4-4                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/4#01-4                                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/5-4                                         1.87 ±275%      0.00          ~     (p=0.084 n=15+14)
ForceCWandForceCCW/5#01-4                                      5.13 ±100%      7.00 ± 0%     ~     (p=0.115 n=15+14)
ForceCWandForceCCW/6-4                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/6#01-4                                       12.0 ± 0%      12.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:amd64
IntersectionWithoutValidation/n=10-4                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100-4                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=1000-4                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=10000-4                         48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10-4                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100-4                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000-4                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000-4                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:amd64
LineStringIsSimpleCircle/n=10-4                                 7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100-4                                71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000-4                                343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000-4                             5.46k ± 0%     5.46k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-4                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-4                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-4                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-4                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
SetOperation/n=4/Go_Intersection-4                               272 ± 0%       272 ± 0%     ~     (all equal)
SetOperation/n=4/Go_Difference-4                                 276 ± 0%       276 ± 0%     ~     (all equal)
SetOperation/n=4/Go_SymmetricDifference-4                        374 ± 0%       374 ± 0%     ~     (all equal)
SetOperation/n=4/Go_Union-4                                      283 ± 0%       283 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Intersection-4                            52.0 ± 0%      52.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference-4                              55.0 ± 0%      55.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-4                      148 ± 0%       148 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Union-4                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection-4                               288 ± 0%       288 ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8/Go_Difference-4                                 289 ± 0%       289 ± 0%   -0.14%  (p=0.009 n=15+13)
SetOperation/n=8/Go_SymmetricDifference-4                        393 ± 0%       393 ± 0%   -0.10%  (p=0.006 n=15+12)
SetOperation/n=8/Go_Union-4                                      294 ± 0%       294 ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8/GEOS_Intersection-4                            56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference-4                              56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-4                      152 ± 0%       152 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Union-4                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection-4                              302 ± 0%       302 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Difference-4                                312 ± 0%       312 ± 0%     ~     (all equal)
SetOperation/n=16/Go_SymmetricDifference-4                       441 ± 0%       441 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Union-4                                     321 ± 0%       321 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Intersection-4                           56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference-4                             64.0 ± 0%      64.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-4                     185 ± 0%       185 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Union-4                                  68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection-4                              353 ± 0%       353 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Difference-4                                359 ± 0%       359 ± 0%     ~     (all equal)
SetOperation/n=32/Go_SymmetricDifference-4                       512 ± 0%       512 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Union-4                                     364 ± 0%       364 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Intersection-4                           68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference-4                             72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-4                     216 ± 0%       216 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Union-4                                  72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection-4                              394 ± 0%       394 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Difference-4                                428 ± 0%       428 ± 0%     ~     (p=0.070 n=15+13)
SetOperation/n=64/Go_SymmetricDifference-4                       679 ± 0%       679 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Union-4                                     441 ± 0%       441 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Intersection-4                           72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference-4                              104 ± 0%       104 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-4                     345 ± 0%       345 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Union-4                                   112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection-4                             568 ± 0%       568 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Difference-4                               594 ± 0%       594 ± 0%     ~     (all equal)
SetOperation/n=128/Go_SymmetricDifference-4                      942 ± 0%       942 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Union-4                                    599 ± 0%       599 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Intersection-4                           112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference-4                             136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-4                    473 ± 0%       473 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Union-4                                  136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection-4                             727 ± 0%       727 ± 0%     ~     (all equal)
SetOperation/n=256/Go_Difference-4                               857 ± 0%       857 ± 0%     ~     (all equal)
SetOperation/n=256/Go_SymmetricDifference-4                    1.59k ± 0%     1.59k ± 0%     ~     (all equal)
SetOperation/n=256/Go_Union-4                                    886 ± 0%       886 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Intersection-4                           136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference-4                             264 ± 0%       264 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-4                    985 ± 0%       985 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Union-4                                  288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/Go_Intersection-4                           1.40k ± 0%     1.40k ± 0%     ~     (p=0.156 n=12+15)
SetOperation/n=512/Go_Difference-4                             1.50k ± 0%     1.50k ± 0%   -0.02%  (p=0.026 n=15+13)
SetOperation/n=512/Go_SymmetricDifference-4                    2.62k ± 0%     2.62k ± 0%     ~     (p=0.450 n=15+15)
SetOperation/n=512/Go_Union-4                                  1.51k ± 0%     1.51k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=512/GEOS_Intersection-4                           288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Difference-4                             392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-4                  1.50k ± 0%     1.50k ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Union-4                                  392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Intersection-4                          2.02k ± 0%     2.02k ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Difference-4                            2.54k ± 0%     2.54k ± 0%     ~     (all equal)
SetOperation/n=1024/Go_SymmetricDifference-4                   5.19k ± 0%     5.19k ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Union-4                                 2.63k ± 0%     2.63k ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Intersection-4                          392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Difference-4                            904 ± 0%       904 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-4                 3.54k ± 0%     3.54k ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Union-4                                 992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Intersection-4                          4.68k ± 0%     4.68k ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Difference-4                            5.11k ± 0%     5.11k ± 0%     ~     (all equal)
SetOperation/n=2048/Go_SymmetricDifference-4                   9.30k ± 0%     9.30k ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Union-4                                 5.11k ± 0%     5.11k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Intersection-4                          992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Difference-4                          1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-4                 5.59k ± 0%     5.59k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Union-4                               1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/Go_Intersection-4                          7.17k ± 0%     7.17k ± 0%   +0.01%  (p=0.017 n=15+15)
SetOperation/n=4096/Go_Difference-4                            9.21k ± 0%     9.22k ± 0%     ~     (p=0.133 n=13+15)
SetOperation/n=4096/Go_SymmetricDifference-4                   19.6k ± 0%     19.6k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=4096/Go_Union-4                                 9.57k ± 0%     9.57k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=4096/GEOS_Intersection-4                        1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Difference-4                          3.46k ± 0%     3.46k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-4                 13.8k ± 0%     13.8k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Union-4                               3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/Go_Intersection-4                          17.8k ± 0%     17.8k ± 0%     ~     (p=0.379 n=15+15)
SetOperation/n=8192/Go_Difference-4                            19.5k ± 0%     19.5k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-4                   36.0k ± 0%     36.0k ± 0%     ~     (p=0.398 n=15+11)
SetOperation/n=8192/Go_Union-4                                 19.5k ± 0%     19.5k ± 0%     ~     (p=1.000 n=15+15)
SetOperation/n=8192/GEOS_Intersection-4                        3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Difference-4                          5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-4                 22.0k ± 0%     22.0k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Union-4                               5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/Go_Intersection-4                         27.7k ± 0%     27.7k ± 0%     ~     (p=0.099 n=14+11)
SetOperation/n=16384/Go_Difference-4                           35.9k ± 0%     35.9k ± 0%     ~     (p=0.133 n=13+15)
SetOperation/n=16384/Go_SymmetricDifference-4                  76.9k ± 0%     76.9k ± 0%     ~     (p=0.519 n=15+15)
SetOperation/n=16384/Go_Union-4                                37.2k ± 0%     37.2k ± 0%     ~     (p=0.580 n=15+15)
SetOperation/n=16384/GEOS_Intersection-4                       5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Difference-4                         13.7k ± 0%     13.7k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-4                54.7k ± 0%     54.7k ± 0%     ~     (p=0.700 n=15+15)
SetOperation/n=16384/GEOS_Union-4                              15.1k ± 0%     15.1k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:amd64
Delete/n=100-4                                                  65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-4                                                  480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-4                                               7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-4                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-4                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-4                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-4                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-4                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-4                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-4                                                  47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-4                                                  457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-4                                               4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-4                                              46.8k ± 0%     46.8k ± 0%     ~     (all equal)
RangeSearch/n=10-4                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100-4                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000-4                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000-4                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000-4                                          0.00           0.00          ~     (all equal)
```

</details>