### PR TITLE
Fix OmitInvalid bug for LineString and Polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fix a bug where the original coordinates type was not retained when using the
+  `OmitInvalid` constructor option on invalid `LineString`s and `Polygon`s.
+
 ## v0.39.0
 
 2022-06-10

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -39,7 +39,7 @@ func NewLineString(seq Sequence, opts ...ConstructorOption) (LineString, error) 
 
 func newLineStringWithOmitInvalid(seq Sequence) LineString {
 	if err := validateLineStringSeq(seq); err != nil {
-		return LineString{}
+		return LineString{}.ForceCoordinatesType(seq.CoordinatesType())
 	}
 	return LineString{seq}
 }

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -51,7 +51,7 @@ func NewPolygon(rings []LineString, opts ...ConstructorOption) (Polygon, error) 
 	ctorOpts := newOptionSet(opts)
 	if err := validatePolygon(rings, ctorOpts); err != nil {
 		if ctorOpts.omitInvalid {
-			return Polygon{}, nil
+			return Polygon{}.ForceCoordinatesType(ctype), nil
 		}
 		return Polygon{}, err
 	}

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -2,27 +2,26 @@ package geom_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"math"
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
 )
 
-func geomFromWKT(t testing.TB, wkt string) Geometry {
+func geomFromWKT(t testing.TB, wkt string, opts ...ConstructorOption) Geometry {
 	t.Helper()
-	geom, err := UnmarshalWKT(wkt)
+	geom, err := UnmarshalWKT(wkt, opts...)
 	if err != nil {
 		t.Fatalf("could not unmarshal WKT:\n  wkt: %s\n  err: %v", wkt, err)
 	}
 	return geom
 }
 
-func geomsFromWKTs(t testing.TB, wkts []string) []Geometry {
+func geomsFromWKTs(t testing.TB, wkts []string, opts ...ConstructorOption) []Geometry {
 	t.Helper()
 	var gs []Geometry
 	for _, wkt := range wkts {
-		g, err := UnmarshalWKT(wkt)
+		g, err := UnmarshalWKT(wkt, opts...)
 		if err != nil {
 			t.Fatalf("could not unmarshal WKT:\n  wkt: %s\n  err: %v", wkt, err)
 		}
@@ -31,10 +30,10 @@ func geomsFromWKTs(t testing.TB, wkts []string) []Geometry {
 	return gs
 }
 
-func geomFromGeoJSON(t testing.TB, geojson string) Geometry {
+func geomFromGeoJSON(t testing.TB, geojson string, opts ...ConstructorOption) Geometry {
 	t.Helper()
-	var g Geometry
-	if err := json.Unmarshal([]byte(geojson), &g); err != nil {
+	g, err := UnmarshalGeoJSON([]byte(geojson), opts...)
+	if err != nil {
 		t.Fatalf("could not unmarshal GeoJSON:\n geojson: %s\n     err: %v", geojson, err)
 	}
 	return g


### PR DESCRIPTION
## Description

The bug occurred when an invalid LineString or Polygon was constructed using the OmitInvalid constructor option. It resulted in the Polygon or LineString correctly being replaced with an EMPTY variant, however the coordinates type was always set to DimXY.

The bugfix sets the coordinates type to match the input in the omit invalid case.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/432

## Benchmark Results

N/A