### PR TITLE
Implement TransformXY method for Envelope type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Improves the performance of WKB parsing.
 
+- Add a `TransformXY` method to the `Envelope` type.
+
 ## v0.39.0
 
 2022-06-10

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -278,6 +278,15 @@ func (e Envelope) Distance(o Envelope) (float64, bool) {
 	return math.Sqrt(dx*dx + dy*dy), true
 }
 
+// TransformXY transforms this Envelope into another Envelope according to fn.
+func (e Envelope) TransformXY(fn func(XY) XY) (Envelope, error) {
+	min, max, ok := e.MinMaxXYs()
+	if !ok {
+		return Envelope{}, nil
+	}
+	return NewEnvelope([]XY{fn(min), fn(max)})
+}
+
 func (e Envelope) box() (rtree.Box, bool) {
 	return rtree.Box{
 		MinX: e.minX(),

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -551,3 +551,34 @@ func TestEnvelopeDistance(t *testing.T) {
 		}
 	})
 }
+
+func TestEnvelopeTransformXY(t *testing.T) {
+	transform := func(in XY) XY {
+		return XY{in.X * 1.5, in.Y * 2.5}
+	}
+	for i, tc := range []struct {
+		input Envelope
+		want  Envelope
+	}{
+		{Envelope{}, Envelope{}},
+		{onePtEnv(1, 2), onePtEnv(1.5, 5)},
+		{twoPtEnv(1, 2, 3, 4), twoPtEnv(1.5, 5, 4.5, 10)},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got, err := tc.input.TransformXY(transform)
+			expectNoErr(t, err)
+			expectEnvEq(t, got, tc.want)
+		})
+	}
+}
+
+func BenchmarkEnvelopeTransformXY(b *testing.B) {
+	input := twoPtEnv(1, 2, 3, 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := input.TransformXY(func(in XY) XY {
+			return XY{in.X * 1.5, in.Y * 2.5}
+		})
+		expectNoErr(b, err)
+	}
+}


### PR DESCRIPTION
## Description

commit dae405ccad01d406322dfeaf5574fad7be75a6c6
Author: Peter Stace <peterstace@gmail.com>
Date:   Sun Sep 25 18:02:35 2022 +1000

    Implement TransformXY method for Envelope type
    
    All regular other geometry types have a TransformXY method, so it's
    reasonable for Envelope to have one as well.
    
    The benchmark test is to confirm sure that the implementation of
    TransformXY doesn't allocate memory, even though it uses a slice of XYs
    internally.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/459

## Benchmark Results

```
$ go test ./geom -run=^\$ -bench=EnvelopeTrans -benchmem
goos: linux
goarch: arm64
pkg: github.com/peterstace/simplefeatures/geom
BenchmarkEnvelopeTransformXY-2           8729284               137.2 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/peterstace/simplefeatures/geom       1.341s
```