### PR TITLE
Use Sequence instead of []XY for DCEL edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use `Sequence` instead of `[]XY` for DCEL edges.
+
 ## v0.40.0
 
 2022-09-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use `Sequence` instead of `[]XY` for DCEL edges.
+
 ## v0.40.1
 
 2022-11-08
@@ -7,8 +11,6 @@
 __Special thanks to @missinglink for contributing to this release.__
 
 - Add benchmarks for WKB parsing.
-
-- Use `Sequence` instead of `[]XY` for DCEL edges.
 
 ## v0.40.0
 

--- a/geom/dcel_edge_set.go
+++ b/geom/dcel_edge_set.go
@@ -3,37 +3,32 @@ package geom
 // edgeSet represents a set of edges in a DCEL. It makes use of assumptions
 // around proper noding in conjunction with interaction points.
 //
-// Implementation detail: the map key is 3 XYs. The first is the start point of
-// the edge, the second is the first intermediate point (or a repeat of the
-// first XY if there are no intermediate points), and the third is the start
-// point of the next edge.
-type edgeSet map[[3]XY]*halfEdgeRecord
+// Implementation detail: the map key is 2 XYs. The first is the start point of
+// the edge, the second is the second point of the edge (which may or may not
+// be the final point of the edge).
+type edgeSet map[[2]XY]*halfEdgeRecord
 
-func (s edgeSet) containsStartIntermediateEnd(start XY, intermediate []XY, end XY) bool {
-	_, ok := s[s.key(start, intermediate, end)]
+func (s edgeSet) containsStartIntermediateEnd(segment Sequence) bool {
+	_, ok := s[s.key(segment)]
 	return ok
 }
 
 func (s edgeSet) insertEdge(e *halfEdgeRecord) {
-	k := s.key(e.origin.coords, e.intermediate, e.next.origin.coords)
+	k := s.key(e.seq)
 	s[k] = e
 }
 
-func (s edgeSet) insertStartIntermediateEnd(start XY, intermediate []XY, end XY) {
-	k := s.key(start, intermediate, end)
+func (s edgeSet) insertStartIntermediateEnd(segment Sequence) {
+	k := s.key(segment)
 	s[k] = nil // TODO: this is a bit weird...
 }
 
 func (s edgeSet) lookupEdge(e *halfEdgeRecord) (*halfEdgeRecord, bool) {
-	k := s.key(e.origin.coords, e.intermediate, e.next.origin.coords)
+	k := s.key(e.seq)
 	e, ok := s[k]
 	return e, ok
 }
 
-func (edgeSet) key(start XY, intermediate []XY, end XY) [3]XY {
-	key := [3]XY{start, start, end}
-	if len(intermediate) > 0 {
-		key[1] = intermediate[0]
-	}
-	return key
+func (edgeSet) key(segment Sequence) [2]XY {
+	return [2]XY{segment.GetXY(0), segment.GetXY(1)}
 }

--- a/geom/dcel_extract.go
+++ b/geom/dcel_extract.go
@@ -112,9 +112,8 @@ func extractPolygonBoundary(faceSet map[*faceRecord]bool, start *halfEdgeRecord,
 	e := start
 	for {
 		seen[e] = true
-		xy := e.origin.coords
-		coords = append(coords, xy.X, xy.Y)
-		for _, xy := range e.intermediate {
+		for i := 0; i < e.seq.Length()-1; i++ {
+			xy := e.seq.GetXY(i)
 			coords = append(coords, xy.X, xy.Y)
 		}
 
@@ -187,18 +186,7 @@ func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]label) bool
 			e.origin.extracted = true
 			e.twin.origin.extracted = true
 
-			coords := make([]float64, 4+2*len(e.intermediate))
-			coords[0] = e.origin.coords.X
-			coords[1] = e.origin.coords.Y
-			for i, xy := range e.intermediate {
-				coords[2+2*i] = xy.X
-				coords[3+2*i] = xy.Y
-			}
-			coords[len(coords)-2] = e.twin.origin.coords.X
-			coords[len(coords)-1] = e.twin.origin.coords.Y
-
-			seq := NewSequence(coords, DimXY)
-			ls, err := NewLineString(seq)
+			ls, err := NewLineString(e.seq)
 			if err != nil {
 				return nil, err
 			}

--- a/geom/dcel_overlay.go
+++ b/geom/dcel_overlay.go
@@ -92,8 +92,8 @@ func (d *doublyConnectedEdgeList) fixVertex(v *vertexRecord) {
 		sort.Slice(v.incidents, func(i, j int) bool {
 			ei := v.incidents[i]
 			ej := v.incidents[j]
-			di := ei.secondXY().Sub(ei.origin.coords)
-			dj := ej.secondXY().Sub(ej.origin.coords)
+			di := ei.seq.GetXY(1).Sub(ei.seq.GetXY(0))
+			dj := ej.seq.GetXY(1).Sub(ej.seq.GetXY(0))
 			aI := math.Atan2(di.Y, di.X)
 			aJ := math.Atan2(dj.Y, dj.X)
 			return aI < aJ

--- a/geom/dcel_test.go
+++ b/geom/dcel_test.go
@@ -143,7 +143,7 @@ func CheckDCEL(t *testing.T, dcel *doublyConnectedEdgeList, spec DCELSpec) {
 				if seq[len(seq)-1] != e.next.origin.coords {
 					continue
 				}
-				if !xysEqual(e.intermediate, seq[1:len(seq)-1]) {
+				if !xysEqual(sequenceToXYs(e.seq), seq) {
 					continue
 				}
 				want = spec.Edges[i]
@@ -181,7 +181,7 @@ func xysEqual(a, b []XY) bool {
 
 func findEdge(t *testing.T, dcel *doublyConnectedEdgeList, first, second XY) *halfEdgeRecord {
 	for _, e := range dcel.halfEdges {
-		if e.origin.coords == first && e.secondXY() == second {
+		if e.seq.GetXY(0) == first && e.seq.GetXY(1) == second {
 			return e
 		}
 	}
@@ -202,8 +202,7 @@ func CheckCycle(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []XY) {
 		if e.origin == nil {
 			t.Errorf("edge origin not set")
 		}
-		got = append(got, e.origin.coords)
-		got = append(got, e.intermediate...)
+		got = append(got, sequenceToXYs(e.seq)[:e.seq.Length()-1]...)
 		e = e.next
 		if e == start {
 			got = append(got, e.origin.coords)
@@ -227,10 +226,7 @@ func CheckCycle(t *testing.T, f *faceRecord, start *halfEdgeRecord, want []XY) {
 			t.Fatal("inf loop")
 		}
 
-		got = append(got, e.next.origin.coords)
-		for j := len(e.intermediate) - 1; j >= 0; j-- {
-			got = append(got, e.intermediate[j])
-		}
+		got = append(got, sequenceToXYs(reverseSequence(e.seq))[:e.seq.Length()-1]...)
 
 		e = e.prev
 		if e == start {

--- a/geom/util.go
+++ b/geom/util.go
@@ -58,12 +58,23 @@ func sortAndUniquifyXYs(xys []XY) []XY {
 	return xys[:n]
 }
 
-func reverseXYs(fwd []XY) []XY {
-	rev := make([]XY, len(fwd))
-	for i := range rev {
-		rev[i] = fwd[len(fwd)-1-i]
+func reverseSequence(seq Sequence) Sequence {
+	n := seq.Length()
+	coords := make([]float64, 0, 2*n)
+	for i := n - 1; i >= 0; i-- {
+		xy := seq.GetXY(i)
+		coords = append(coords, xy.X, xy.Y)
 	}
-	return rev
+	return NewSequence(coords, DimXY)
+}
+
+func sequenceToXYs(seq Sequence) []XY {
+	n := seq.Length()
+	xys := make([]XY, seq.Length())
+	for i := 0; i < n; i++ {
+		xys[i] = seq.GetXY(i)
+	}
+	return xys
 }
 
 // fastMin is a faster but not functionally identical version of math.Min.


### PR DESCRIPTION
## Description

commit 08c83784f8e7d2a5ae37a7204cc96dc55a755525
Author: Peter Stace <peterstace@gmail.com>
Date:   Sun Nov 6 20:36:23 2022 +1100

```
Use Sequence instead of []XY for DCEL edges

The DCEL algorithm needs to represent the points along an edge. The
sources of these points are `Sequence` values from the input geometries.
The DCEL geometry extraction phase (the last step of the DCEL algorithm)
includes a step that inserts points along the edge into the output
geometry.

Before this change, DCEL edges represent points as a slice of `XY`. This
has the disadvantage of a conversion step from a `Sequence` to `[]XY`
(in the DCEL input stage), and then from `[]XY` back to `Sequence` (in
the DCEL output stage).

This change simplifies things by just using `Sequence` throughout. It
also slightly increases the range of points stored on each DCEL edge to
include the origin of the edge, and the final point on the next edge.
These points are redundant (since the output stage could read them from
the vertex records) but help with debugging. Because the Sequences are
shallow copies rather than deep copies, there is no performance penalty.
```

## Check List

Have you:

- Added unit tests? N/A, relies on existing.

- Add cmprefimpl tests? (if appropriate?) N/A, relies on existing.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/302

## Benchmark Results

- Some _very_ slight perf improvements. This PR is more about code simplification than getting a perf improvement, so the perf check was more to ensure there wasn't an unexpected regression.

<details>

<summary>Click to expand</summary>

```
name                                                        old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:arm64
LineEnvelope/0-2                                              2.23ns ± 7%    2.31ns ± 7%   +3.57%  (p=0.014 n=14+15)
LineEnvelope/1-2                                              2.15ns ± 2%    2.13ns ± 2%     ~     (p=0.059 n=14+13)
LineEnvelope/2-2                                              2.14ns ± 3%    2.13ns ± 2%     ~     (p=0.168 n=15+14)
LineEnvelope/3-2                                              2.13ns ± 3%    2.12ns ± 2%     ~     (p=0.659 n=15+14)
MarshalWKB/polygon/n=10-2                                     92.0ns ± 2%    92.3ns ± 1%     ~     (p=0.191 n=13+12)
MarshalWKB/polygon/n=100-2                                     237ns ± 5%     237ns ± 5%     ~     (p=0.830 n=14+14)
MarshalWKB/polygon/n=1000-2                                   1.54µs ±11%    1.59µs ±11%     ~     (p=0.210 n=14+14)
MarshalWKB/polygon/n=10000-2                                  33.6µs ±44%    39.7µs ±43%     ~     (p=0.148 n=15+15)
UnmarshalWKB/polygon/n=10-2                                    159ns ± 3%     156ns ± 1%   -2.21%  (p=0.000 n=14+13)
UnmarshalWKB/polygon/n=100-2                                   300ns ± 4%     295ns ± 6%     ~     (p=0.095 n=15+14)
UnmarshalWKB/polygon/n=1000-2                                 1.80µs ±16%    1.77µs ±11%     ~     (p=0.621 n=15+14)
UnmarshalWKB/polygon/n=10000-2                                38.9µs ±47%   41.8µs ±113%     ~     (p=0.874 n=14+14)
IntersectsLineStringWithLineString/n=10-2                      767ns ± 2%     767ns ± 5%     ~     (p=0.448 n=14+14)
IntersectsLineStringWithLineString/n=100-2                    11.9µs ± 4%    11.8µs ± 3%     ~     (p=0.471 n=13+13)
IntersectsLineStringWithLineString/n=1000-2                    141µs ±10%     146µs ±21%     ~     (p=0.354 n=14+15)
IntersectsLineStringWithLineString/n=10000-2                  3.03ms ±49%    3.21ms ±32%     ~     (p=0.252 n=14+15)
IntersectsMultiPointWithMultiPoint/n=20-2                      553ns ± 0%     555ns ± 1%   +0.44%  (p=0.001 n=13+14)
IntersectsMultiPointWithMultiPoint/n=200-2                    7.55µs ± 1%    7.53µs ± 1%     ~     (p=0.838 n=15+14)
IntersectsMultiPointWithMultiPoint/n=2000-2                   71.4µs ± 2%    71.3µs ± 1%     ~     (p=0.946 n=14+14)
IntersectsMultiPointWithMultiPoint/n=20000-2                   779µs ± 1%     783µs ± 2%   +0.54%  (p=0.022 n=13+14)
PolygonSingleRingValidation/n=10-2                            1.28µs ± 3%    1.27µs ± 1%     ~     (p=0.381 n=13+13)
PolygonSingleRingValidation/n=100-2                           19.2µs ± 2%    19.1µs ± 1%   -0.95%  (p=0.001 n=14+12)
PolygonSingleRingValidation/n=1000-2                           283µs ± 2%     283µs ± 1%     ~     (p=0.139 n=15+12)
PolygonSingleRingValidation/n=10000-2                         4.68ms ±23%    4.79ms ±20%     ~     (p=0.621 n=14+15)
PolygonMultipleRingsValidation/n=4-2                          3.65µs ± 1%    3.66µs ± 4%     ~     (p=0.659 n=12+13)
PolygonMultipleRingsValidation/n=36-2                         30.8µs ± 3%    30.7µs ± 4%     ~     (p=1.000 n=13+14)
PolygonMultipleRingsValidation/n=400-2                         407µs ± 3%     407µs ± 4%     ~     (p=0.982 n=14+14)
PolygonMultipleRingsValidation/n=4096-2                       5.18ms ± 1%    5.18ms ± 2%     ~     (p=0.720 n=13+14)
PolygonZigZagRingsValidation/n=10-2                           6.12µs ± 1%    6.13µs ± 3%     ~     (p=0.381 n=12+14)
PolygonZigZagRingsValidation/n=100-2                          74.1µs ± 2%    73.9µs ± 3%     ~     (p=0.164 n=14+14)
PolygonZigZagRingsValidation/n=1000-2                          989µs ± 5%     979µs ± 2%     ~     (p=0.981 n=14+13)
PolygonZigZagRingsValidation/n=10000-2                        16.3ms ±20%    16.2ms ±32%     ~     (p=0.838 n=15+15)
PolygonAnnulusValidation/n=10-2                               1.98µs ± 3%    1.98µs ± 5%     ~     (p=0.693 n=13+14)
PolygonAnnulusValidation/n=100-2                              19.2µs ± 4%    19.3µs ± 3%     ~     (p=0.650 n=13+15)
PolygonAnnulusValidation/n=1000-2                              347µs ± 2%     343µs ± 2%   -1.19%  (p=0.001 n=14+14)
PolygonAnnulusValidation/n=10000-2                            4.55ms ± 4%    4.55ms ± 4%     ~     (p=0.943 n=13+14)
MultipolygonValidation/n=1-2                                   218ns ± 4%     217ns ± 1%     ~     (p=0.092 n=13+14)
MultipolygonValidation/n=4-2                                   486ns ± 2%     486ns ± 2%     ~     (p=0.955 n=13+15)
MultipolygonValidation/n=16-2                                 2.16µs ± 4%    2.13µs ± 1%     ~     (p=0.091 n=14+13)
MultipolygonValidation/n=64-2                                 10.3µs ± 1%    10.3µs ± 2%     ~     (p=0.759 n=13+15)
MultipolygonValidation/n=256-2                                56.1µs ± 4%    56.1µs ± 4%     ~     (p=0.793 n=14+13)
MultipolygonValidation/n=1024-2                                342µs ± 2%     341µs ± 1%     ~     (p=0.899 n=14+12)
MultiPolygonTwoCircles/n=10-2                                 1.94µs ± 3%    1.92µs ± 2%     ~     (p=0.070 n=15+13)
MultiPolygonTwoCircles/n=100-2                                23.1µs ± 4%    22.9µs ± 1%     ~     (p=0.103 n=15+12)
MultiPolygonTwoCircles/n=1000-2                                298µs ± 8%     324µs ±28%     ~     (p=0.310 n=14+15)
MultiPolygonTwoCircles/n=10000-2                              4.88ms ±11%    4.82ms ±13%     ~     (p=0.567 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-2                      2.62µs ± 3%    2.60µs ± 1%     ~     (p=0.188 n=12+14)
MultiPolygonMultipleTouchingPoints/n=10-2                     20.9µs ± 2%    21.0µs ± 4%     ~     (p=0.847 n=13+15)
MultiPolygonMultipleTouchingPoints/n=100-2                     266µs ± 3%     265µs ± 1%     ~     (p=0.479 n=13+13)
MultiPolygonMultipleTouchingPoints/n=1000-2                   3.32ms ± 4%    3.28ms ± 1%   -1.22%  (p=0.048 n=13+14)
WKTParsing/point-2                                            1.13µs ± 3%    1.13µs ± 2%     ~     (p=0.659 n=13+13)
DistancePolygonToPolygonOrdering/n=100_swap=false-2           27.1µs ± 6%    26.8µs ± 6%     ~     (p=0.174 n=15+15)
DistancePolygonToPolygonOrdering/n=100_swap=true-2            26.6µs ± 8%    26.7µs ± 4%     ~     (p=0.252 n=12+14)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2           464µs ± 2%     464µs ± 2%     ~     (p=0.943 n=14+13)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2            464µs ± 2%     463µs ± 1%     ~     (p=0.977 n=12+12)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2     3.25µs ± 2%    3.24µs ± 3%     ~     (p=0.343 n=13+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2      3.26µs ± 5%    3.24µs ± 2%     ~     (p=0.676 n=14+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2    35.1µs ± 4%    34.6µs ± 1%   -1.46%  (p=0.002 n=13+12)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2     34.8µs ± 1%    34.9µs ± 4%     ~     (p=0.969 n=12+14)
MultiLineStringIsSimpleManyLineStrings/n=100-2                26.9µs ± 2%    26.7µs ± 1%   -0.55%  (p=0.014 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                331µs ± 3%     329µs ± 3%     ~     (p=0.194 n=14+14)
ForceCWandForceCCW/0-2                                        16.5ns ± 8%    16.5ns ± 5%     ~     (p=0.675 n=14+14)
ForceCWandForceCCW/0#01-2                                      103ns ± 3%     101ns ± 1%   -1.48%  (p=0.010 n=14+13)
ForceCWandForceCCW/1-2                                        16.9ns ± 6%    16.7ns ± 6%     ~     (p=0.462 n=14+12)
ForceCWandForceCCW/1#01-2                                      101ns ± 2%     102ns ± 2%     ~     (p=0.070 n=12+12)
ForceCWandForceCCW/2-2                                        31.1ns ± 4%    30.7ns ±10%     ~     (p=0.164 n=15+15)
ForceCWandForceCCW/2#01-2                                      155ns ± 3%     157ns ± 6%     ~     (p=0.167 n=14+14)
ForceCWandForceCCW/3-2                                        30.5ns ± 6%    30.5ns ± 4%     ~     (p=0.198 n=12+14)
ForceCWandForceCCW/3#01-2                                      156ns ± 3%     156ns ± 2%     ~     (p=0.571 n=10+12)
ForceCWandForceCCW/4-2                                        44.5ns ± 6%    43.9ns ± 5%     ~     (p=0.565 n=13+12)
ForceCWandForceCCW/4#01-2                                      241ns ± 3%     239ns ± 1%     ~     (p=0.110 n=10+10)
ForceCWandForceCCW/5-2                                        44.7ns ± 5%    44.5ns ± 6%     ~     (p=0.667 n=14+12)
ForceCWandForceCCW/5#01-2                                      241ns ± 3%     240ns ± 1%     ~     (p=0.936 n=12+10)
ForceCWandForceCCW/6-2                                        65.0ns ± 8%    63.7ns ± 6%     ~     (p=0.092 n=14+14)
ForceCWandForceCCW/6#01-2                                      392ns ± 6%     389ns ± 3%     ~     (p=0.960 n=13+13)
EnvelopeTransformXY-2                                          141ns ± 3%     142ns ± 4%     ~     (p=0.064 n=14+15)
WKBParse/0-2                                                   420ns ± 0%     420ns ± 1%     ~     (p=0.396 n=13+13)
WKBParse/1-2                                                   426ns ± 2%     425ns ± 1%     ~     (p=0.480 n=13+14)
WKBParse/2-2                                                   480ns ± 0%     491ns ± 1%   +2.25%  (p=0.000 n=12+14)
WKBParse/3-2                                                   484ns ± 5%     483ns ± 1%     ~     (p=0.990 n=13+14)
WKBParse/4-2                                                   558ns ± 1%     567ns ± 1%   +1.55%  (p=0.000 n=15+13)
WKBParse/5-2                                                   434ns ± 1%     424ns ± 1%   -2.31%  (p=0.000 n=13+15)
WKBParse/6-2                                                   487ns ± 2%     487ns ± 1%     ~     (p=0.923 n=14+15)
WKBParse/7-2                                                   486ns ± 0%     488ns ± 2%     ~     (p=0.368 n=13+15)
WKBParse/8-2                                                   577ns ± 1%     577ns ± 0%     ~     (p=0.461 n=13+12)
WKBParse/9-2                                                   313ns ± 2%     314ns ± 2%     ~     (p=0.310 n=13+15)
WKBParse/10-2                                                  315ns ± 5%     313ns ± 1%     ~     (p=1.000 n=13+14)
WKBParse/11-2                                                  313ns ± 1%     313ns ± 1%     ~     (p=0.708 n=13+15)
WKBParse/12-2                                                  308ns ± 1%     309ns ± 1%   +0.33%  (p=0.011 n=14+15)
WKBParse/13-2                                                  605ns ± 1%     595ns ± 1%   -1.64%  (p=0.000 n=13+14)
WKBParse/14-2                                                  704ns ± 1%     705ns ± 1%     ~     (p=0.877 n=13+14)
WKBParse/15-2                                                  713ns ± 1%     712ns ± 1%     ~     (p=0.381 n=13+14)
WKBParse/16-2                                                  836ns ± 1%     837ns ± 1%     ~     (p=0.253 n=13+14)
WKBParse/17-2                                                  703ns ± 1%     701ns ± 0%     ~     (p=0.883 n=14+14)
WKBParse/18-2                                                  907ns ± 0%     907ns ± 1%     ~     (p=0.883 n=12+13)
WKBParse/19-2                                                  908ns ± 1%     909ns ± 1%     ~     (p=0.553 n=13+13)
WKBParse/20-2                                                 1.09µs ± 0%    1.10µs ± 1%   +1.02%  (p=0.000 n=12+14)
WKBParse/21-2                                                  302ns ± 1%     301ns ± 1%   -0.49%  (p=0.018 n=14+14)
WKBParse/22-2                                                  303ns ± 1%     303ns ± 1%     ~     (p=0.305 n=14+15)
WKBParse/23-2                                                  304ns ± 1%     302ns ± 0%   -0.65%  (p=0.000 n=15+14)
WKBParse/24-2                                                  300ns ± 2%     298ns ± 1%     ~     (p=0.091 n=15+15)
WKBParse/25-2                                                 1.56µs ± 2%    1.56µs ± 1%     ~     (p=0.955 n=13+15)
WKBParse/26-2                                                 1.97µs ± 1%    1.97µs ± 1%     ~     (p=0.277 n=13+15)
WKBParse/27-2                                                 1.97µs ± 0%    1.98µs ± 1%     ~     (p=0.186 n=12+15)
WKBParse/28-2                                                 2.47µs ± 1%    2.47µs ± 1%     ~     (p=0.518 n=14+14)
WKBParse/29-2                                                  302ns ± 0%     301ns ± 1%   -0.29%  (p=0.023 n=13+14)
WKBParse/30-2                                                  304ns ± 2%     304ns ± 2%     ~     (p=0.174 n=14+14)
WKBParse/31-2                                                  303ns ± 1%     302ns ± 1%     ~     (p=0.075 n=14+15)
WKBParse/32-2                                                  299ns ± 1%     299ns ± 1%     ~     (p=0.246 n=14+15)
WKBParse/33-2                                                  569ns ± 1%     571ns ± 1%   +0.28%  (p=0.049 n=14+13)
WKBParse/34-2                                                  660ns ± 0%     649ns ± 1%   -1.72%  (p=0.000 n=14+15)
WKBParse/35-2                                                  659ns ± 0%     659ns ± 1%     ~     (p=0.733 n=12+14)
WKBParse/36-2                                                  722ns ± 2%     711ns ± 1%   -1.47%  (p=0.000 n=13+14)
WKBParse/37-2                                                  807ns ± 1%     814ns ± 0%   +0.83%  (p=0.000 n=13+12)
WKBParse/38-2                                                  965ns ± 1%     962ns ± 3%     ~     (p=0.105 n=13+15)
WKBParse/39-2                                                  965ns ± 1%     966ns ± 1%     ~     (p=0.910 n=13+13)
WKBParse/40-2                                                 1.07µs ± 2%    1.08µs ± 1%   +0.86%  (p=0.000 n=14+14)
WKBParse/41-2                                                  303ns ± 1%     302ns ± 0%   -0.38%  (p=0.000 n=13+14)
WKBParse/42-2                                                  306ns ± 1%     305ns ± 1%     ~     (p=0.489 n=14+14)
WKBParse/43-2                                                  305ns ± 1%     306ns ± 1%     ~     (p=0.802 n=13+14)
WKBParse/44-2                                                  300ns ± 1%     302ns ± 1%   +0.40%  (p=0.009 n=13+15)
WKBParse/45-2                                                  888ns ± 1%     889ns ± 3%     ~     (p=0.777 n=14+14)
WKBParse/46-2                                                 1.09µs ± 1%    1.08µs ± 1%   -0.61%  (p=0.023 n=15+13)
WKBParse/47-2                                                 1.08µs ± 2%    1.08µs ± 2%     ~     (p=0.839 n=14+13)
WKBParse/48-2                                                 1.23µs ± 2%    1.24µs ± 1%   +0.71%  (p=0.011 n=14+12)
WKBParse/49-2                                                 1.28µs ± 1%    1.27µs ± 2%   -0.68%  (p=0.002 n=15+13)
WKBParse/50-2                                                 1.60µs ± 1%    1.60µs ± 1%     ~     (p=0.711 n=14+13)
WKBParse/51-2                                                 1.59µs ± 1%    1.61µs ± 3%   +1.18%  (p=0.000 n=12+13)
WKBParse/52-2                                                 1.87µs ± 1%    1.88µs ± 1%   +0.83%  (p=0.000 n=14+12)
WKBParse/53-2                                                  303ns ± 1%     302ns ± 1%   -0.56%  (p=0.000 n=14+13)
WKBParse/54-2                                                  305ns ± 1%     305ns ± 1%     ~     (p=0.103 n=14+12)
WKBParse/55-2                                                  305ns ± 1%     305ns ± 4%     ~     (p=0.181 n=13+13)
WKBParse/56-2                                                  300ns ± 1%     299ns ± 1%     ~     (p=0.135 n=13+13)
WKBParse/57-2                                                 1.93µs ± 1%    1.92µs ± 2%   -0.41%  (p=0.005 n=12+13)
WKBParse/58-2                                                 2.38µs ± 1%    2.37µs ± 1%   -0.38%  (p=0.047 n=15+13)
WKBParse/59-2                                                 2.37µs ± 1%    2.36µs ± 1%   -0.62%  (p=0.000 n=13+12)
WKBParse/60-2                                                 2.86µs ± 1%    2.86µs ± 2%     ~     (p=0.990 n=13+14)
WKBParse/61-2                                                  302ns ± 1%     303ns ± 1%     ~     (p=0.641 n=14+13)
WKBParse/62-2                                                  305ns ± 2%     304ns ± 1%     ~     (p=0.838 n=15+14)
WKBParse/63-2                                                  304ns ± 1%     303ns ± 1%     ~     (p=0.334 n=14+14)
WKBParse/64-2                                                  298ns ± 1%     299ns ± 1%     ~     (p=0.077 n=15+13)
WKBParse/65-2                                                  871ns ± 0%     859ns ± 1%   -1.41%  (p=0.000 n=13+14)
WKBParse/66-2                                                 1.03µs ± 1%    1.02µs ± 1%   -0.46%  (p=0.002 n=14+13)
WKBParse/67-2                                                 1.01µs ± 1%    1.02µs ± 1%   +0.76%  (p=0.000 n=14+13)
WKBParse/68-2                                                 1.14µs ± 1%    1.13µs ± 1%   -0.37%  (p=0.007 n=13+14)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:arm64
IntersectionWithoutValidation/n=10-2                          13.4µs ± 2%    13.4µs ± 2%     ~     (p=0.475 n=14+14)
IntersectionWithoutValidation/n=100-2                         29.1µs ± 2%    29.0µs ± 1%     ~     (p=0.652 n=15+14)
IntersectionWithoutValidation/n=1000-2                         149µs ± 3%     149µs ± 3%     ~     (p=0.801 n=13+13)
IntersectionWithoutValidation/n=10000-2                       1.38ms ± 5%    1.41ms ± 4%   +2.37%  (p=0.025 n=14+13)
NoOp/n=10-2                                                   2.17µs ± 2%    2.16µs ± 2%     ~     (p=0.290 n=14+14)
NoOp/n=100-2                                                  5.70µs ± 1%    5.73µs ± 4%     ~     (p=0.395 n=14+14)
NoOp/n=1000-2                                                 39.8µs ± 2%    40.3µs ± 5%     ~     (p=0.367 n=15+15)
NoOp/n=10000-2                                                 457µs ± 9%     462µs ± 9%     ~     (p=0.430 n=13+14)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:arm64
LineStringIsSimpleCircle/n=10-2                               1.08µs ± 3%    1.07µs ± 0%     ~     (p=0.971 n=15+12)
LineStringIsSimpleCircle/n=100-2                              17.0µs ± 1%    17.1µs ± 2%     ~     (p=0.643 n=14+14)
LineStringIsSimpleCircle/n=1000-2                              263µs ± 1%     264µs ± 1%     ~     (p=0.169 n=13+14)
LineStringIsSimpleCircle/n=10000-2                            4.17ms ±17%    4.25ms ±19%     ~     (p=0.813 n=14+15)
LineStringIsSimpleZigZag/10-2                                  956ns ± 1%     958ns ± 1%     ~     (p=0.092 n=13+14)
LineStringIsSimpleZigZag/100-2                                16.9µs ± 1%    17.0µs ± 1%     ~     (p=0.068 n=13+14)
LineStringIsSimpleZigZag/1000-2                                243µs ± 3%     243µs ± 2%     ~     (p=0.928 n=13+15)
LineStringIsSimpleZigZag/10000-2                              4.10ms ±10%    4.37ms ±21%     ~     (p=0.077 n=15+14)
SetOperation/n=4/Go_Intersection-2                            21.4µs ± 2%    19.9µs ± 1%   -6.92%  (p=0.000 n=14+12)
SetOperation/n=4/Go_Difference-2                              21.9µs ± 1%    20.6µs ± 3%   -5.82%  (p=0.000 n=12+14)
SetOperation/n=4/Go_SymmetricDifference-2                     27.6µs ± 1%    26.4µs ± 1%   -4.66%  (p=0.000 n=13+15)
SetOperation/n=4/Go_Union-2                                   22.7µs ± 1%    21.5µs ± 4%   -5.38%  (p=0.000 n=12+14)
SetOperation/n=4/GEOS_Intersection-2                          11.7µs ± 2%    11.7µs ± 2%     ~     (p=0.563 n=15+13)
SetOperation/n=4/GEOS_Difference-2                            12.2µs ± 4%    12.2µs ± 4%     ~     (p=0.650 n=14+13)
SetOperation/n=4/GEOS_SymmetricDifference-2                   18.9µs ± 4%    18.8µs ± 2%     ~     (p=0.943 n=13+14)
SetOperation/n=4/GEOS_Union-2                                 12.3µs ± 2%    12.3µs ± 1%     ~     (p=0.352 n=14+14)
SetOperation/n=8/Go_Intersection-2                            27.1µs ± 0%    25.7µs ± 1%   -5.41%  (p=0.000 n=13+13)
SetOperation/n=8/Go_Difference-2                              27.6µs ± 3%    26.2µs ± 5%   -4.96%  (p=0.000 n=14+15)
SetOperation/n=8/Go_SymmetricDifference-2                     34.2µs ± 0%    33.1µs ± 5%   -3.25%  (p=0.001 n=13+15)
SetOperation/n=8/Go_Union-2                                   28.0µs ± 0%    26.5µs ± 1%   -5.36%  (p=0.000 n=12+12)
SetOperation/n=8/GEOS_Intersection-2                          15.5µs ± 3%    15.6µs ± 3%     ~     (p=0.381 n=13+15)
SetOperation/n=8/GEOS_Difference-2                            15.3µs ± 2%    15.3µs ± 3%     ~     (p=0.603 n=14+14)
SetOperation/n=8/GEOS_SymmetricDifference-2                   22.7µs ± 4%    22.5µs ± 1%     ~     (p=0.185 n=14+13)
SetOperation/n=8/GEOS_Union-2                                 15.0µs ± 2%    15.0µs ± 4%     ~     (p=0.547 n=13+15)
SetOperation/n=16/Go_Intersection-2                           37.3µs ± 1%    36.1µs ± 5%   -3.38%  (p=0.000 n=13+14)
SetOperation/n=16/Go_Difference-2                             39.0µs ± 1%    38.0µs ± 5%   -2.46%  (p=0.013 n=13+15)
SetOperation/n=16/Go_SymmetricDifference-2                    51.6µs ±10%    49.4µs ± 3%   -4.30%  (p=0.000 n=13+15)
SetOperation/n=16/Go_Union-2                                  41.0µs ± 4%    38.8µs ± 1%   -5.29%  (p=0.000 n=14+12)
SetOperation/n=16/GEOS_Intersection-2                         17.2µs ± 3%    17.4µs ± 4%     ~     (p=0.128 n=13+14)
SetOperation/n=16/GEOS_Difference-2                           18.4µs ± 1%    18.5µs ± 2%     ~     (p=0.440 n=13+15)
SetOperation/n=16/GEOS_SymmetricDifference-2                  30.3µs ± 3%    30.3µs ± 2%     ~     (p=0.477 n=14+15)
SetOperation/n=16/GEOS_Union-2                                18.9µs ± 1%    19.0µs ± 3%     ~     (p=0.199 n=13+13)
SetOperation/n=32/Go_Intersection-2                           61.7µs ± 2%    59.7µs ± 2%   -3.26%  (p=0.000 n=14+14)
SetOperation/n=32/Go_Difference-2                             63.5µs ± 1%    62.1µs ± 3%   -2.17%  (p=0.000 n=12+14)
SetOperation/n=32/Go_SymmetricDifference-2                    85.1µs ± 3%    83.9µs ± 3%   -1.35%  (p=0.019 n=14+14)
SetOperation/n=32/Go_Union-2                                  66.0µs ± 1%    64.6µs ± 4%   -2.04%  (p=0.002 n=13+14)
SetOperation/n=32/GEOS_Intersection-2                         22.8µs ± 6%    22.8µs ± 3%     ~     (p=0.370 n=14+14)
SetOperation/n=32/GEOS_Difference-2                           24.1µs ± 5%    24.1µs ± 4%     ~     (p=0.874 n=14+14)
SetOperation/n=32/GEOS_SymmetricDifference-2                  43.0µs ± 2%    42.9µs ± 2%     ~     (p=0.376 n=14+14)
SetOperation/n=32/GEOS_Union-2                                24.3µs ± 3%    24.3µs ± 1%     ~     (p=0.650 n=14+13)
SetOperation/n=64/Go_Intersection-2                            111µs ± 2%     109µs ± 5%   -1.64%  (p=0.017 n=13+15)
SetOperation/n=64/Go_Difference-2                              119µs ± 6%     116µs ± 4%   -2.22%  (p=0.002 n=13+15)
SetOperation/n=64/Go_SymmetricDifference-2                     164µs ± 2%     163µs ± 3%   -0.72%  (p=0.033 n=14+15)
SetOperation/n=64/Go_Union-2                                   125µs ± 2%     122µs ± 1%   -2.34%  (p=0.000 n=12+12)
SetOperation/n=64/GEOS_Intersection-2                         30.7µs ± 4%    30.8µs ± 2%     ~     (p=0.377 n=15+14)
SetOperation/n=64/GEOS_Difference-2                           36.9µs ± 3%    37.4µs ± 5%     ~     (p=0.081 n=15+15)
SetOperation/n=64/GEOS_SymmetricDifference-2                  78.1µs ± 2%    79.2µs ± 3%   +1.32%  (p=0.031 n=14+14)
SetOperation/n=64/GEOS_Union-2                                39.4µs ± 1%    40.2µs ± 6%   +1.95%  (p=0.038 n=13+14)
SetOperation/n=128/Go_Intersection-2                           229µs ± 2%     227µs ± 3%     ~     (p=0.069 n=14+14)
SetOperation/n=128/Go_Difference-2                             240µs ± 1%     240µs ± 1%     ~     (p=0.406 n=13+12)
SetOperation/n=128/Go_SymmetricDifference-2                    332µs ± 3%     330µs ± 4%   -0.67%  (p=0.033 n=14+15)
SetOperation/n=128/Go_Union-2                                  251µs ± 2%     250µs ± 2%   -0.58%  (p=0.029 n=13+13)
SetOperation/n=128/GEOS_Intersection-2                        50.2µs ± 2%    50.4µs ± 2%     ~     (p=0.220 n=14+13)
SetOperation/n=128/GEOS_Difference-2                          59.7µs ± 6%    59.4µs ± 3%     ~     (p=0.793 n=14+13)
SetOperation/n=128/GEOS_SymmetricDifference-2                  143µs ± 3%     144µs ± 3%   +1.08%  (p=0.010 n=13+13)
SetOperation/n=128/GEOS_Union-2                               65.5µs ± 1%    65.1µs ± 2%   -0.68%  (p=0.012 n=14+13)
SetOperation/n=256/Go_Intersection-2                           445µs ± 1%     445µs ± 1%     ~     (p=0.810 n=13+12)
SetOperation/n=256/Go_Difference-2                             482µs ± 2%     483µs ± 3%     ~     (p=0.943 n=13+14)
SetOperation/n=256/Go_SymmetricDifference-2                    680µs ± 1%     680µs ± 3%     ~     (p=0.503 n=12+13)
SetOperation/n=256/Go_Union-2                                  508µs ± 1%     503µs ± 1%   -0.98%  (p=0.000 n=14+12)
SetOperation/n=256/GEOS_Intersection-2                        84.7µs ± 4%    84.6µs ± 3%     ~     (p=0.967 n=15+15)
SetOperation/n=256/GEOS_Difference-2                           119µs ± 3%     120µs ± 2%     ~     (p=0.093 n=15+12)
SetOperation/n=256/GEOS_SymmetricDifference-2                  322µs ± 2%     322µs ± 3%     ~     (p=0.943 n=14+13)
SetOperation/n=256/GEOS_Union-2                                139µs ± 2%     140µs ± 2%   +0.71%  (p=0.014 n=13+13)
SetOperation/n=512/Go_Intersection-2                           934µs ± 8%     934µs ±10%     ~     (p=0.720 n=14+13)
SetOperation/n=512/Go_Difference-2                            1.02ms ±16%    1.11ms ±19%   +8.95%  (p=0.006 n=14+14)
SetOperation/n=512/Go_SymmetricDifference-2                   1.41ms ± 7%    1.37ms ± 3%   -3.13%  (p=0.000 n=14+14)
SetOperation/n=512/Go_Union-2                                 1.04ms ± 5%    1.03ms ± 8%     ~     (p=0.091 n=13+13)
SetOperation/n=512/GEOS_Intersection-2                         173µs ± 2%     173µs ± 2%     ~     (p=0.940 n=14+12)
SetOperation/n=512/GEOS_Difference-2                           234µs ± 1%     237µs ± 2%   +1.13%  (p=0.002 n=11+14)
SetOperation/n=512/GEOS_SymmetricDifference-2                  645µs ± 2%     644µs ± 1%     ~     (p=0.717 n=15+13)
SetOperation/n=512/GEOS_Union-2                                290µs ±11%     291µs ± 6%     ~     (p=0.635 n=14+14)
SetOperation/n=1024/Go_Intersection-2                         1.82ms ± 4%    1.81ms ± 3%     ~     (p=0.685 n=13+14)
SetOperation/n=1024/Go_Difference-2                           2.07ms ± 7%    2.01ms ± 2%   -2.76%  (p=0.000 n=15+13)
SetOperation/n=1024/Go_SymmetricDifference-2                  2.99ms ± 2%    3.00ms ± 7%     ~     (p=0.960 n=13+13)
SetOperation/n=1024/Go_Union-2                                2.21ms ± 7%    2.16ms ± 1%     ~     (p=0.201 n=15+13)
SetOperation/n=1024/GEOS_Intersection-2                        347µs ± 1%     351µs ± 4%     ~     (p=0.118 n=12+14)
SetOperation/n=1024/GEOS_Difference-2                          531µs ± 7%     537µs ±10%     ~     (p=0.425 n=14+15)
SetOperation/n=1024/GEOS_SymmetricDifference-2                1.46ms ±12%    1.47ms ± 8%     ~     (p=0.539 n=15+15)
SetOperation/n=1024/GEOS_Union-2                               646µs ±12%     620µs ± 4%     ~     (p=0.412 n=15+15)
SetOperation/n=2048/Go_Intersection-2                         3.99ms ± 6%    3.94ms ± 5%     ~     (p=0.202 n=15+15)
SetOperation/n=2048/Go_Difference-2                           4.20ms ± 4%    4.25ms ± 7%     ~     (p=0.150 n=14+14)
SetOperation/n=2048/Go_SymmetricDifference-2                  6.20ms ± 8%    6.10ms ± 6%     ~     (p=0.187 n=15+15)
SetOperation/n=2048/Go_Union-2                                4.49ms ± 4%    4.46ms ± 4%     ~     (p=0.054 n=13+14)
SetOperation/n=2048/GEOS_Intersection-2                        782µs ± 5%     763µs ± 3%   -2.38%  (p=0.038 n=13+14)
SetOperation/n=2048/GEOS_Difference-2                         1.05ms ± 7%    1.03ms ± 3%   -1.88%  (p=0.014 n=14+13)
SetOperation/n=2048/GEOS_SymmetricDifference-2                2.88ms ± 5%    2.89ms ±16%     ~     (p=0.527 n=12+14)
SetOperation/n=2048/GEOS_Union-2                              1.23ms ± 6%    1.22ms ± 6%     ~     (p=0.920 n=13+13)
SetOperation/n=4096/Go_Intersection-2                         8.56ms ± 9%    8.42ms ±13%     ~     (p=0.265 n=14+14)
SetOperation/n=4096/Go_Difference-2                           10.2ms ±22%     9.9ms ±16%     ~     (p=0.512 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-2                  13.8ms ±17%    13.7ms ±21%     ~     (p=0.624 n=15+15)
SetOperation/n=4096/Go_Union-2                                10.3ms ±14%    10.6ms ±15%     ~     (p=0.331 n=14+15)
SetOperation/n=4096/GEOS_Intersection-2                       1.46ms ± 2%    1.47ms ± 2%     ~     (p=0.322 n=12+14)
SetOperation/n=4096/GEOS_Difference-2                         2.17ms ±10%    2.13ms ± 2%     ~     (p=0.390 n=13+13)
SetOperation/n=4096/GEOS_SymmetricDifference-2                6.91ms ±18%    7.11ms ±24%     ~     (p=0.458 n=13+14)
SetOperation/n=4096/GEOS_Union-2                              3.12ms ±41%    2.73ms ±23%  -12.25%  (p=0.016 n=15+15)
SetOperation/n=8192/Go_Intersection-2                         19.0ms ±19%    19.0ms ±20%     ~     (p=0.935 n=15+15)
SetOperation/n=8192/Go_Difference-2                           19.6ms ±10%    20.5ms ±26%     ~     (p=0.512 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-2                  30.7ms ±12%    32.4ms ±18%     ~     (p=0.316 n=13+15)
SetOperation/n=8192/Go_Union-2                                20.9ms ±10%    20.8ms ±18%     ~     (p=0.270 n=15+14)
SetOperation/n=8192/GEOS_Intersection-2                       3.32ms ± 8%    3.38ms ±10%     ~     (p=0.436 n=15+15)
SetOperation/n=8192/GEOS_Difference-2                         4.48ms ±10%    4.38ms ± 7%     ~     (p=0.482 n=14+14)
SetOperation/n=8192/GEOS_SymmetricDifference-2                14.0ms ±23%    14.0ms ±23%     ~     (p=1.000 n=15+15)
SetOperation/n=8192/GEOS_Union-2                              5.25ms ±13%    5.26ms ±14%     ~     (p=0.621 n=15+14)
SetOperation/n=16384/Go_Intersection-2                        45.4ms ±52%    39.0ms ±23%     ~     (p=0.160 n=14+12)
SetOperation/n=16384/Go_Difference-2                          49.0ms ±75%    51.1ms ±53%     ~     (p=0.550 n=13+14)
SetOperation/n=16384/Go_SymmetricDifference-2                 61.6ms ±22%   76.3ms ±124%     ~     (p=0.110 n=12+13)
SetOperation/n=16384/Go_Union-2                               57.5ms ±88%    47.4ms ±17%     ~     (p=0.440 n=15+13)
SetOperation/n=16384/GEOS_Intersection-2                      6.68ms ±20%    6.91ms ±23%     ~     (p=0.387 n=13+15)
SetOperation/n=16384/GEOS_Difference-2                        9.45ms ± 4%    9.69ms ± 8%   +2.51%  (p=0.011 n=14+14)
SetOperation/n=16384/GEOS_SymmetricDifference-2               26.5ms ± 4%    27.1ms ± 6%   +2.11%  (p=0.023 n=15+14)
SetOperation/n=16384/GEOS_Union-2                             11.7ms ± 6%    11.5ms ± 5%     ~     (p=0.477 n=14+15)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:arm64
Delete/n=100-2                                                10.7µs ± 2%    10.7µs ± 2%     ~     (p=0.214 n=14+14)
Delete/n=1000-2                                                441µs ± 7%     437µs ± 1%     ~     (p=0.270 n=14+15)
Delete/n=10000-2                                              23.9ms ± 1%    24.0ms ± 1%     ~     (p=0.078 n=12+12)
Bulk/n=10-2                                                    440ns ± 1%     442ns ± 2%     ~     (p=0.383 n=12+13)
Bulk/n=100-2                                                  8.98µs ± 2%    8.97µs ± 1%     ~     (p=0.429 n=13+12)
Bulk/n=1000-2                                                  188µs ± 1%     188µs ± 1%     ~     (p=0.478 n=12+12)
Bulk/n=10000-2                                                2.74ms ± 0%    2.74ms ± 0%     ~     (p=0.319 n=12+12)
Bulk/n=100000-2                                               32.4ms ± 3%    32.9ms ± 5%     ~     (p=0.290 n=14+15)
Insert/n=10-2                                                  777ns ± 1%     779ns ± 2%     ~     (p=0.650 n=12+13)
Insert/n=100-2                                                13.5µs ± 1%    13.6µs ± 1%     ~     (p=0.574 n=14+13)
Insert/n=1000-2                                                279µs ± 1%     280µs ± 3%     ~     (p=0.723 n=14+15)
Insert/n=10000-2                                              3.74ms ± 1%    3.76ms ± 2%     ~     (p=0.118 n=12+14)
Insert/n=100000-2                                             44.6ms ± 1%    44.6ms ± 1%     ~     (p=0.734 n=14+14)
RangeSearch/n=10-2                                            10.5ns ± 5%    10.6ns ± 5%     ~     (p=0.119 n=15+14)
RangeSearch/n=100-2                                           45.3ns ± 6%    45.1ns ± 6%     ~     (p=0.976 n=15+15)
RangeSearch/n=1000-2                                           164ns ± 4%     167ns ± 5%     ~     (p=0.213 n=15+15)
RangeSearch/n=10000-2                                          589ns ± 4%     595ns ± 4%     ~     (p=0.418 n=15+15)
RangeSearch/n=100000-2                                        5.72µs ± 4%    5.72µs ± 3%     ~     (p=0.783 n=15+15)

name                                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:arm64
LineEnvelope/0-2                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/1-2                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/2-2                                               0.00B          0.00B          ~     (all equal)
LineEnvelope/3-2                                               0.00B          0.00B          ~     (all equal)
MarshalWKB/polygon/n=10-2                                       232B ± 0%      232B ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-2                                    1.83kB ± 0%    1.83kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-2                                   16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-2                                   164kB ± 0%     164kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-2                                     284B ± 0%      284B ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-2                                  1.90kB ± 0%    1.90kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-2                                 16.5kB ± 0%    16.5kB ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-2                                 164kB ± 0%     164kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-2                     2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-2                    30.4kB ± 0%    30.4kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-2                    205kB ± 0%     205kB ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-2                  2.63MB ± 0%    2.63MB ± 0%     ~     (p=0.480 n=13+13)
IntersectsMultiPointWithMultiPoint/n=20-2                       324B ± 0%      324B ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-2                    3.06kB ± 0%    3.07kB ± 0%     ~     (p=0.699 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000-2                   49.3kB ± 0%    49.3kB ± 0%   +0.00%  (p=0.011 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000-2                   339kB ± 0%     339kB ± 0%     ~     (p=0.707 n=14+15)
PolygonSingleRingValidation/n=10-2                            2.29kB ± 0%    2.29kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-2                           24.4kB ± 0%    24.4kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-2                           140kB ± 0%     140kB ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-2                         1.97MB ± 0%    1.97MB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-2                          6.61kB ± 0%    6.61kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-2                         53.2kB ± 0%    53.2kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-2                         597kB ± 0%     597kB ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-2                       6.28MB ± 0%    6.28MB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-2                           9.62kB ± 0%    9.62kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-2                          88.0kB ± 0%    88.0kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-2                          551kB ± 0%     551kB ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-2                        7.24MB ± 0%    7.24MB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10-2                               4.10kB ± 0%    4.10kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-2                              28.4kB ± 0%    28.4kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-2                              379kB ± 0%     379kB ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000-2                            3.89MB ± 0%    3.89MB ± 0%     ~     (all equal)
MultipolygonValidation/n=1-2                                    481B ± 0%      481B ± 0%     ~     (all equal)
MultipolygonValidation/n=4-2                                    980B ± 0%      980B ± 0%     ~     (all equal)
MultipolygonValidation/n=16-2                                 4.16kB ± 0%    4.16kB ± 0%     ~     (all equal)
MultipolygonValidation/n=64-2                                 17.0kB ± 0%    17.0kB ± 0%     ~     (all equal)
MultipolygonValidation/n=256-2                                67.8kB ± 0%    67.8kB ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-2                                271kB ± 0%     271kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-2                                 5.15kB ± 0%    5.15kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-2                                55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-2                                345kB ± 0%     345kB ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-2                              4.60MB ± 0%    4.60MB ± 0%     ~     (p=0.705 n=14+12)
MultiPolygonMultipleTouchingPoints/n=1-2                      4.16kB ± 0%    4.16kB ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-2                     23.9kB ± 0%    23.9kB ± 0%     ~     (p=1.000 n=14+15)
MultiPolygonMultipleTouchingPoints/n=100-2                     182kB ± 0%     182kB ± 0%     ~     (p=0.151 n=13+15)
MultiPolygonMultipleTouchingPoints/n=1000-2                   2.16MB ± 0%    2.16MB ± 0%     ~     (p=0.467 n=15+15)
WKTParsing/point-2                                            1.89kB ± 0%    1.89kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-2           40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-2            40.7kB ± 0%    40.7kB ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2           369kB ± 0%     369kB ± 0%     ~     (p=0.248 n=12+14)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2            369kB ± 0%     369kB ± 0%     ~     (p=0.789 n=15+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2     5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2      5.52kB ± 0%    5.52kB ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2    60.1kB ± 0%    60.1kB ± 0%   +0.00%  (p=0.006 n=15+12)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2     60.1kB ± 0%    60.1kB ± 0%     ~     (p=1.000 n=15+15)
MultiLineStringIsSimpleManyLineStrings/n=100-2                59.2kB ± 0%    59.2kB ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                491kB ± 0%     491kB ± 0%     ~     (all equal)
ForceCWandForceCCW/0-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/0#01-2                                       144B ± 0%      144B ± 0%     ~     (all equal)
ForceCWandForceCCW/1-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/1#01-2                                       144B ± 0%      144B ± 0%     ~     (all equal)
ForceCWandForceCCW/2-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/2#01-2                                       256B ± 0%      256B ± 0%     ~     (all equal)
ForceCWandForceCCW/3-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/3#01-2                                       256B ± 0%      256B ± 0%     ~     (all equal)
ForceCWandForceCCW/4-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/4#01-2                                       416B ± 0%      416B ± 0%     ~     (all equal)
ForceCWandForceCCW/5-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/5#01-2                                       416B ± 0%      416B ± 0%     ~     (all equal)
ForceCWandForceCCW/6-2                                         0.00B          0.00B          ~     (all equal)
ForceCWandForceCCW/6#01-2                                       624B ± 0%      624B ± 0%     ~     (all equal)
EnvelopeTransformXY-2                                          0.00B          0.00B          ~     (all equal)
WKBParse/0-2                                                    112B ± 0%      112B ± 0%     ~     (all equal)
WKBParse/1-2                                                    112B ± 0%      112B ± 0%     ~     (all equal)
WKBParse/2-2                                                    112B ± 0%      112B ± 0%     ~     (all equal)
WKBParse/3-2                                                    112B ± 0%      112B ± 0%     ~     (all equal)
WKBParse/4-2                                                    176B ± 0%      176B ± 0%     ~     (all equal)
WKBParse/5-2                                                    120B ± 0%      120B ± 0%     ~     (all equal)
WKBParse/6-2                                                    120B ± 0%      120B ± 0%     ~     (all equal)
WKBParse/7-2                                                    120B ± 0%      120B ± 0%     ~     (all equal)
WKBParse/8-2                                                    184B ± 0%      184B ± 0%     ~     (all equal)
WKBParse/9-2                                                   72.0B ± 0%     72.0B ± 0%     ~     (all equal)
WKBParse/10-2                                                  72.0B ± 0%     72.0B ± 0%     ~     (all equal)
WKBParse/11-2                                                  72.0B ± 0%     72.0B ± 0%     ~     (all equal)
WKBParse/12-2                                                  72.0B ± 0%     72.0B ± 0%     ~     (all equal)
WKBParse/13-2                                                   200B ± 0%      200B ± 0%     ~     (all equal)
WKBParse/14-2                                                   216B ± 0%      216B ± 0%     ~     (all equal)
WKBParse/15-2                                                   216B ± 0%      216B ± 0%     ~     (all equal)
WKBParse/16-2                                                   360B ± 0%      360B ± 0%     ~     (all equal)
WKBParse/17-2                                                   216B ± 0%      216B ± 0%     ~     (all equal)
WKBParse/18-2                                                   376B ± 0%      376B ± 0%     ~     (all equal)
WKBParse/19-2                                                   376B ± 0%      376B ± 0%     ~     (all equal)
WKBParse/20-2                                                   392B ± 0%      392B ± 0%     ~     (all equal)
WKBParse/21-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/22-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/23-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/24-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/25-2                                                   808B ± 0%      808B ± 0%     ~     (all equal)
WKBParse/26-2                                                   872B ± 0%      872B ± 0%     ~     (all equal)
WKBParse/27-2                                                   872B ± 0%      872B ± 0%     ~     (all equal)
WKBParse/28-2                                                 1.45kB ± 0%    1.45kB ± 0%     ~     (all equal)
WKBParse/29-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/30-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/31-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/32-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/33-2                                                   248B ± 0%      248B ± 0%     ~     (all equal)
WKBParse/34-2                                                   312B ± 0%      312B ± 0%     ~     (all equal)
WKBParse/35-2                                                   312B ± 0%      312B ± 0%     ~     (all equal)
WKBParse/36-2                                                   312B ± 0%      312B ± 0%     ~     (all equal)
WKBParse/37-2                                                   456B ± 0%      456B ± 0%     ~     (all equal)
WKBParse/38-2                                                   584B ± 0%      584B ± 0%     ~     (all equal)
WKBParse/39-2                                                   584B ± 0%      584B ± 0%     ~     (all equal)
WKBParse/40-2                                                   584B ± 0%      584B ± 0%     ~     (all equal)
WKBParse/41-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/42-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/43-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/44-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/45-2                                                   440B ± 0%      440B ± 0%     ~     (all equal)
WKBParse/46-2                                                   472B ± 0%      472B ± 0%     ~     (all equal)
WKBParse/47-2                                                   472B ± 0%      472B ± 0%     ~     (all equal)
WKBParse/48-2                                                   488B ± 0%      488B ± 0%     ~     (all equal)
WKBParse/49-2                                                   568B ± 0%      568B ± 0%     ~     (all equal)
WKBParse/50-2                                                   872B ± 0%      872B ± 0%     ~     (all equal)
WKBParse/51-2                                                   872B ± 0%      872B ± 0%     ~     (all equal)
WKBParse/52-2                                                   904B ± 0%      904B ± 0%     ~     (all equal)
WKBParse/53-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/54-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/55-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/56-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/57-2                                                 1.07kB ± 0%    1.07kB ± 0%     ~     (all equal)
WKBParse/58-2                                                 1.14kB ± 0%    1.14kB ± 0%     ~     (all equal)
WKBParse/59-2                                                 1.14kB ± 0%    1.14kB ± 0%     ~     (all equal)
WKBParse/60-2                                                 1.71kB ± 0%    1.71kB ± 0%     ~     (all equal)
WKBParse/61-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/62-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/63-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/64-2                                                  64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WKBParse/65-2                                                   424B ± 0%      424B ± 0%     ~     (all equal)
WKBParse/66-2                                                   552B ± 0%      552B ± 0%     ~     (all equal)
WKBParse/67-2                                                   552B ± 0%      552B ± 0%     ~     (all equal)
WKBParse/68-2                                                   552B ± 0%      552B ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:arm64
IntersectionWithoutValidation/n=10-2                          1.32kB ± 0%    1.32kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100-2                         6.46kB ± 0%    6.46kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=1000-2                        55.1kB ± 0%    55.1kB ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=10000-2                        558kB ± 0%     558kB ± 0%     ~     (p=0.196 n=14+13)
NoOp/n=10-2                                                     952B ± 0%      952B ± 0%     ~     (all equal)
NoOp/n=100-2                                                  5.77kB ± 0%    5.77kB ± 0%     ~     (all equal)
NoOp/n=1000-2                                                 49.5kB ± 0%    49.5kB ± 0%     ~     (all equal)
NoOp/n=10000-2                                                 492kB ± 0%     492kB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:arm64
LineStringIsSimpleCircle/n=10-2                               1.87kB ± 0%    1.87kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100-2                              24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000-2                              139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000-2                            1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.464 n=13+14)
LineStringIsSimpleZigZag/10-2                                 1.84kB ± 0%    1.84kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-2                                24.0kB ± 0%    24.0kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-2                                139kB ± 0%     139kB ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-2                              1.97MB ± 0%    1.97MB ± 0%     ~     (p=0.451 n=15+15)
SetOperation/n=4/Go_Intersection-2                            20.3kB ± 0%    19.5kB ± 0%   -4.11%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference-2                              21.3kB ± 0%    20.4kB ± 0%   -3.94%  (p=0.000 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-2                     29.3kB ± 0%    28.5kB ± 0%   -2.85%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union-2                                   22.0kB ± 0%    21.1kB ± 0%   -3.80%  (p=0.000 n=15+15)
SetOperation/n=4/GEOS_Intersection-2                          1.77kB ± 0%    1.77kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference-2                            2.78kB ± 0%    2.78kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-2                   10.7kB ± 0%    10.7kB ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Union-2                                 3.21kB ± 0%    3.21kB ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection-2                            27.0kB ± 0%    26.1kB ± 0%   -3.56%  (p=0.000 n=14+15)
SetOperation/n=8/Go_Difference-2                              27.1kB ± 0%    26.2kB ± 0%   -3.55%  (p=0.000 n=15+15)
SetOperation/n=8/Go_SymmetricDifference-2                     36.8kB ± 0%    35.9kB ± 0%   -2.63%  (p=0.000 n=15+15)
SetOperation/n=8/Go_Union-2                                   27.3kB ± 0%    26.3kB ± 0%   -3.54%  (p=0.000 n=15+15)
SetOperation/n=8/GEOS_Intersection-2                          3.34kB ± 0%    3.34kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference-2                            3.50kB ± 0%    3.50kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-2                   13.0kB ± 0%    13.0kB ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Union-2                                 3.62kB ± 0%    3.62kB ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection-2                           37.3kB ± 0%    36.0kB ± 0%   -3.27%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Difference-2                             40.4kB ± 0%    39.2kB ± 0%   -3.02%  (p=0.000 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-2                    58.7kB ± 0%    57.4kB ± 0%   -2.08%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Union-2                                  41.9kB ± 0%    40.7kB ± 0%   -2.91%  (p=0.000 n=14+15)
SetOperation/n=16/GEOS_Intersection-2                         3.88kB ± 0%    3.88kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference-2                           6.68kB ± 0%    6.68kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-2                  24.7kB ± 0%    24.7kB ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Union-2                                8.28kB ± 0%    8.28kB ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection-2                           67.8kB ± 0%    66.1kB ± 0%   -2.55%  (p=0.000 n=15+13)
SetOperation/n=32/Go_Difference-2                             70.4kB ± 0%    68.7kB ± 0%   -2.46%  (p=0.000 n=14+14)
SetOperation/n=32/Go_SymmetricDifference-2                     100kB ± 0%      98kB ± 0%   -1.74%  (p=0.000 n=13+15)
SetOperation/n=32/Go_Union-2                                  70.9kB ± 0%    69.1kB ± 0%   -2.45%  (p=0.000 n=14+14)
SetOperation/n=32/GEOS_Intersection-2                         8.86kB ± 0%    8.86kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference-2                           10.7kB ± 0%    10.7kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-2                  38.9kB ± 0%    38.9kB ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Union-2                                11.5kB ± 0%    11.5kB ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection-2                            113kB ± 0%     110kB ± 0%   -2.55%  (p=0.000 n=15+15)
SetOperation/n=64/Go_Difference-2                              125kB ± 0%     122kB ± 0%   -2.30%  (p=0.000 n=15+15)
SetOperation/n=64/Go_SymmetricDifference-2                     191kB ± 0%     188kB ± 0%   -1.51%  (p=0.000 n=15+15)
SetOperation/n=64/Go_Union-2                                   129kB ± 0%     126kB ± 0%   -2.23%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Intersection-2                         12.6kB ± 0%    12.6kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference-2                           23.5kB ± 0%    23.5kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-2                  87.1kB ± 0%    87.1kB ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Union-2                                28.0kB ± 0%    28.0kB ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection-2                           230kB ± 0%     225kB ± 0%   -2.19%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Difference-2                             242kB ± 0%     237kB ± 0%   -2.08%  (p=0.000 n=15+15)
SetOperation/n=128/Go_SymmetricDifference-2                    352kB ± 0%     347kB ± 0%   -1.43%  (p=0.000 n=15+13)
SetOperation/n=128/Go_Union-2                                  244kB ± 0%     239kB ± 0%   -2.06%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Intersection-2                        30.3kB ± 0%    30.3kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference-2                          40.0kB ± 0%    40.0kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-2                  147kB ± 0%     147kB ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Union-2                               43.1kB ± 0%    43.1kB ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection-2                           409kB ± 0%     399kB ± 0%   -2.36%  (p=0.000 n=15+15)
SetOperation/n=256/Go_Difference-2                             456kB ± 0%     447kB ± 0%   -2.11%  (p=0.000 n=15+14)
SetOperation/n=256/Go_SymmetricDifference-2                    710kB ± 0%     700kB ± 0%   -1.36%  (p=0.000 n=15+15)
SetOperation/n=256/Go_Union-2                                  467kB ± 0%     457kB ± 0%   -2.06%  (p=0.000 n=15+15)
SetOperation/n=256/GEOS_Intersection-2                        48.2kB ± 0%    48.2kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference-2                          92.6kB ± 0%    92.6kB ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-2                  340kB ± 0%     340kB ± 0%     ~     (p=0.070 n=15+13)
SetOperation/n=256/GEOS_Union-2                                106kB ± 0%     106kB ± 0%     ~     (all equal)
SetOperation/n=512/Go_Intersection-2                           848kB ± 0%     830kB ± 0%   -2.13%  (p=0.000 n=15+14)
SetOperation/n=512/Go_Difference-2                             896kB ± 0%     878kB ± 0%   -2.01%  (p=0.000 n=15+15)
SetOperation/n=512/Go_SymmetricDifference-2                   1.32MB ± 0%    1.30MB ± 0%   -1.36%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Union-2                                  917kB ± 0%     899kB ± 0%   -1.97%  (p=0.000 n=15+15)
SetOperation/n=512/GEOS_Intersection-2                         115kB ± 0%     115kB ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Difference-2                           159kB ± 0%     159kB ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-2                  576kB ± 0%     576kB ± 0%     ~     (p=0.548 n=15+15)
SetOperation/n=512/GEOS_Union-2                                171kB ± 0%     171kB ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Intersection-2                         1.59MB ± 0%    1.55MB ± 0%   -2.22%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_Difference-2                           1.78MB ± 0%    1.74MB ± 0%   -1.99%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_SymmetricDifference-2                  2.81MB ± 0%    2.77MB ± 0%   -1.26%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_Union-2                                1.84MB ± 0%    1.80MB ± 0%   -1.92%  (p=0.000 n=15+15)
SetOperation/n=1024/GEOS_Intersection-2                        189kB ± 0%     189kB ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Difference-2                          369kB ± 0%     369kB ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-2                1.38MB ± 0%    1.38MB ± 0%     ~     (p=0.426 n=10+14)
SetOperation/n=1024/GEOS_Union-2                               415kB ± 0%     415kB ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Intersection-2                         3.49MB ± 0%    3.41MB ± 0%   -2.08%  (p=0.000 n=14+15)
SetOperation/n=2048/Go_Difference-2                           3.68MB ± 0%    3.61MB ± 0%   -1.97%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference-2                  5.41MB ± 0%    5.34MB ± 0%   -1.34%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Union-2                                3.76MB ± 0%    3.69MB ± 0%   -1.92%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Intersection-2                        460kB ± 0%     460kB ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Difference-2                          648kB ± 0%     648kB ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-2                2.32MB ± 0%    2.32MB ± 0%     ~     (p=0.158 n=14+11)
SetOperation/n=2048/GEOS_Union-2                               689kB ± 0%     689kB ± 0%     ~     (all equal)
SetOperation/n=4096/Go_Intersection-2                         6.68MB ± 0%    6.53MB ± 0%   -2.16%  (p=0.000 n=15+14)
SetOperation/n=4096/Go_Difference-2                           7.40MB ± 0%    7.25MB ± 0%   -1.95%  (p=0.000 n=15+14)
SetOperation/n=4096/Go_SymmetricDifference-2                  11.4MB ± 0%    11.3MB ± 0%   -1.26%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_Union-2                                7.64MB ± 0%    7.50MB ± 0%   -1.88%  (p=0.000 n=14+15)
SetOperation/n=4096/GEOS_Intersection-2                        755kB ± 0%     755kB ± 0%     ~     (p=0.363 n=15+14)
SetOperation/n=4096/GEOS_Difference-2                         1.45MB ± 0%    1.45MB ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-2                5.34MB ± 0%    5.34MB ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Union-2                              1.63MB ± 0%    1.63MB ± 0%     ~     (p=0.100 n=14+15)
SetOperation/n=8192/Go_Intersection-2                         14.3MB ± 0%    14.0MB ± 0%   -2.01%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Difference-2                           15.2MB ± 0%    14.9MB ± 0%   -1.89%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_SymmetricDifference-2                  22.1MB ± 0%    21.8MB ± 0%   -1.30%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Union-2                                15.5MB ± 0%    15.2MB ± 0%   -1.85%  (p=0.000 n=14+15)
SetOperation/n=8192/GEOS_Intersection-2                       1.76MB ± 0%    1.76MB ± 0%     ~     (p=0.223 n=10+15)
SetOperation/n=8192/GEOS_Difference-2                         2.47MB ± 0%    2.47MB ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-2                9.01MB ± 0%    9.01MB ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Union-2                              2.66MB ± 0%    2.66MB ± 0%     ~     (all equal)
SetOperation/n=16384/Go_Intersection-2                        26.5MB ± 0%    26.0MB ± 0%   -2.04%  (p=0.000 n=15+14)
SetOperation/n=16384/Go_Difference-2                          29.4MB ± 0%    28.8MB ± 0%   -1.84%  (p=0.000 n=15+14)
SetOperation/n=16384/Go_SymmetricDifference-2                 45.4MB ± 0%    44.8MB ± 0%   -1.19%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Union-2                               30.3MB ± 0%    29.8MB ± 0%   -1.79%  (p=0.000 n=15+15)
SetOperation/n=16384/GEOS_Intersection-2                      2.92MB ± 0%    2.92MB ± 0%     ~     (p=0.161 n=15+14)
SetOperation/n=16384/GEOS_Difference-2                        5.68MB ± 0%    5.68MB ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-2               21.1MB ± 0%    21.1MB ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Union-2                             6.45MB ± 0%    6.45MB ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:arm64
Delete/n=100-2                                                  712B ± 0%      712B ± 0%     ~     (all equal)
Delete/n=1000-2                                               26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
Delete/n=10000-2                                               412kB ± 0%     412kB ± 0%     ~     (all equal)
Bulk/n=10-2                                                   1.46kB ± 0%    1.46kB ± 0%     ~     (all equal)
Bulk/n=100-2                                                  19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)
Bulk/n=1000-2                                                 98.2kB ± 0%    98.2kB ± 0%     ~     (all equal)
Bulk/n=10000-2                                                1.57MB ± 0%    1.57MB ± 0%     ~     (all equal)
Bulk/n=100000-2                                               20.4MB ± 0%    20.4MB ± 0%     ~     (all equal)
Insert/n=10-2                                                 1.44kB ± 0%    1.44kB ± 0%     ~     (all equal)
Insert/n=100-2                                                13.5kB ± 0%    13.5kB ± 0%     ~     (all equal)
Insert/n=1000-2                                                132kB ± 0%     132kB ± 0%     ~     (all equal)
Insert/n=10000-2                                              1.34MB ± 0%    1.34MB ± 0%     ~     (all equal)
Insert/n=100000-2                                             13.5MB ± 0%    13.5MB ± 0%     ~     (all equal)
RangeSearch/n=10-2                                             0.00B          0.00B          ~     (all equal)
RangeSearch/n=100-2                                            0.00B          0.00B          ~     (all equal)
RangeSearch/n=1000-2                                           0.00B          0.00B          ~     (all equal)
RangeSearch/n=10000-2                                          0.00B          0.00B          ~     (all equal)
RangeSearch/n=100000-2                                         0.00B          0.00B          ~     (all equal)

name                                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:arm64
LineEnvelope/0-2                                                0.00           0.00          ~     (all equal)
LineEnvelope/1-2                                                0.00           0.00          ~     (all equal)
LineEnvelope/2-2                                                0.00           0.00          ~     (all equal)
LineEnvelope/3-2                                                0.00           0.00          ~     (all equal)
MarshalWKB/polygon/n=10-2                                       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=100-2                                      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=1000-2                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
MarshalWKB/polygon/n=10000-2                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10-2                                     7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=100-2                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=1000-2                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
UnmarshalWKB/polygon/n=10000-2                                  7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10-2                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=100-2                      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=1000-2                      345 ± 0%       345 ± 0%     ~     (all equal)
IntersectsLineStringWithLineString/n=10000-2                   5.46k ± 0%     5.46k ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-2                       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-2                      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-2                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-2                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10-2                              12.0 ± 0%      12.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=100-2                             76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=1000-2                             348 ± 0%       348 ± 0%     ~     (all equal)
PolygonSingleRingValidation/n=10000-2                          5.47k ± 0%     5.47k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4-2                            42.0 ± 0%      42.0 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=36-2                            316 ± 0%       316 ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=400-2                         3.48k ± 0%     3.48k ± 0%     ~     (all equal)
PolygonMultipleRingsValidation/n=4096-2                        36.2k ± 0%     36.2k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10-2                             41.0 ± 0%      41.0 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=100-2                             233 ± 0%       233 ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=1000-2                          1.05k ± 0%     1.05k ± 0%     ~     (all equal)
PolygonZigZagRingsValidation/n=10000-2                         16.4k ± 0%     16.4k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10-2                                 22.0 ± 0%      22.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=100-2                                76.0 ± 0%      76.0 ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=1000-2                              1.00k ± 0%     1.00k ± 0%     ~     (all equal)
PolygonAnnulusValidation/n=10000-2                             10.3k ± 0%     10.3k ± 0%     ~     (all equal)
MultipolygonValidation/n=1-2                                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MultipolygonValidation/n=4-2                                    11.0 ± 0%      11.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=16-2                                   27.0 ± 0%      27.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=64-2                                   91.0 ± 0%      91.0 ± 0%     ~     (all equal)
MultipolygonValidation/n=256-2                                   347 ± 0%       347 ± 0%     ~     (all equal)
MultipolygonValidation/n=1024-2                                1.37k ± 0%     1.37k ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10-2                                   29.0 ± 0%      29.0 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=100-2                                   157 ± 0%       157 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=1000-2                                  701 ± 0%       701 ± 0%     ~     (all equal)
MultiPolygonTwoCircles/n=10000-2                               10.9k ± 0%     10.9k ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-2                        51.0 ± 0%      51.0 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-2                        298 ± 0%       298 ± 0%     ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-2                     2.61k ± 0%     2.61k ± 0%     ~     (p=1.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-2                    26.7k ± 0%     26.7k ± 0%     ~     (p=0.656 n=15+15)
WKTParsing/point-2                                              22.0 ± 0%      22.0 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-2              234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-2               234 ± 0%       234 ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2           2.10k ± 0%     2.10k ± 0%     ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2            2.10k ± 0%     2.10k ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2       13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2       77.0 ± 0%      77.0 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-2                   371 ± 0%       371 ± 0%     ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                3.34k ± 0%     3.34k ± 0%     ~     (all equal)
ForceCWandForceCCW/0-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/0#01-2                                       3.00 ± 0%      3.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/1-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/1#01-2                                       3.00 ± 0%      3.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/2-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/2#01-2                                       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/3-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/3#01-2                                       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/4-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/4#01-2                                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/5-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/5#01-2                                       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
ForceCWandForceCCW/6-2                                          0.00           0.00          ~     (all equal)
ForceCWandForceCCW/6#01-2                                       12.0 ± 0%      12.0 ± 0%     ~     (all equal)
EnvelopeTransformXY-2                                           0.00           0.00          ~     (all equal)
WKBParse/0-2                                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/1-2                                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/2-2                                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/3-2                                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/4-2                                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
WKBParse/5-2                                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
WKBParse/6-2                                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
WKBParse/7-2                                                    6.00 ± 0%      6.00 ± 0%     ~     (all equal)
WKBParse/8-2                                                    7.00 ± 0%      7.00 ± 0%     ~     (all equal)
WKBParse/9-2                                                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/10-2                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/11-2                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/12-2                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
WKBParse/13-2                                                   8.00 ± 0%      8.00 ± 0%     ~     (all equal)
WKBParse/14-2                                                   8.00 ± 0%      8.00 ± 0%     ~     (all equal)
WKBParse/15-2                                                   8.00 ± 0%      8.00 ± 0%     ~     (all equal)
WKBParse/16-2                                                   9.00 ± 0%      9.00 ± 0%     ~     (all equal)
WKBParse/17-2                                                   8.00 ± 0%      8.00 ± 0%     ~     (all equal)
WKBParse/18-2                                                   9.00 ± 0%      9.00 ± 0%     ~     (all equal)
WKBParse/19-2                                                   9.00 ± 0%      9.00 ± 0%     ~     (all equal)
WKBParse/20-2                                                   9.00 ± 0%      9.00 ± 0%     ~     (all equal)
WKBParse/21-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/22-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/23-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/24-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/25-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
WKBParse/26-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
WKBParse/27-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
WKBParse/28-2                                                   16.0 ± 0%      16.0 ± 0%     ~     (all equal)
WKBParse/29-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/30-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/31-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/32-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/33-2                                                   9.00 ± 0%      9.00 ± 0%     ~     (all equal)
WKBParse/34-2                                                   10.0 ± 0%      10.0 ± 0%     ~     (all equal)
WKBParse/35-2                                                   10.0 ± 0%      10.0 ± 0%     ~     (all equal)
WKBParse/36-2                                                   10.0 ± 0%      10.0 ± 0%     ~     (all equal)
WKBParse/37-2                                                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
WKBParse/38-2                                                   13.0 ± 0%      13.0 ± 0%     ~     (all equal)
WKBParse/39-2                                                   13.0 ± 0%      13.0 ± 0%     ~     (all equal)
WKBParse/40-2                                                   13.0 ± 0%      13.0 ± 0%     ~     (all equal)
WKBParse/41-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/42-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/43-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/44-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/45-2                                                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
WKBParse/46-2                                                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
WKBParse/47-2                                                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
WKBParse/48-2                                                   12.0 ± 0%      12.0 ± 0%     ~     (all equal)
WKBParse/49-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
WKBParse/50-2                                                   16.0 ± 0%      16.0 ± 0%     ~     (all equal)
WKBParse/51-2                                                   16.0 ± 0%      16.0 ± 0%     ~     (all equal)
WKBParse/52-2                                                   16.0 ± 0%      16.0 ± 0%     ~     (all equal)
WKBParse/53-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/54-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/55-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/56-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/57-2                                                   25.0 ± 0%      25.0 ± 0%     ~     (all equal)
WKBParse/58-2                                                   25.0 ± 0%      25.0 ± 0%     ~     (all equal)
WKBParse/59-2                                                   25.0 ± 0%      25.0 ± 0%     ~     (all equal)
WKBParse/60-2                                                   26.0 ± 0%      26.0 ± 0%     ~     (all equal)
WKBParse/61-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/62-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/63-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/64-2                                                   4.00 ± 0%      4.00 ± 0%     ~     (all equal)
WKBParse/65-2                                                   14.0 ± 0%      14.0 ± 0%     ~     (all equal)
WKBParse/66-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
WKBParse/67-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
WKBParse/68-2                                                   15.0 ± 0%      15.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:arm64
IntersectionWithoutValidation/n=10-2                            48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=100-2                           48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=1000-2                          48.0 ± 0%      48.0 ± 0%     ~     (all equal)
IntersectionWithoutValidation/n=10000-2                         48.0 ± 0%      48.0 ± 0%     ~     (all equal)
NoOp/n=10-2                                                     33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=100-2                                                    33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=1000-2                                                   33.0 ± 0%      33.0 ± 0%     ~     (all equal)
NoOp/n=10000-2                                                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:arm64
LineStringIsSimpleCircle/n=10-2                                 7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=100-2                                71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=1000-2                                343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleCircle/n=10000-2                             5.46k ± 0%     5.46k ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10-2                                   7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/100-2                                  71.0 ± 0%      71.0 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/1000-2                                  343 ± 0%       343 ± 0%     ~     (all equal)
LineStringIsSimpleZigZag/10000-2                               5.46k ± 0%     5.46k ± 0%     ~     (all equal)
SetOperation/n=4/Go_Intersection-2                               272 ± 0%       268 ± 0%   -1.47%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference-2                                 276 ± 0%       272 ± 0%   -1.45%  (p=0.000 n=15+15)
SetOperation/n=4/Go_SymmetricDifference-2                        374 ± 0%       370 ± 0%   -1.07%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union-2                                      283 ± 0%       279 ± 0%   -1.41%  (p=0.000 n=15+15)
SetOperation/n=4/GEOS_Intersection-2                            52.0 ± 0%      52.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Difference-2                              55.0 ± 0%      55.0 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-2                      146 ± 0%       146 ± 0%     ~     (all equal)
SetOperation/n=4/GEOS_Union-2                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/Go_Intersection-2                               288 ± 0%       284 ± 0%   -1.30%  (p=0.000 n=13+15)
SetOperation/n=8/Go_Difference-2                                 289 ± 0%       285 ± 0%   -1.38%  (p=0.000 n=12+12)
SetOperation/n=8/Go_SymmetricDifference-2                        383 ± 0%       379 ± 0%   -1.13%  (p=0.000 n=15+13)
SetOperation/n=8/Go_Union-2                                      294 ± 0%       290 ± 0%   -1.36%  (p=0.000 n=12+13)
SetOperation/n=8/GEOS_Intersection-2                            56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Difference-2                              56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-2                      143 ± 0%       143 ± 0%     ~     (all equal)
SetOperation/n=8/GEOS_Union-2                                   56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/Go_Intersection-2                              302 ± 0%       296 ± 0%   -1.99%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Difference-2                                312 ± 0%       306 ± 0%   -1.92%  (p=0.000 n=15+15)
SetOperation/n=16/Go_SymmetricDifference-2                       419 ± 0%       413 ± 0%   -1.43%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Union-2                                     321 ± 0%       315 ± 0%   -1.87%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Intersection-2                           56.0 ± 0%      56.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Difference-2                             64.0 ± 0%      64.0 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-2                     169 ± 0%       169 ± 0%     ~     (all equal)
SetOperation/n=16/GEOS_Union-2                                  68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/Go_Intersection-2                              353 ± 0%       347 ± 0%   -1.70%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Difference-2                                359 ± 0%       353 ± 0%   -1.67%  (p=0.000 n=15+15)
SetOperation/n=32/Go_SymmetricDifference-2                       491 ± 0%       485 ± 0%   -1.22%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Union-2                                     364 ± 0%       358 ± 0%   -1.65%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Intersection-2                           68.0 ± 0%      68.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Difference-2                             72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-2                     189 ± 0%       189 ± 0%     ~     (all equal)
SetOperation/n=32/GEOS_Union-2                                  72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/Go_Intersection-2                              394 ± 0%       388 ± 0%   -1.52%  (p=0.000 n=15+15)
SetOperation/n=64/Go_Difference-2                                428 ± 0%       422 ± 0%   -1.40%  (p=0.000 n=15+15)
SetOperation/n=64/Go_SymmetricDifference-2                       675 ± 0%       669 ± 0%   -0.89%  (p=0.000 n=14+15)
SetOperation/n=64/Go_Union-2                                     441 ± 0%       435 ± 0%   -1.36%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Intersection-2                           72.0 ± 0%      72.0 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Difference-2                              104 ± 0%       104 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-2                     335 ± 0%       335 ± 0%     ~     (all equal)
SetOperation/n=64/GEOS_Union-2                                   112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/Go_Intersection-2                             568 ± 0%       562 ± 0%   -1.06%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Difference-2                               594 ± 0%       588 ± 0%   -1.01%  (p=0.000 n=15+15)
SetOperation/n=128/Go_SymmetricDifference-2                      920 ± 0%       914 ± 0%   -0.65%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Union-2                                    599 ± 0%       593 ± 0%   -1.00%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Intersection-2                           112 ± 0%       112 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Difference-2                             136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-2                    457 ± 0%       457 ± 0%     ~     (all equal)
SetOperation/n=128/GEOS_Union-2                                  136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/Go_Intersection-2                             727 ± 0%       721 ± 0%   -0.83%  (p=0.000 n=14+15)
SetOperation/n=256/Go_Difference-2                               857 ± 0%       851 ± 0%   -0.70%  (p=0.000 n=15+15)
SetOperation/n=256/Go_SymmetricDifference-2                    1.58k ± 0%     1.57k ± 0%   -0.38%  (p=0.000 n=14+14)
SetOperation/n=256/Go_Union-2                                    886 ± 0%       880 ± 0%   -0.68%  (p=0.000 n=15+15)
SetOperation/n=256/GEOS_Intersection-2                           136 ± 0%       136 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Difference-2                             264 ± 0%       264 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-2                    969 ± 0%       969 ± 0%     ~     (all equal)
SetOperation/n=256/GEOS_Union-2                                  288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/Go_Intersection-2                           1.40k ± 0%     1.39k ± 0%   -0.43%  (p=0.000 n=13+15)
SetOperation/n=512/Go_Difference-2                             1.50k ± 0%     1.50k ± 0%   -0.38%  (p=0.000 n=13+15)
SetOperation/n=512/Go_SymmetricDifference-2                    2.62k ± 0%     2.61k ± 0%   -0.23%  (p=0.000 n=14+14)
SetOperation/n=512/Go_Union-2                                  1.51k ± 0%     1.50k ± 0%   -0.40%  (p=0.000 n=12+14)
SetOperation/n=512/GEOS_Intersection-2                           288 ± 0%       288 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Difference-2                             392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-2                  1.48k ± 0%     1.48k ± 0%     ~     (all equal)
SetOperation/n=512/GEOS_Union-2                                  392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/Go_Intersection-2                          2.02k ± 0%     2.02k ± 0%   -0.30%  (p=0.000 n=14+14)
SetOperation/n=1024/Go_Difference-2                            2.54k ± 0%     2.53k ± 0%   -0.24%  (p=0.000 n=14+14)
SetOperation/n=1024/Go_SymmetricDifference-2                   5.18k ± 0%     5.18k ± 0%   -0.12%  (p=0.000 n=13+14)
SetOperation/n=1024/Go_Union-2                                 2.63k ± 0%     2.63k ± 0%   -0.23%  (p=0.000 n=13+14)
SetOperation/n=1024/GEOS_Intersection-2                          392 ± 0%       392 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Difference-2                            904 ± 0%       904 ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-2                 3.52k ± 0%     3.52k ± 0%     ~     (all equal)
SetOperation/n=1024/GEOS_Union-2                                 992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/Go_Intersection-2                          4.68k ± 0%     4.68k ± 0%   -0.13%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Difference-2                            5.11k ± 0%     5.10k ± 0%   -0.12%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference-2                   9.29k ± 0%     9.28k ± 0%   -0.06%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Union-2                                 5.11k ± 0%     5.11k ± 0%   -0.12%  (p=0.000 n=14+14)
SetOperation/n=2048/GEOS_Intersection-2                          992 ± 0%       992 ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Difference-2                          1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-2                 5.58k ± 0%     5.58k ± 0%     ~     (all equal)
SetOperation/n=2048/GEOS_Union-2                               1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/Go_Intersection-2                          7.17k ± 0%     7.16k ± 0%   -0.08%  (p=0.000 n=14+14)
SetOperation/n=4096/Go_Difference-2                            9.21k ± 0%     9.21k ± 0%   -0.07%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-2                   19.5k ± 0%     19.5k ± 0%   -0.03%  (p=0.000 n=14+14)
SetOperation/n=4096/Go_Union-2                                 9.56k ± 0%     9.56k ± 0%   -0.06%  (p=0.000 n=15+15)
SetOperation/n=4096/GEOS_Intersection-2                        1.42k ± 0%     1.42k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Difference-2                          3.46k ± 0%     3.46k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-2                 13.8k ± 0%     13.8k ± 0%     ~     (all equal)
SetOperation/n=4096/GEOS_Union-2                               3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/Go_Intersection-2                          17.8k ± 0%     17.8k ± 0%   -0.03%  (p=0.000 n=14+14)
SetOperation/n=8192/Go_Difference-2                            19.5k ± 0%     19.5k ± 0%   -0.03%  (p=0.000 n=13+12)
SetOperation/n=8192/Go_SymmetricDifference-2                   35.9k ± 0%     35.9k ± 0%   -0.02%  (p=0.000 n=13+12)
SetOperation/n=8192/Go_Union-2                                 19.5k ± 0%     19.5k ± 0%   -0.03%  (p=0.000 n=13+13)
SetOperation/n=8192/GEOS_Intersection-2                        3.81k ± 0%     3.81k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Difference-2                          5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-2                 22.0k ± 0%     22.0k ± 0%     ~     (all equal)
SetOperation/n=8192/GEOS_Union-2                               5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/Go_Intersection-2                         27.7k ± 0%     27.7k ± 0%   -0.02%  (p=0.000 n=12+12)
SetOperation/n=16384/Go_Difference-2                           35.9k ± 0%     35.9k ± 0%   -0.02%  (p=0.000 n=13+13)
SetOperation/n=16384/Go_SymmetricDifference-2                  76.9k ± 0%     76.9k ± 0%   -0.01%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Union-2                                37.2k ± 0%     37.2k ± 0%   -0.02%  (p=0.000 n=15+15)
SetOperation/n=16384/GEOS_Intersection-2                       5.51k ± 0%     5.51k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Difference-2                         13.7k ± 0%     13.7k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-2                54.7k ± 0%     54.7k ± 0%     ~     (all equal)
SetOperation/n=16384/GEOS_Union-2                              15.1k ± 0%     15.1k ± 0%     ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:arm64
Delete/n=100-2                                                  65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Delete/n=1000-2                                                  480 ± 0%       480 ± 0%     ~     (all equal)
Delete/n=10000-2                                               7.62k ± 0%     7.62k ± 0%     ~     (all equal)
Bulk/n=10-2                                                     6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Bulk/n=100-2                                                    70.0 ± 0%      70.0 ± 0%     ~     (all equal)
Bulk/n=1000-2                                                    342 ± 0%       342 ± 0%     ~     (all equal)
Bulk/n=10000-2                                                 5.46k ± 0%     5.46k ± 0%     ~     (all equal)
Bulk/n=100000-2                                                71.0k ± 0%     71.0k ± 0%     ~     (all equal)
Insert/n=10-2                                                   5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Insert/n=100-2                                                  47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Insert/n=1000-2                                                  457 ± 0%       457 ± 0%     ~     (all equal)
Insert/n=10000-2                                               4.65k ± 0%     4.65k ± 0%     ~     (all equal)
Insert/n=100000-2                                              46.8k ± 0%     46.8k ± 0%     ~     (all equal)
RangeSearch/n=10-2                                              0.00           0.00          ~     (all equal)
RangeSearch/n=100-2                                             0.00           0.00          ~     (all equal)
RangeSearch/n=1000-2                                            0.00           0.00          ~     (all equal)
RangeSearch/n=10000-2                                           0.00           0.00          ~     (all equal)
RangeSearch/n=100000-2                                          0.00           0.00          ~     (all equal)

```

</details>