### PR TITLE
Simplify DCEL label management

### DIFF
--- a/geom/alg_set_op.go
+++ b/geom/alg_set_op.go
@@ -13,7 +13,7 @@ func Union(a, b Geometry) (Geometry, error) {
 	if b.IsEmpty() {
 		return a, nil
 	}
-	g, err := setOp(a, b, selectUnion)
+	g, err := setOp(a, or, b)
 	return g, wrap(err, "executing union")
 }
 
@@ -24,7 +24,7 @@ func Intersection(a, b Geometry) (Geometry, error) {
 	if a.IsEmpty() || b.IsEmpty() {
 		return Geometry{}, nil
 	}
-	g, err := setOp(a, b, selectIntersection)
+	g, err := setOp(a, and, b)
 	return g, wrap(err, "executing intersection")
 }
 
@@ -38,7 +38,7 @@ func Difference(a, b Geometry) (Geometry, error) {
 	if b.IsEmpty() {
 		return a, nil
 	}
-	g, err := setOp(a, b, selectDifference)
+	g, err := setOp(a, andNot, b)
 	return g, wrap(err, "executing difference")
 }
 
@@ -55,11 +55,11 @@ func SymmetricDifference(a, b Geometry) (Geometry, error) {
 	if b.IsEmpty() {
 		return a, nil
 	}
-	g, err := setOp(a, b, selectSymmetricDifference)
+	g, err := setOp(a, xor, b)
 	return g, wrap(err, "executing symmetric difference")
 }
 
-func setOp(a, b Geometry, include func([2]label) bool) (Geometry, error) {
+func setOp(a Geometry, include func([2]bool) bool, b Geometry) (Geometry, error) {
 	overlay, err := createOverlay(a, b)
 	if err != nil {
 		return Geometry{}, wrap(err, "internal error creating overlay")
@@ -71,3 +71,8 @@ func setOp(a, b Geometry, include func([2]label) bool) (Geometry, error) {
 	}
 	return g, nil
 }
+
+func or(b [2]bool) bool     { return b[0] || b[1] }
+func and(b [2]bool) bool    { return b[0] && b[1] }
+func xor(b [2]bool) bool    { return b[0] != b[1] }
+func andNot(b [2]bool) bool { return b[0] && !b[1] }

--- a/geom/alg_set_op_test.go
+++ b/geom/alg_set_op_test.go
@@ -1082,6 +1082,7 @@ func TestBinaryOp(t *testing.T) {
 			input1: "POINT(0 0)",
 			input2: "POINT(0 0)",
 			relate: "0FFFFFFF2",
+			union:  "POINT(0 0)",
 		},
 		{
 			input1: "GEOMETRYCOLLECTION(POINT(0 0))",

--- a/geom/dcel_extract_intersection_matrix.go
+++ b/geom/dcel_extract_intersection_matrix.go
@@ -21,29 +21,25 @@ func (d *doublyConnectedEdgeList) extractIntersectionMatrix() matrix {
 }
 
 func (f *faceRecord) location(operand operand) imLocation {
-	assertPresence(f.labels)
-	if !f.labels[operand].inSet {
+	if !f.inSet[operand] {
 		return imExterior
 	}
 	return imInterior
 }
 
 func (e *halfEdgeRecord) location(operand operand) imLocation {
-	assertPresence(e.edgeLabels)
-
-	if !e.edgeLabels[operand].inSet {
-		return imExterior
+	face1Present := e.incident.inSet[operand]
+	face2Present := e.twin.incident.inSet[operand]
+	if face1Present && face2Present {
+		return imInterior
 	}
-
-	assertPresence(e.incident.labels)
-	assertPresence(e.twin.incident.labels)
-
-	face1Present := e.incident.labels[operand].inSet
-	face2Present := e.twin.incident.labels[operand].inSet
 	if face1Present != face2Present {
 		return imBoundary
 	}
-	return imInterior
+	if e.inSet[operand] {
+		return imInterior
+	}
+	return imExterior
 }
 
 func (v *vertexRecord) location(operand operand) imLocation {

--- a/geom/dcel_label.go
+++ b/geom/dcel_label.go
@@ -1,7 +1,5 @@
 package geom
 
-import "fmt"
-
 // operand represents either the first (A) or second (B) geometry in a binary
 // operation (such as Union or Covers).
 type operand int
@@ -11,40 +9,14 @@ const (
 	operandB operand = 1
 )
 
-type label struct {
-	// Set to true once inSet has a valid value.
-	populated bool
-
-	// Indicates whether the thing being labelled is in a set or not (context
-	// specific to how the label is used).
-	inSet bool
+func forEachOperand(fn func(operand operand)) {
+	fn(operandA)
+	fn(operandB)
 }
 
-func newUnpopulatedLabels() [2]label {
-	return [2]label{}
-}
-
-func newHalfPopulatedLabels(operand operand, inSet bool) [2]label {
-	var labels [2]label
-	labels[operand].populated = true
-	labels[operand].inSet = inSet
-	return labels
-}
-
-func newPopulatedLabels(inSet bool) [2]label {
-	var labels [2]label
-	labels[0].populated = true
-	labels[1].populated = true
-	labels[0].inSet = inSet
-	labels[1].inSet = inSet
-	return labels
-}
-
-func mergeLabels(dst *[2]label, src [2]label) {
-	dst[0].populated = dst[0].populated || src[0].populated
-	dst[1].populated = dst[1].populated || src[1].populated
-	dst[0].inSet = dst[0].inSet || src[0].inSet
-	dst[1].inSet = dst[1].inSet || src[1].inSet
+func mergeBools(dst *[2]bool, src [2]bool) {
+	dst[0] = dst[0] || src[0]
+	dst[1] = dst[1] || src[1]
 }
 
 type location struct {
@@ -63,30 +35,4 @@ func newLocationsOnBoundary(operand operand) [2]location {
 	var locs [2]location
 	locs[operand].boundary = true
 	return locs
-}
-
-func assertPresence(labels [2]label) {
-	if !labels[0].populated || !labels[1].populated {
-		panic(fmt.Sprintf("all presence flags in labels not set: %v", labels))
-	}
-}
-
-func selectUnion(labels [2]label) bool {
-	assertPresence(labels)
-	return labels[0].inSet || labels[1].inSet
-}
-
-func selectIntersection(labels [2]label) bool {
-	assertPresence(labels)
-	return labels[0].inSet && labels[1].inSet
-}
-
-func selectDifference(labels [2]label) bool {
-	assertPresence(labels)
-	return labels[0].inSet && !labels[1].inSet
-}
-
-func selectSymmetricDifference(labels [2]label) bool {
-	assertPresence(labels)
-	return labels[0].inSet != labels[1].inSet
 }

--- a/geom/dcel_overlay.go
+++ b/geom/dcel_overlay.go
@@ -30,14 +30,15 @@ func (d *doublyConnectedEdgeList) overlay(other *doublyConnectedEdgeList) {
 	d.overlayEdges(other)
 	d.fixVertices()
 	d.reAssignFaces()
-	d.fixLabels()
+	d.populateInSetLabels()
 }
 
 func (d *doublyConnectedEdgeList) overlayVertices(other *doublyConnectedEdgeList) {
 	for xy, otherVert := range other.vertices {
 		vert, ok := d.vertices[xy]
 		if ok {
-			mergeLabels(&vert.labels, otherVert.labels)
+			mergeBools(&vert.src, otherVert.src)
+			mergeBools(&vert.inSet, otherVert.inSet)
 			mergeLocations(&vert.locations, otherVert.locations)
 		} else {
 			d.vertices[xy] = otherVert
@@ -69,8 +70,9 @@ func (d *doublyConnectedEdgeList) overlayEdges(other *doublyConnectedEdgeList) {
 
 	for _, e := range other.halfEdges {
 		if existing, ok := edges.lookupEdge(e); ok {
-			mergeLabels(&existing.edgeLabels, e.edgeLabels)
-			mergeLabels(&existing.faceLabels, e.faceLabels)
+			mergeBools(&existing.srcEdge, e.srcEdge)
+			mergeBools(&existing.srcFace, e.srcFace)
+			mergeBools(&existing.inSet, e.inSet)
 		} else {
 			edges.insertEdge(e)
 			e.origin = d.vertices[e.origin.coords]
@@ -129,67 +131,52 @@ func (d *doublyConnectedEdgeList) reAssignFaces() {
 	d.faces = nil
 	for _, cycle := range cycles {
 		f := &faceRecord{
-			cycle:  cycle,
-			labels: [2]label{}, // populated below
+			cycle: cycle,
 		}
 		d.faces = append(d.faces, f)
 		forEachEdge(cycle, func(e *halfEdgeRecord) {
-			mergeLabels(&f.labels, e.faceLabels)
+			forEachOperand(func(operand operand) {
+				if e.srcFace[operand] {
+					f.inSet[operand] = true
+				}
+			})
 			e.incident = f
 		})
 	}
+
+	// Populate inSet for faces that did not have edges from their respective
+	// input geometries.
+	forEachOperand(func(operand operand) {
+		visited := make(map[*faceRecord]bool)
+		var dfs func(*faceRecord)
+		dfs = func(f *faceRecord) {
+			if visited[f] {
+				return
+			}
+			visited[f] = true
+			forEachEdge(f.cycle, func(e *halfEdgeRecord) {
+				if !e.srcFace[operand] {
+					e.twin.incident.inSet[operand] = true
+					dfs(e.twin.incident)
+				}
+			})
+		}
+		for _, f := range d.faces {
+			if f.inSet[operand] {
+				dfs(f)
+			}
+		}
+	})
 
 	// If we couldn't find any cycles, then we wouldn't have constructed any
 	// faces. This happens in the case where there are only point geometries.
 	// We need to artificially create an infinite face.
 	if len(d.faces) == 0 {
 		d.faces = append(d.faces, &faceRecord{
-			cycle:  nil,
-			labels: newPopulatedLabels(false),
+			cycle: nil,
+			inSet: [2]bool{},
 		})
 	}
-
-	for _, face := range d.faces {
-		d.completePartialFaceLabel(face)
-	}
-}
-
-// completePartialFaceLabel checks to see if the face label for the given face
-// is complete (i.e. contains a part for both A and B). If it's not complete,
-// then in searches adjacent faces until it finds a face that it can copy the
-// missing part of the label from. This situation occurs whenever a face in the
-// overlay DCEL doesn't have any edges from one of the original geometries.
-func (d *doublyConnectedEdgeList) completePartialFaceLabel(face *faceRecord) {
-	labelIsComplete := func() bool {
-		return face.labels[0].populated && face.labels[1].populated
-	}
-	if labelIsComplete() {
-		return
-	}
-	expanded := make(map[*faceRecord]bool)
-	stack := []*faceRecord{face}
-	for len(stack) > 0 {
-		popped := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		adjacent := adjacentFaces(popped)
-		expanded[popped] = true
-		for _, adj := range adjacent {
-			face.labels = completeLabels(face.labels, adj.labels)
-			if labelIsComplete() {
-				return
-			}
-			if !expanded[adj] {
-				stack = append(stack, adj)
-			}
-		}
-	}
-
-	// It's possible that we're still missing part of the face label. This
-	// could happen if one of the inputs is a Point/MultiPoint input because
-	// its associated ghost lines would not add to the label pool. We can
-	// safely fill in the presence bits for this case.
-	face.labels[0].populated = true
-	face.labels[1].populated = true
 }
 
 // adjacentFaces finds all of the faces that adjacent to f.
@@ -206,36 +193,18 @@ func adjacentFaces(f *faceRecord) []*faceRecord {
 	return adjacent
 }
 
-// completeLabels copies any missing portion (part A or part B) of the label
-// from donor to recipient, and then returns recipient.
-func completeLabels(recipient, donor [2]label) [2]label {
-	for i := 0; i < 2; i++ {
-		if !recipient[i].populated && donor[i].populated {
-			recipient[i].populated = true
-			recipient[i].inSet = donor[i].inSet
-		}
-	}
-	return recipient
-}
-
-// fixLabels updates edge and vertex labels after performing an overlay.
-func (d *doublyConnectedEdgeList) fixLabels() {
+// populateInSetLabels populates the inSet labels for edges and vertices.
+func (d *doublyConnectedEdgeList) populateInSetLabels() {
 	for _, e := range d.halfEdges {
 		// Copy labels from incident faces into edge since the edge represents
 		// the (closed) border of the face.
-		mergeLabels(&e.edgeLabels, e.incident.labels)
-		mergeLabels(&e.edgeLabels, e.twin.incident.labels)
-
-		// If we haven't seen an edge label yet for one of the two input
-		// geometries, we can assume that we'll never see it. So we mark off
-		// that side as having the bit populated.
-		e.edgeLabels[0].populated = true
-		e.edgeLabels[1].populated = true
+		e.inSet[0] = e.srcEdge[0] || e.incident.inSet[0] || e.twin.incident.inSet[0]
+		e.inSet[1] = e.srcEdge[1] || e.incident.inSet[1] || e.twin.incident.inSet[1]
 
 		// Copy edge labels onto the labels of adjacent vertices. This is
 		// because the vertices represent the endpoints of the edges, and
 		// should have at least those bits set.
-		mergeLabels(&e.origin.labels, e.edgeLabels)
-		mergeLabels(&e.origin.labels, e.prev.edgeLabels)
+		e.origin.inSet[0] = e.origin.src[0] || e.inSet[0] || e.prev.inSet[0]
+		e.origin.inSet[1] = e.origin.src[1] || e.inSet[1] || e.prev.inSet[1]
 	}
 }

--- a/geom/dcel_overlay.go
+++ b/geom/dcel_overlay.go
@@ -195,16 +195,21 @@ func adjacentFaces(f *faceRecord) []*faceRecord {
 
 // populateInSetLabels populates the inSet labels for edges and vertices.
 func (d *doublyConnectedEdgeList) populateInSetLabels() {
+	for _, v := range d.vertices {
+		forEachOperand(func(op operand) {
+			v.inSet[op] = v.src[op]
+		})
+	}
 	for _, e := range d.halfEdges {
-		// Copy labels from incident faces into edge since the edge represents
-		// the (closed) border of the face.
-		e.inSet[0] = e.srcEdge[0] || e.incident.inSet[0] || e.twin.incident.inSet[0]
-		e.inSet[1] = e.srcEdge[1] || e.incident.inSet[1] || e.twin.incident.inSet[1]
+		forEachOperand(func(op operand) {
+			// Copy labels from incident faces into edge since the edge
+			// represents the (closed) border of the face.
+			e.inSet[op] = e.srcEdge[op] || e.incident.inSet[op] || e.twin.incident.inSet[op]
 
-		// Copy edge labels onto the labels of adjacent vertices. This is
-		// because the vertices represent the endpoints of the edges, and
-		// should have at least those bits set.
-		e.origin.inSet[0] = e.origin.src[0] || e.inSet[0] || e.prev.inSet[0]
-		e.origin.inSet[1] = e.origin.src[1] || e.inSet[1] || e.prev.inSet[1]
+			// Copy edge labels onto the labels of adjacent vertices. This is
+			// because the vertices represent the endpoints of the edges, and
+			// should have at least those bits set.
+			e.origin.inSet[op] = e.origin.inSet[op] || e.inSet[op] || e.prev.inSet[op]
+		})
 	}
 }


### PR DESCRIPTION
## Description

commit 45ccc4bdfc05aa867cdddaa2061dd8da79c4de83
Author: Peter Stace <peterstace@gmail.com>
Date:   Mon Nov 7 20:19:20 2022 +1100

    Simplify DCEL label management
    
    In the DCEL data structure, there are labels on the vertex records,
    (half) edge records, and face records. These labels keep track
    information such as which input geometry the record originates from and
    whether it will appear in the output geometry.
    
    The original approach to labelling was to use the same data structure
    for all record types. The label had two booleans per operand.  The first
    boolean determined whether the record would appear in the final output,
    and the second boolean would show whether the first boolean was
    populated or not. This was essentially tri-state logic. The trouble with
    this approach was that the DCEL algorithm doesn't know whether each
    record should appear in the output geometry right up until the last
    stage. The labels are used in the earlier stages of the algorithm to
    record other facts, such as whether or not the records appear in the
    input geometry. The semantics of the fields subtly change over the
    course of the algorithm, making the code hard to understand and
    maintain.
    
    The new approach (implemented by this PR) changes how label management
    is performed. Instead of having a single labels data structure, the
    fields are slightly different for vertex, edge, and face records. This
    is to account for the differences in information available when
    processing vertexes vs. edges vs. faces. The number of fields is also
    expanded, so that concepts like "is this record explicitly present in
    the input geometry's control points" are separate from concepts like "is
    this record present in the input geometry but not explicitly in its
    control points". The populated fields are also removed, and tracked
    separately in each algorithm that modifies the labels.

## Check List

Have you:

- Added unit tests? No, relies on existing.

- Add cmprefimpl tests? (if appropriate?) No, relies on existing.

- Updated release notes? (if appropriate?) No, relies on existing.

## Related Issue

- N/A

## Benchmark Results

- No significant changes.

<details>

<summary>Click to expand</summary>

```
name                                                        old time/op    new time/op    delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:arm64
LineEnvelope/0-2                                              2.22ns ±10%    2.25ns ± 8%    ~     (p=0.361 n=15+15)
LineEnvelope/1-2                                              2.17ns ± 6%    2.18ns ± 5%    ~     (p=0.720 n=15+15)
LineEnvelope/2-2                                              2.13ns ± 3%    2.14ns ± 6%    ~     (p=0.710 n=14+13)
LineEnvelope/3-2                                              2.14ns ± 4%    2.14ns ± 6%    ~     (p=0.442 n=15+14)
MarshalWKB/polygon/n=10-2                                     93.3ns ± 4%    92.3ns ± 1%    ~     (p=0.054 n=14+14)
MarshalWKB/polygon/n=100-2                                     237ns ± 4%     237ns ± 6%    ~     (p=0.847 n=15+14)
MarshalWKB/polygon/n=1000-2                                   1.63µs ±19%    1.60µs ±12%    ~     (p=0.949 n=15+14)
MarshalWKB/polygon/n=10000-2                                  40.4µs ±79%    37.7µs ±76%    ~     (p=0.713 n=15+15)
UnmarshalWKB/polygon/n=10-2                                    156ns ± 1%     157ns ± 1%  +0.73%  (p=0.012 n=13+13)
UnmarshalWKB/polygon/n=100-2                                   297ns ± 6%     300ns ± 8%    ~     (p=0.591 n=14+15)
UnmarshalWKB/polygon/n=1000-2                                 1.80µs ± 9%    1.79µs ±10%    ~     (p=0.616 n=15+15)
UnmarshalWKB/polygon/n=10000-2                                42.2µs ±49%    41.0µs ±73%    ~     (p=0.744 n=15+15)
IntersectsLineStringWithLineString/n=10-2                      765ns ± 2%     767ns ± 4%    ~     (p=0.856 n=15+14)
IntersectsLineStringWithLineString/n=100-2                    11.8µs ± 1%    11.9µs ± 4%    ~     (p=0.611 n=14+14)
IntersectsLineStringWithLineString/n=1000-2                    149µs ±15%     153µs ±22%    ~     (p=0.838 n=15+15)
IntersectsLineStringWithLineString/n=10000-2                  3.28ms ±39%    3.36ms ±38%    ~     (p=0.747 n=14+15)
IntersectsMultiPointWithMultiPoint/n=20-2                      555ns ± 1%     553ns ± 1%  -0.47%  (p=0.007 n=14+12)
IntersectsMultiPointWithMultiPoint/n=200-2                    7.54µs ± 1%    7.53µs ± 0%    ~     (p=0.610 n=14+14)
IntersectsMultiPointWithMultiPoint/n=2000-2                   71.2µs ± 1%    71.6µs ± 3%    ~     (p=0.935 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000-2                   779µs ± 0%     781µs ± 1%    ~     (p=0.949 n=15+14)
PolygonSingleRingValidation/n=10-2                            1.27µs ± 1%    1.27µs ± 1%    ~     (p=0.273 n=13+14)
PolygonSingleRingValidation/n=100-2                           19.1µs ± 1%    19.1µs ± 1%    ~     (p=0.786 n=15+13)
PolygonSingleRingValidation/n=1000-2                           282µs ± 0%     282µs ± 1%    ~     (p=0.621 n=14+15)
PolygonSingleRingValidation/n=10000-2                         4.79ms ±22%    4.60ms ±13%    ~     (p=0.454 n=14+14)
PolygonMultipleRingsValidation/n=4-2                          3.65µs ± 2%    3.67µs ± 3%    ~     (p=0.691 n=15+15)
PolygonMultipleRingsValidation/n=36-2                         30.6µs ± 3%    30.5µs ± 1%    ~     (p=0.335 n=14+14)
PolygonMultipleRingsValidation/n=400-2                         404µs ± 3%     403µs ± 4%    ~     (p=0.325 n=14+13)
PolygonMultipleRingsValidation/n=4096-2                       5.16ms ± 1%    5.17ms ± 1%    ~     (p=0.910 n=14+14)
PolygonZigZagRingsValidation/n=10-2                           6.11µs ± 1%    6.11µs ± 1%    ~     (p=0.725 n=15+13)
PolygonZigZagRingsValidation/n=100-2                          73.6µs ± 1%    73.4µs ± 1%    ~     (p=0.150 n=14+14)
PolygonZigZagRingsValidation/n=1000-2                          983µs ± 5%     984µs ± 5%    ~     (p=0.701 n=14+14)
PolygonZigZagRingsValidation/n=10000-2                        16.7ms ±22%    16.5ms ±24%    ~     (p=0.652 n=15+14)
PolygonAnnulusValidation/n=10-2                               1.97µs ± 1%    1.98µs ± 3%    ~     (p=0.315 n=14+15)
PolygonAnnulusValidation/n=100-2                              19.1µs ± 1%    19.1µs ± 1%    ~     (p=0.801 n=13+13)
PolygonAnnulusValidation/n=1000-2                              340µs ± 2%     340µs ± 2%    ~     (p=0.545 n=13+13)
PolygonAnnulusValidation/n=10000-2                            4.52ms ± 4%    4.53ms ± 7%    ~     (p=0.616 n=14+13)
MultipolygonValidation/n=1-2                                   217ns ± 1%     219ns ± 3%  +1.03%  (p=0.010 n=12+13)
MultipolygonValidation/n=4-2                                   488ns ± 2%     491ns ± 1%  +0.59%  (p=0.048 n=14+14)
MultipolygonValidation/n=16-2                                 2.14µs ± 2%    2.18µs ± 3%  +1.93%  (p=0.000 n=14+15)
MultipolygonValidation/n=64-2                                 10.3µs ± 1%    10.4µs ± 1%  +1.16%  (p=0.000 n=14+12)
MultipolygonValidation/n=256-2                                54.8µs ± 3%    55.9µs ± 3%  +1.92%  (p=0.001 n=14+13)
MultipolygonValidation/n=1024-2                                340µs ± 1%     341µs ± 1%    ~     (p=0.413 n=15+13)
MultiPolygonTwoCircles/n=10-2                                 1.93µs ± 2%    1.93µs ± 2%    ~     (p=0.334 n=14+14)
MultiPolygonTwoCircles/n=100-2                                23.0µs ± 3%    23.1µs ± 2%    ~     (p=0.616 n=13+14)
MultiPolygonTwoCircles/n=1000-2                                326µs ±27%     337µs ±40%    ~     (p=0.856 n=13+15)
MultiPolygonTwoCircles/n=10000-2                              4.81ms ±13%    5.08ms ±15%    ~     (p=0.126 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-2                      2.60µs ± 1%    2.60µs ± 1%    ~     (p=0.510 n=13+14)
MultiPolygonMultipleTouchingPoints/n=10-2                     20.9µs ± 1%    20.9µs ± 0%    ~     (p=0.205 n=12+13)
MultiPolygonMultipleTouchingPoints/n=100-2                     265µs ± 1%     262µs ± 2%  -1.11%  (p=0.001 n=13+14)
MultiPolygonMultipleTouchingPoints/n=1000-2                   3.29ms ± 3%    3.29ms ± 2%    ~     (p=0.614 n=13+13)
WKTParsing/point-2                                            1.13µs ± 1%    1.13µs ± 1%  -0.46%  (p=0.022 n=15+14)
DistancePolygonToPolygonOrdering/n=100_swap=false-2           26.9µs ± 3%    26.6µs ± 2%    ~     (p=0.256 n=15+14)
DistancePolygonToPolygonOrdering/n=100_swap=true-2            26.5µs ± 1%    26.5µs ± 1%    ~     (p=0.952 n=14+13)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2           462µs ± 1%     463µs ± 1%    ~     (p=0.110 n=13+12)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2            462µs ± 1%     462µs ± 1%    ~     (p=0.561 n=15+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2     3.26µs ± 4%    3.23µs ± 1%    ~     (p=0.319 n=14+13)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2      3.23µs ± 1%    3.23µs ± 1%    ~     (p=0.456 n=13+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2    34.7µs ± 2%    34.6µs ± 1%    ~     (p=0.458 n=14+13)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2     34.6µs ± 1%    35.0µs ± 3%    ~     (p=0.073 n=12+14)
MultiLineStringIsSimpleManyLineStrings/n=100-2                26.7µs ± 2%    26.8µs ± 2%    ~     (p=0.352 n=14+14)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                327µs ± 4%     326µs ± 2%    ~     (p=0.519 n=13+14)
ForceCWandForceCCW/0-2                                        16.7ns ±16%    16.7ns ± 8%    ~     (p=0.573 n=14+13)
ForceCWandForceCCW/0#01-2                                      101ns ± 2%     101ns ± 2%    ~     (p=0.637 n=12+11)
ForceCWandForceCCW/1-2                                        16.8ns ± 8%    16.7ns ± 6%    ~     (p=0.929 n=14+12)
ForceCWandForceCCW/1#01-2                                      101ns ± 2%     101ns ± 1%    ~     (p=0.340 n=13+12)
ForceCWandForceCCW/2-2                                        30.9ns ±10%    31.1ns ± 7%    ~     (p=0.921 n=12+12)
ForceCWandForceCCW/2#01-2                                      155ns ± 1%     155ns ± 1%    ~     (p=0.496 n=9+12)
ForceCWandForceCCW/3-2                                        30.9ns ± 6%    30.5ns ± 9%    ~     (p=0.164 n=13+12)
ForceCWandForceCCW/3#01-2                                      155ns ± 1%     156ns ± 3%    ~     (p=0.096 n=12+10)
ForceCWandForceCCW/4-2                                        45.2ns ± 8%    45.3ns ± 6%    ~     (p=0.524 n=15+12)
ForceCWandForceCCW/4#01-2                                      240ns ± 1%     241ns ± 2%    ~     (p=0.083 n=15+10)
ForceCWandForceCCW/5-2                                        44.2ns ± 7%    44.5ns ± 7%    ~     (p=0.502 n=14+12)
ForceCWandForceCCW/5#01-2                                      241ns ± 1%     240ns ± 0%    ~     (p=0.552 n=14+10)
ForceCWandForceCCW/6-2                                        63.5ns ± 5%    65.5ns ± 8%  +3.25%  (p=0.027 n=13+13)
ForceCWandForceCCW/6#01-2                                      389ns ± 3%     386ns ± 2%    ~     (p=0.135 n=13+13)
EnvelopeTransformXY-2                                          143ns ± 5%     143ns ± 7%    ~     (p=1.000 n=15+15)
WKBParse/0-2                                                   420ns ± 1%     421ns ± 1%    ~     (p=0.480 n=14+13)
WKBParse/1-2                                                   424ns ± 0%     416ns ± 0%  -1.96%  (p=0.000 n=13+13)
WKBParse/2-2                                                   490ns ± 1%     491ns ± 0%    ~     (p=0.303 n=13+13)
WKBParse/3-2                                                   480ns ± 1%     481ns ± 0%  +0.20%  (p=0.010 n=12+14)
WKBParse/4-2                                                   567ns ± 1%     568ns ± 1%    ~     (p=0.626 n=15+13)
WKBParse/5-2                                                   422ns ± 0%     422ns ± 0%  +0.20%  (p=0.011 n=13+13)
WKBParse/6-2                                                   486ns ± 1%     487ns ± 1%    ~     (p=0.079 n=14+14)
WKBParse/7-2                                                   485ns ± 1%     487ns ± 1%  +0.37%  (p=0.038 n=14+14)
WKBParse/8-2                                                   576ns ± 1%     577ns ± 0%    ~     (p=0.113 n=14+13)
WKBParse/9-2                                                   310ns ± 0%     313ns ± 2%  +0.67%  (p=0.001 n=12+13)
WKBParse/10-2                                                  312ns ± 1%     313ns ± 1%    ~     (p=0.243 n=14+13)
WKBParse/11-2                                                  312ns ± 1%     314ns ± 2%  +0.73%  (p=0.001 n=14+14)
WKBParse/12-2                                                  309ns ± 2%     310ns ± 1%  +0.36%  (p=0.036 n=15+14)
WKBParse/13-2                                                  593ns ± 1%     598ns ± 1%  +0.82%  (p=0.000 n=14+14)
WKBParse/14-2                                                  703ns ± 1%     704ns ± 1%    ~     (p=0.105 n=15+13)
WKBParse/15-2                                                  712ns ± 1%     713ns ± 0%    ~     (p=0.190 n=15+14)
WKBParse/16-2                                                  838ns ± 1%     838ns ± 0%    ~     (p=0.765 n=14+13)
WKBParse/17-2                                                  701ns ± 1%     704ns ± 1%  +0.41%  (p=0.011 n=13+15)
WKBParse/18-2                                                  907ns ± 1%     910ns ± 1%  +0.35%  (p=0.002 n=13+14)
WKBParse/19-2                                                  905ns ± 0%     909ns ± 1%  +0.47%  (p=0.000 n=14+14)
WKBParse/20-2                                                 1.10µs ± 0%    1.10µs ± 1%  +0.49%  (p=0.000 n=14+14)
WKBParse/21-2                                                  300ns ± 1%     302ns ± 3%  +0.71%  (p=0.005 n=13+13)
WKBParse/22-2                                                  303ns ± 1%     303ns ± 1%    ~     (p=0.394 n=15+13)
WKBParse/23-2                                                  303ns ± 2%     303ns ± 1%    ~     (p=0.119 n=13+14)
WKBParse/24-2                                                  298ns ± 1%     299ns ± 1%    ~     (p=0.172 n=13+14)
WKBParse/25-2                                                 1.56µs ± 1%    1.56µs ± 1%    ~     (p=0.073 n=14+13)
WKBParse/26-2                                                 1.98µs ± 3%    1.98µs ± 1%    ~     (p=0.473 n=14+14)
WKBParse/27-2                                                 1.97µs ± 1%    1.96µs ± 0%  -0.50%  (p=0.002 n=13+14)
WKBParse/28-2                                                 2.47µs ± 0%    2.47µs ± 1%    ~     (p=0.215 n=12+14)
WKBParse/29-2                                                  301ns ± 1%     302ns ± 0%  +0.44%  (p=0.002 n=15+13)
WKBParse/30-2                                                  303ns ± 2%     305ns ± 1%  +0.70%  (p=0.002 n=15+15)
WKBParse/31-2                                                  302ns ± 1%     304ns ± 1%  +0.72%  (p=0.000 n=15+15)
WKBParse/32-2                                                  298ns ± 0%     300ns ± 1%  +0.82%  (p=0.000 n=13+15)
WKBParse/33-2                                                  569ns ± 0%     569ns ± 1%    ~     (p=0.821 n=14+15)
WKBParse/34-2                                                  649ns ± 1%     649ns ± 1%    ~     (p=0.784 n=13+14)
WKBParse/35-2                                                  658ns ± 1%     649ns ± 1%  -1.38%  (p=0.000 n=13+13)
WKBParse/36-2                                                  710ns ± 0%     712ns ± 1%    ~     (p=0.394 n=14+14)
WKBParse/37-2                                                  814ns ± 1%     815ns ± 0%    ~     (p=0.288 n=13+12)
WKBParse/38-2                                                  958ns ± 2%     960ns ± 1%    ~     (p=0.270 n=14+14)
WKBParse/39-2                                                  966ns ± 2%     954ns ± 1%  -1.19%  (p=0.000 n=14+13)
WKBParse/40-2                                                 1.08µs ± 1%    1.08µs ± 1%    ~     (p=0.808 n=12+12)
WKBParse/41-2                                                  302ns ± 1%     303ns ± 0%    ~     (p=0.057 n=13+12)
WKBParse/42-2                                                  305ns ± 0%     305ns ± 1%    ~     (p=0.838 n=12+15)
WKBParse/43-2                                                  305ns ± 1%     305ns ± 1%    ~     (p=0.890 n=12+14)
WKBParse/44-2                                                  302ns ± 1%     301ns ± 1%    ~     (p=0.510 n=13+14)
WKBParse/45-2                                                  887ns ± 1%     888ns ± 1%    ~     (p=0.379 n=15+12)
WKBParse/46-2                                                 1.07µs ± 1%    1.08µs ± 3%  +0.88%  (p=0.048 n=14+14)
WKBParse/47-2                                                 1.08µs ± 1%    1.08µs ± 1%    ~     (p=0.610 n=14+14)
WKBParse/48-2                                                 1.24µs ± 2%    1.24µs ± 2%    ~     (p=0.541 n=14+13)
WKBParse/49-2                                                 1.26µs ± 1%    1.27µs ± 1%  +0.39%  (p=0.004 n=15+15)
WKBParse/50-2                                                 1.60µs ± 1%    1.60µs ± 1%    ~     (p=0.197 n=14+13)
WKBParse/51-2                                                 1.60µs ± 1%    1.60µs ± 1%    ~     (p=0.407 n=13+14)
WKBParse/52-2                                                 1.88µs ± 1%    1.88µs ± 1%    ~     (p=0.610 n=14+14)
WKBParse/53-2                                                  303ns ± 3%     303ns ± 1%    ~     (p=0.091 n=15+13)
WKBParse/54-2                                                  305ns ± 1%     305ns ± 1%    ~     (p=0.533 n=14+14)
WKBParse/55-2                                                  304ns ± 2%     304ns ± 1%    ~     (p=0.563 n=13+15)
WKBParse/56-2                                                  299ns ± 1%     300ns ± 1%    ~     (p=0.100 n=12+15)
WKBParse/57-2                                                 1.91µs ± 1%    1.92µs ± 1%  +0.38%  (p=0.017 n=14+13)
WKBParse/58-2                                                 2.36µs ± 1%    2.37µs ± 0%  +0.34%  (p=0.001 n=14+13)
WKBParse/59-2                                                 2.35µs ± 0%    2.36µs ± 1%  +0.53%  (p=0.000 n=13+13)
WKBParse/60-2                                                 2.85µs ± 1%    2.87µs ± 1%  +0.46%  (p=0.037 n=15+13)
WKBParse/61-2                                                  302ns ± 0%     302ns ± 1%    ~     (p=0.772 n=13+13)
WKBParse/62-2                                                  304ns ± 1%     304ns ± 1%    ~     (p=0.574 n=13+14)
WKBParse/63-2                                                  304ns ± 1%     304ns ± 1%    ~     (p=0.525 n=14+15)
WKBParse/64-2                                                  300ns ± 2%     299ns ± 0%    ~     (p=0.640 n=13+13)
WKBParse/65-2                                                  871ns ± 5%     863ns ± 1%    ~     (p=0.627 n=14+14)
WKBParse/66-2                                                 1.02µs ± 2%    1.02µs ± 1%    ~     (p=0.758 n=13+15)
WKBParse/67-2                                                 1.02µs ± 2%    1.02µs ± 1%    ~     (p=0.721 n=14+15)
WKBParse/68-2                                                 1.13µs ± 2%    1.12µs ± 1%  -1.01%  (p=0.000 n=14+13)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:arm64
IntersectionWithoutValidation/n=10-2                          13.4µs ± 2%    13.4µs ± 2%    ~     (p=0.683 n=15+14)
IntersectionWithoutValidation/n=100-2                         29.0µs ± 2%    29.0µs ± 2%    ~     (p=0.880 n=15+14)
IntersectionWithoutValidation/n=1000-2                         148µs ± 2%     149µs ± 4%    ~     (p=0.126 n=15+15)
IntersectionWithoutValidation/n=10000-2                       1.39ms ± 3%    1.39ms ± 3%    ~     (p=0.579 n=13+13)
NoOp/n=10-2                                                   2.16µs ± 2%    2.15µs ± 2%    ~     (p=0.463 n=12+15)
NoOp/n=100-2                                                  5.70µs ± 1%    5.70µs ± 3%    ~     (p=0.801 n=12+15)
NoOp/n=1000-2                                                 39.6µs ± 3%    39.5µs ± 3%    ~     (p=0.621 n=14+15)
NoOp/n=10000-2                                                 448µs ±13%     440µs ±15%    ~     (p=0.624 n=15+15)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:arm64
LineStringIsSimpleCircle/n=10-2                               1.07µs ± 1%    1.07µs ± 1%  -0.35%  (p=0.011 n=15+13)
LineStringIsSimpleCircle/n=100-2                              17.0µs ± 1%    16.9µs ± 1%  -0.50%  (p=0.010 n=15+13)
LineStringIsSimpleCircle/n=1000-2                              264µs ± 2%     262µs ± 0%  -0.70%  (p=0.001 n=13+13)
LineStringIsSimpleCircle/n=10000-2                            3.88ms ±10%    4.21ms ±11%  +8.55%  (p=0.005 n=13+14)
LineStringIsSimpleZigZag/10-2                                  957ns ± 1%     952ns ± 0%  -0.53%  (p=0.005 n=12+13)
LineStringIsSimpleZigZag/100-2                                17.0µs ± 1%    16.9µs ± 2%    ~     (p=0.217 n=14+15)
LineStringIsSimpleZigZag/1000-2                                241µs ± 1%     241µs ± 1%    ~     (p=0.793 n=14+13)
LineStringIsSimpleZigZag/10000-2                              4.24ms ±13%    4.55ms ±27%    ~     (p=0.112 n=14+15)
SetOperation/n=4/Go_Intersection-2                            20.0µs ± 0%    20.0µs ± 5%  +0.12%  (p=0.022 n=13+13)
SetOperation/n=4/Go_Difference-2                              20.5µs ± 1%    20.4µs ± 0%  -0.73%  (p=0.000 n=14+14)
SetOperation/n=4/Go_SymmetricDifference-2                     26.3µs ± 1%    26.2µs ± 1%    ~     (p=0.052 n=12+13)
SetOperation/n=4/Go_Union-2                                   21.3µs ± 1%    21.1µs ± 1%  -0.85%  (p=0.000 n=14+14)
SetOperation/n=4/GEOS_Intersection-2                          11.8µs ± 2%    11.7µs ± 1%    ~     (p=0.583 n=14+15)
SetOperation/n=4/GEOS_Difference-2                            12.1µs ± 2%    12.1µs ± 1%    ~     (p=0.541 n=14+14)
SetOperation/n=4/GEOS_SymmetricDifference-2                   18.7µs ± 1%    18.7µs ± 2%    ~     (p=0.659 n=14+14)
SetOperation/n=4/GEOS_Union-2                                 12.3µs ± 2%    12.3µs ± 1%    ~     (p=0.793 n=14+13)
SetOperation/n=8/Go_Intersection-2                            25.6µs ± 1%    25.5µs ± 1%  -0.67%  (p=0.000 n=12+13)
SetOperation/n=8/Go_Difference-2                              25.9µs ± 2%    25.8µs ± 0%  -0.63%  (p=0.004 n=13+12)
SetOperation/n=8/Go_SymmetricDifference-2                     32.7µs ± 1%    32.6µs ± 1%  -0.44%  (p=0.003 n=14+14)
SetOperation/n=8/Go_Union-2                                   26.5µs ± 1%    26.4µs ± 1%  -0.44%  (p=0.011 n=13+14)
SetOperation/n=8/GEOS_Intersection-2                          15.4µs ± 1%    15.5µs ± 3%    ~     (p=0.715 n=14+15)
SetOperation/n=8/GEOS_Difference-2                            15.2µs ± 2%    15.3µs ± 3%    ~     (p=0.325 n=15+15)
SetOperation/n=8/GEOS_SymmetricDifference-2                   22.5µs ± 2%    22.6µs ± 3%    ~     (p=0.943 n=13+14)
SetOperation/n=8/GEOS_Union-2                                 14.9µs ± 2%    14.9µs ± 2%    ~     (p=0.830 n=13+14)
SetOperation/n=16/Go_Intersection-2                           35.7µs ± 0%    35.6µs ± 1%  -0.26%  (p=0.038 n=13+14)
SetOperation/n=16/Go_Difference-2                             37.7µs ± 2%    37.6µs ± 2%    ~     (p=0.701 n=14+14)
SetOperation/n=16/Go_SymmetricDifference-2                    49.0µs ± 0%    49.0µs ± 2%    ~     (p=0.611 n=13+12)
SetOperation/n=16/Go_Union-2                                  38.8µs ± 1%    38.8µs ± 1%    ~     (p=0.394 n=14+15)
SetOperation/n=16/GEOS_Intersection-2                         17.4µs ± 3%    17.3µs ± 3%    ~     (p=0.884 n=14+14)
SetOperation/n=16/GEOS_Difference-2                           18.4µs ± 3%    18.4µs ± 1%    ~     (p=0.518 n=14+12)
SetOperation/n=16/GEOS_SymmetricDifference-2                  30.4µs ± 4%    30.4µs ± 3%    ~     (p=0.902 n=15+15)
SetOperation/n=16/GEOS_Union-2                                19.0µs ± 3%    18.9µs ± 2%    ~     (p=0.484 n=15+14)
SetOperation/n=32/Go_Intersection-2                           59.7µs ± 1%    59.7µs ± 1%    ~     (p=0.804 n=14+14)
SetOperation/n=32/Go_Difference-2                             61.6µs ± 1%    61.7µs ± 1%    ~     (p=0.623 n=13+13)
SetOperation/n=32/Go_SymmetricDifference-2                    83.8µs ± 3%    83.0µs ± 1%    ~     (p=0.401 n=14+14)
SetOperation/n=32/Go_Union-2                                  64.1µs ± 0%    64.3µs ± 1%  +0.35%  (p=0.029 n=12+15)
SetOperation/n=32/GEOS_Intersection-2                         22.6µs ± 1%    22.7µs ± 2%    ~     (p=0.118 n=13+15)
SetOperation/n=32/GEOS_Difference-2                           24.0µs ± 3%    24.0µs ± 2%    ~     (p=0.775 n=15+15)
SetOperation/n=32/GEOS_SymmetricDifference-2                  43.0µs ± 2%    42.8µs ± 2%    ~     (p=0.430 n=13+14)
SetOperation/n=32/GEOS_Union-2                                24.3µs ± 3%    24.3µs ± 2%    ~     (p=0.918 n=13+15)
SetOperation/n=64/Go_Intersection-2                            107µs ± 1%     108µs ± 1%  +0.63%  (p=0.003 n=13+13)
SetOperation/n=64/Go_Difference-2                              115µs ± 1%     115µs ± 1%  +0.46%  (p=0.034 n=13+13)
SetOperation/n=64/Go_SymmetricDifference-2                     163µs ± 3%     162µs ± 4%    ~     (p=0.077 n=14+14)
SetOperation/n=64/Go_Union-2                                   122µs ± 1%     123µs ± 1%    ~     (p=0.101 n=12+12)
SetOperation/n=64/GEOS_Intersection-2                         30.5µs ± 3%    30.6µs ± 3%    ~     (p=0.549 n=14+14)
SetOperation/n=64/GEOS_Difference-2                           36.7µs ± 3%    36.8µs ± 1%    ~     (p=0.667 n=14+14)
SetOperation/n=64/GEOS_SymmetricDifference-2                  78.9µs ± 5%    78.0µs ± 2%    ~     (p=0.185 n=15+13)
SetOperation/n=64/GEOS_Union-2                                39.7µs ± 4%    39.7µs ± 3%    ~     (p=1.000 n=14+14)
SetOperation/n=128/Go_Intersection-2                           225µs ± 2%     224µs ± 0%    ~     (p=0.186 n=13+12)
SetOperation/n=128/Go_Difference-2                             240µs ± 2%     239µs ± 1%    ~     (p=0.616 n=14+13)
SetOperation/n=128/Go_SymmetricDifference-2                    328µs ± 3%     327µs ± 2%    ~     (p=0.621 n=15+14)
SetOperation/n=128/Go_Union-2                                  249µs ± 1%     249µs ± 2%    ~     (p=0.571 n=14+14)
SetOperation/n=128/GEOS_Intersection-2                        49.9µs ± 1%    50.1µs ± 3%    ~     (p=0.621 n=14+15)
SetOperation/n=128/GEOS_Difference-2                          59.2µs ± 2%    59.4µs ± 3%    ~     (p=0.427 n=14+14)
SetOperation/n=128/GEOS_SymmetricDifference-2                  145µs ± 4%     144µs ± 4%    ~     (p=0.202 n=15+15)
SetOperation/n=128/GEOS_Union-2                               65.2µs ± 1%    65.3µs ± 2%    ~     (p=0.857 n=14+13)
SetOperation/n=256/Go_Intersection-2                           443µs ± 1%     449µs ± 4%  +1.45%  (p=0.031 n=12+14)
SetOperation/n=256/Go_Difference-2                             478µs ± 1%     480µs ± 2%    ~     (p=0.376 n=12+13)
SetOperation/n=256/Go_SymmetricDifference-2                    677µs ± 1%     677µs ± 1%    ~     (p=0.687 n=13+13)
SetOperation/n=256/Go_Union-2                                  502µs ± 1%     502µs ± 2%    ~     (p=0.322 n=12+14)
SetOperation/n=256/GEOS_Intersection-2                        83.9µs ± 2%    83.7µs ± 3%    ~     (p=0.354 n=15+14)
SetOperation/n=256/GEOS_Difference-2                           120µs ± 2%     120µs ± 3%    ~     (p=0.603 n=14+14)
SetOperation/n=256/GEOS_SymmetricDifference-2                  321µs ± 2%     323µs ± 3%    ~     (p=0.254 n=13+15)
SetOperation/n=256/GEOS_Union-2                                140µs ± 3%     139µs ± 2%    ~     (p=0.085 n=14+12)
SetOperation/n=512/Go_Intersection-2                           914µs ± 4%     938µs ± 9%  +2.62%  (p=0.041 n=12+14)
SetOperation/n=512/Go_Difference-2                            1.07ms ±11%    1.01ms ± 7%  -6.27%  (p=0.008 n=14+15)
SetOperation/n=512/Go_SymmetricDifference-2                   1.36ms ± 1%    1.39ms ± 6%    ~     (p=0.054 n=14+13)
SetOperation/n=512/Go_Union-2                                 1.01ms ± 1%    1.03ms ± 6%    ~     (p=0.094 n=13+14)
SetOperation/n=512/GEOS_Intersection-2                         174µs ± 3%     172µs ± 2%    ~     (p=0.172 n=15+14)
SetOperation/n=512/GEOS_Difference-2                           235µs ± 1%     234µs ± 1%    ~     (p=0.259 n=14+13)
SetOperation/n=512/GEOS_SymmetricDifference-2                  641µs ± 1%     648µs ± 3%  +1.16%  (p=0.024 n=14+14)
SetOperation/n=512/GEOS_Union-2                                293µs ±13%     281µs ± 5%  -4.16%  (p=0.022 n=14+13)
SetOperation/n=1024/Go_Intersection-2                         1.79ms ± 1%    1.79ms ± 1%    ~     (p=0.852 n=13+12)
SetOperation/n=1024/Go_Difference-2                           2.00ms ± 2%    2.00ms ± 1%    ~     (p=0.830 n=13+14)
SetOperation/n=1024/Go_SymmetricDifference-2                  2.98ms ± 3%    2.99ms ± 5%    ~     (p=0.458 n=14+13)
SetOperation/n=1024/Go_Union-2                                2.18ms ± 3%    2.19ms ± 8%    ~     (p=0.756 n=14+13)
SetOperation/n=1024/GEOS_Intersection-2                        350µs ± 2%     349µs ± 4%    ~     (p=0.128 n=13+14)
SetOperation/n=1024/GEOS_Difference-2                          539µs ± 7%     535µs ± 7%    ~     (p=0.806 n=15+15)
SetOperation/n=1024/GEOS_SymmetricDifference-2                1.46ms ±13%    1.47ms ±10%    ~     (p=0.914 n=14+15)
SetOperation/n=1024/GEOS_Union-2                               622µs ±10%     622µs ± 8%    ~     (p=0.880 n=14+15)
SetOperation/n=2048/Go_Intersection-2                         3.99ms ± 7%    4.01ms ±11%    ~     (p=1.000 n=15+15)
SetOperation/n=2048/Go_Difference-2                           4.23ms ± 8%    4.21ms ± 4%    ~     (p=0.701 n=14+14)
SetOperation/n=2048/Go_SymmetricDifference-2                  6.01ms ± 5%    6.12ms ±12%    ~     (p=0.425 n=15+14)
SetOperation/n=2048/Go_Union-2                                4.46ms ± 3%    4.46ms ± 3%    ~     (p=0.793 n=14+13)
SetOperation/n=2048/GEOS_Intersection-2                        762µs ± 5%     758µs ± 3%    ~     (p=0.343 n=13+13)
SetOperation/n=2048/GEOS_Difference-2                         1.04ms ± 6%    1.04ms ± 4%    ~     (p=0.354 n=14+15)
SetOperation/n=2048/GEOS_SymmetricDifference-2                2.98ms ±15%    2.84ms ±13%    ~     (p=0.085 n=15+14)
SetOperation/n=2048/GEOS_Union-2                              1.21ms ± 3%    1.21ms ± 3%    ~     (p=0.352 n=14+14)
SetOperation/n=4096/Go_Intersection-2                         8.73ms ±20%    8.73ms ±16%    ~     (p=1.000 n=13+14)
SetOperation/n=4096/Go_Difference-2                           9.86ms ±20%    9.97ms ±19%    ~     (p=0.744 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-2                  13.4ms ±18%    13.3ms ±11%    ~     (p=0.715 n=14+15)
SetOperation/n=4096/Go_Union-2                                10.9ms ±35%    10.1ms ±16%    ~     (p=0.077 n=14+15)
SetOperation/n=4096/GEOS_Intersection-2                       1.46ms ± 6%    1.46ms ± 4%    ~     (p=0.762 n=13+13)
SetOperation/n=4096/GEOS_Difference-2                         2.13ms ± 5%    2.12ms ± 3%    ~     (p=0.894 n=13+12)
SetOperation/n=4096/GEOS_SymmetricDifference-2                6.96ms ±23%    7.06ms ±19%    ~     (p=0.400 n=15+14)
SetOperation/n=4096/GEOS_Union-2                              2.82ms ±23%    3.04ms ±19%    ~     (p=0.077 n=14+14)
SetOperation/n=8192/Go_Intersection-2                         19.8ms ±36%    18.4ms ±28%    ~     (p=0.306 n=14+14)
SetOperation/n=8192/Go_Difference-2                           19.4ms ±11%    19.4ms ±14%    ~     (p=0.894 n=12+13)
SetOperation/n=8192/Go_SymmetricDifference-2                  31.9ms ±18%    31.2ms ±21%    ~     (p=0.685 n=14+13)
SetOperation/n=8192/Go_Union-2                                20.3ms ± 6%    20.4ms ± 8%    ~     (p=0.880 n=15+14)
SetOperation/n=8192/GEOS_Intersection-2                       3.41ms ±15%    3.32ms ±15%    ~     (p=0.174 n=15+15)
SetOperation/n=8192/GEOS_Difference-2                         4.42ms ± 9%    4.38ms ± 7%    ~     (p=0.618 n=15+13)
SetOperation/n=8192/GEOS_SymmetricDifference-2                14.1ms ± 8%    13.5ms ±23%  -4.19%  (p=0.023 n=15+14)
SetOperation/n=8192/GEOS_Union-2                              5.17ms ± 7%    5.11ms ± 4%    ~     (p=0.840 n=13+13)
SetOperation/n=16384/Go_Intersection-2                        41.4ms ±14%    40.5ms ±31%    ~     (p=0.266 n=12+12)
SetOperation/n=16384/Go_Difference-2                          46.1ms ±37%   64.9ms ±123%    ~     (p=0.401 n=14+14)
SetOperation/n=16384/Go_SymmetricDifference-2                 62.8ms ±25%    60.3ms ±18%    ~     (p=0.448 n=13+13)
SetOperation/n=16384/Go_Union-2                               51.7ms ±46%    62.3ms ±83%    ~     (p=0.265 n=14+14)
SetOperation/n=16384/GEOS_Intersection-2                      6.80ms ±13%    6.63ms ±16%    ~     (p=0.352 n=14+14)
SetOperation/n=16384/GEOS_Difference-2                        9.66ms ± 8%    9.67ms ± 6%    ~     (p=0.856 n=15+13)
SetOperation/n=16384/GEOS_SymmetricDifference-2               27.3ms ±14%    27.3ms ±12%    ~     (p=0.683 n=14+15)
SetOperation/n=16384/GEOS_Union-2                             11.3ms ± 4%    11.5ms ± 3%    ~     (p=0.265 n=14+14)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:arm64
Delete/n=100-2                                                10.7µs ± 1%    10.7µs ± 3%    ~     (p=0.659 n=14+14)
Delete/n=1000-2                                                434µs ± 1%     434µs ± 0%    ~     (p=0.981 n=15+12)
Delete/n=10000-2                                              23.9ms ± 0%    23.9ms ± 1%    ~     (p=0.801 n=13+13)
Bulk/n=10-2                                                    440ns ± 1%     442ns ± 3%    ~     (p=0.622 n=12+14)
Bulk/n=100-2                                                  8.99µs ± 2%    8.94µs ± 1%    ~     (p=0.095 n=15+14)
Bulk/n=1000-2                                                  188µs ± 2%     187µs ± 1%    ~     (p=0.586 n=14+12)
Bulk/n=10000-2                                                2.74ms ± 0%    2.74ms ± 1%    ~     (p=0.852 n=12+13)
Bulk/n=100000-2                                               32.2ms ± 2%    32.3ms ± 2%    ~     (p=0.650 n=13+13)
Insert/n=10-2                                                  776ns ± 1%     777ns ± 1%    ~     (p=0.889 n=12+14)
Insert/n=100-2                                                13.5µs ± 1%    13.6µs ± 2%    ~     (p=0.369 n=15+13)
Insert/n=1000-2                                                277µs ± 1%     277µs ± 1%  -0.33%  (p=0.037 n=15+14)
Insert/n=10000-2                                              3.74ms ± 1%    3.73ms ± 1%    ~     (p=0.545 n=13+13)
Insert/n=100000-2                                             44.5ms ± 1%    44.6ms ± 2%    ~     (p=0.983 n=15+14)
RangeSearch/n=10-2                                            10.8ns ± 6%    10.6ns ± 8%    ~     (p=0.280 n=15+15)
RangeSearch/n=100-2                                           45.2ns ±10%    45.1ns ± 9%    ~     (p=1.000 n=15+15)
RangeSearch/n=1000-2                                           167ns ± 6%     165ns ± 5%    ~     (p=0.361 n=15+15)
RangeSearch/n=10000-2                                          593ns ± 7%     602ns ± 7%    ~     (p=0.205 n=15+15)
RangeSearch/n=100000-2                                        5.60µs ± 1%    5.77µs ± 9%  +2.95%  (p=0.009 n=12+15)

name                                                        old alloc/op   new alloc/op   delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:arm64
LineEnvelope/0-2                                               0.00B          0.00B         ~     (all equal)
LineEnvelope/1-2                                               0.00B          0.00B         ~     (all equal)
LineEnvelope/2-2                                               0.00B          0.00B         ~     (all equal)
LineEnvelope/3-2                                               0.00B          0.00B         ~     (all equal)
MarshalWKB/polygon/n=10-2                                       232B ± 0%      232B ± 0%    ~     (all equal)
MarshalWKB/polygon/n=100-2                                    1.83kB ± 0%    1.83kB ± 0%    ~     (all equal)
MarshalWKB/polygon/n=1000-2                                   16.4kB ± 0%    16.4kB ± 0%    ~     (all equal)
MarshalWKB/polygon/n=10000-2                                   164kB ± 0%     164kB ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10-2                                     284B ± 0%      284B ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=100-2                                  1.90kB ± 0%    1.90kB ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=1000-2                                 16.5kB ± 0%    16.5kB ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10000-2                                 164kB ± 0%     164kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=10-2                     2.42kB ± 0%    2.42kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=100-2                    30.4kB ± 0%    30.4kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=1000-2                    205kB ± 0%     205kB ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=10000-2                  2.63MB ± 0%    2.63MB ± 0%    ~     (p=0.074 n=12+15)
IntersectsMultiPointWithMultiPoint/n=20-2                       324B ± 0%      324B ± 0%    ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-2                    3.06kB ± 0%    3.07kB ± 0%    ~     (p=0.250 n=15+15)
IntersectsMultiPointWithMultiPoint/n=2000-2                   49.3kB ± 0%    49.3kB ± 0%    ~     (p=0.413 n=15+15)
IntersectsMultiPointWithMultiPoint/n=20000-2                   339kB ± 0%     339kB ± 0%    ~     (p=0.430 n=15+15)
PolygonSingleRingValidation/n=10-2                            2.29kB ± 0%    2.29kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=100-2                           24.4kB ± 0%    24.4kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=1000-2                           140kB ± 0%     140kB ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10000-2                         1.97MB ± 0%    1.97MB ± 0%  +0.00%  (p=0.034 n=12+15)
PolygonMultipleRingsValidation/n=4-2                          6.61kB ± 0%    6.61kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=36-2                         53.2kB ± 0%    53.2kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=400-2                         597kB ± 0%     597kB ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4096-2                       6.28MB ± 0%    6.28MB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10-2                           9.62kB ± 0%    9.62kB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=100-2                          88.0kB ± 0%    88.0kB ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=1000-2                          551kB ± 0%     551kB ± 0%    ~     (p=0.196 n=14+13)
PolygonZigZagRingsValidation/n=10000-2                        7.24MB ± 0%    7.24MB ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=10-2                               4.10kB ± 0%    4.10kB ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=100-2                              28.4kB ± 0%    28.4kB ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=1000-2                              379kB ± 0%     379kB ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=10000-2                            3.89MB ± 0%    3.89MB ± 0%    ~     (all equal)
MultipolygonValidation/n=1-2                                    481B ± 0%      481B ± 0%    ~     (all equal)
MultipolygonValidation/n=4-2                                    980B ± 0%      980B ± 0%    ~     (all equal)
MultipolygonValidation/n=16-2                                 4.16kB ± 0%    4.16kB ± 0%    ~     (all equal)
MultipolygonValidation/n=64-2                                 17.0kB ± 0%    17.0kB ± 0%    ~     (all equal)
MultipolygonValidation/n=256-2                                67.8kB ± 0%    67.8kB ± 0%    ~     (all equal)
MultipolygonValidation/n=1024-2                                271kB ± 0%     271kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10-2                                 5.15kB ± 0%    5.15kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=100-2                                55.1kB ± 0%    55.1kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=1000-2                                345kB ± 0%     345kB ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10000-2                              4.60MB ± 0%    4.60MB ± 0%    ~     (p=0.853 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1-2                      4.16kB ± 0%    4.16kB ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-2                     23.9kB ± 0%    23.9kB ± 0%    ~     (p=0.727 n=15+15)
MultiPolygonMultipleTouchingPoints/n=100-2                     182kB ± 0%     182kB ± 0%    ~     (p=0.767 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-2                   2.16MB ± 0%    2.16MB ± 0%    ~     (p=0.486 n=15+15)
WKTParsing/point-2                                            1.89kB ± 0%    1.89kB ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-2           40.7kB ± 0%    40.7kB ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-2            40.7kB ± 0%    40.7kB ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2           369kB ± 0%     369kB ± 0%    ~     (p=0.511 n=13+14)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2            369kB ± 0%     369kB ± 0%    ~     (p=0.932 n=15+14)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2     5.52kB ± 0%    5.52kB ± 0%    ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2      5.52kB ± 0%    5.52kB ± 0%    ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2    60.1kB ± 0%    60.1kB ± 0%    ~     (p=0.450 n=15+15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2     60.1kB ± 0%    60.1kB ± 0%    ~     (p=1.000 n=15+15)
MultiLineStringIsSimpleManyLineStrings/n=100-2                59.2kB ± 0%    59.2kB ± 0%    ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                491kB ± 0%     491kB ± 0%    ~     (all equal)
ForceCWandForceCCW/0-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/0#01-2                                       144B ± 0%      144B ± 0%    ~     (all equal)
ForceCWandForceCCW/1-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/1#01-2                                       144B ± 0%      144B ± 0%    ~     (all equal)
ForceCWandForceCCW/2-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/2#01-2                                       256B ± 0%      256B ± 0%    ~     (all equal)
ForceCWandForceCCW/3-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/3#01-2                                       256B ± 0%      256B ± 0%    ~     (all equal)
ForceCWandForceCCW/4-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/4#01-2                                       416B ± 0%      416B ± 0%    ~     (all equal)
ForceCWandForceCCW/5-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/5#01-2                                       416B ± 0%      416B ± 0%    ~     (all equal)
ForceCWandForceCCW/6-2                                         0.00B          0.00B         ~     (all equal)
ForceCWandForceCCW/6#01-2                                       624B ± 0%      624B ± 0%    ~     (all equal)
EnvelopeTransformXY-2                                          0.00B          0.00B         ~     (all equal)
WKBParse/0-2                                                    112B ± 0%      112B ± 0%    ~     (all equal)
WKBParse/1-2                                                    112B ± 0%      112B ± 0%    ~     (all equal)
WKBParse/2-2                                                    112B ± 0%      112B ± 0%    ~     (all equal)
WKBParse/3-2                                                    112B ± 0%      112B ± 0%    ~     (all equal)
WKBParse/4-2                                                    176B ± 0%      176B ± 0%    ~     (all equal)
WKBParse/5-2                                                    120B ± 0%      120B ± 0%    ~     (all equal)
WKBParse/6-2                                                    120B ± 0%      120B ± 0%    ~     (all equal)
WKBParse/7-2                                                    120B ± 0%      120B ± 0%    ~     (all equal)
WKBParse/8-2                                                    184B ± 0%      184B ± 0%    ~     (all equal)
WKBParse/9-2                                                   72.0B ± 0%     72.0B ± 0%    ~     (all equal)
WKBParse/10-2                                                  72.0B ± 0%     72.0B ± 0%    ~     (all equal)
WKBParse/11-2                                                  72.0B ± 0%     72.0B ± 0%    ~     (all equal)
WKBParse/12-2                                                  72.0B ± 0%     72.0B ± 0%    ~     (all equal)
WKBParse/13-2                                                   200B ± 0%      200B ± 0%    ~     (all equal)
WKBParse/14-2                                                   216B ± 0%      216B ± 0%    ~     (all equal)
WKBParse/15-2                                                   216B ± 0%      216B ± 0%    ~     (all equal)
WKBParse/16-2                                                   360B ± 0%      360B ± 0%    ~     (all equal)
WKBParse/17-2                                                   216B ± 0%      216B ± 0%    ~     (all equal)
WKBParse/18-2                                                   376B ± 0%      376B ± 0%    ~     (all equal)
WKBParse/19-2                                                   376B ± 0%      376B ± 0%    ~     (all equal)
WKBParse/20-2                                                   392B ± 0%      392B ± 0%    ~     (all equal)
WKBParse/21-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/22-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/23-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/24-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/25-2                                                   808B ± 0%      808B ± 0%    ~     (all equal)
WKBParse/26-2                                                   872B ± 0%      872B ± 0%    ~     (all equal)
WKBParse/27-2                                                   872B ± 0%      872B ± 0%    ~     (all equal)
WKBParse/28-2                                                 1.45kB ± 0%    1.45kB ± 0%    ~     (all equal)
WKBParse/29-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/30-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/31-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/32-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/33-2                                                   248B ± 0%      248B ± 0%    ~     (all equal)
WKBParse/34-2                                                   312B ± 0%      312B ± 0%    ~     (all equal)
WKBParse/35-2                                                   312B ± 0%      312B ± 0%    ~     (all equal)
WKBParse/36-2                                                   312B ± 0%      312B ± 0%    ~     (all equal)
WKBParse/37-2                                                   456B ± 0%      456B ± 0%    ~     (all equal)
WKBParse/38-2                                                   584B ± 0%      584B ± 0%    ~     (all equal)
WKBParse/39-2                                                   584B ± 0%      584B ± 0%    ~     (all equal)
WKBParse/40-2                                                   584B ± 0%      584B ± 0%    ~     (all equal)
WKBParse/41-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/42-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/43-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/44-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/45-2                                                   440B ± 0%      440B ± 0%    ~     (all equal)
WKBParse/46-2                                                   472B ± 0%      472B ± 0%    ~     (all equal)
WKBParse/47-2                                                   472B ± 0%      472B ± 0%    ~     (all equal)
WKBParse/48-2                                                   488B ± 0%      488B ± 0%    ~     (all equal)
WKBParse/49-2                                                   568B ± 0%      568B ± 0%    ~     (all equal)
WKBParse/50-2                                                   872B ± 0%      872B ± 0%    ~     (all equal)
WKBParse/51-2                                                   872B ± 0%      872B ± 0%    ~     (all equal)
WKBParse/52-2                                                   904B ± 0%      904B ± 0%    ~     (all equal)
WKBParse/53-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/54-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/55-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/56-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/57-2                                                 1.07kB ± 0%    1.07kB ± 0%    ~     (all equal)
WKBParse/58-2                                                 1.14kB ± 0%    1.14kB ± 0%    ~     (all equal)
WKBParse/59-2                                                 1.14kB ± 0%    1.14kB ± 0%    ~     (all equal)
WKBParse/60-2                                                 1.71kB ± 0%    1.71kB ± 0%    ~     (all equal)
WKBParse/61-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/62-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/63-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/64-2                                                  64.0B ± 0%     64.0B ± 0%    ~     (all equal)
WKBParse/65-2                                                   424B ± 0%      424B ± 0%    ~     (all equal)
WKBParse/66-2                                                   552B ± 0%      552B ± 0%    ~     (all equal)
WKBParse/67-2                                                   552B ± 0%      552B ± 0%    ~     (all equal)
WKBParse/68-2                                                   552B ± 0%      552B ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:arm64
IntersectionWithoutValidation/n=10-2                          1.32kB ± 0%    1.32kB ± 0%    ~     (all equal)
IntersectionWithoutValidation/n=100-2                         6.46kB ± 0%    6.46kB ± 0%    ~     (all equal)
IntersectionWithoutValidation/n=1000-2                        55.1kB ± 0%    55.1kB ± 0%    ~     (all equal)
IntersectionWithoutValidation/n=10000-2                        558kB ± 0%     558kB ± 0%  -0.00%  (p=0.030 n=13+12)
NoOp/n=10-2                                                     952B ± 0%      952B ± 0%    ~     (all equal)
NoOp/n=100-2                                                  5.77kB ± 0%    5.77kB ± 0%    ~     (all equal)
NoOp/n=1000-2                                                 49.5kB ± 0%    49.5kB ± 0%    ~     (all equal)
NoOp/n=10000-2                                                 492kB ± 0%     492kB ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:arm64
LineStringIsSimpleCircle/n=10-2                               1.87kB ± 0%    1.87kB ± 0%    ~     (all equal)
LineStringIsSimpleCircle/n=100-2                              24.0kB ± 0%    24.0kB ± 0%    ~     (all equal)
LineStringIsSimpleCircle/n=1000-2                              139kB ± 0%     139kB ± 0%    ~     (all equal)
LineStringIsSimpleCircle/n=10000-2                            1.97MB ± 0%    1.97MB ± 0%    ~     (p=0.493 n=15+14)
LineStringIsSimpleZigZag/10-2                                 1.84kB ± 0%    1.84kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/100-2                                24.0kB ± 0%    24.0kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/1000-2                                139kB ± 0%     139kB ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10000-2                              1.97MB ± 0%    1.97MB ± 0%    ~     (p=0.765 n=14+14)
SetOperation/n=4/Go_Intersection-2                            19.5kB ± 0%    19.2kB ± 0%  -1.31%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Difference-2                              20.4kB ± 0%    20.2kB ± 0%  -1.25%  (p=0.000 n=14+14)
SetOperation/n=4/Go_SymmetricDifference-2                     28.5kB ± 0%    28.3kB ± 0%  -0.89%  (p=0.000 n=15+15)
SetOperation/n=4/Go_Union-2                                   21.1kB ± 0%    20.9kB ± 0%  -1.22%  (p=0.000 n=13+15)
SetOperation/n=4/GEOS_Intersection-2                          1.77kB ± 0%    1.77kB ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_Difference-2                            2.78kB ± 0%    2.78kB ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-2                   10.7kB ± 0%    10.7kB ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_Union-2                                 3.21kB ± 0%    3.21kB ± 0%    ~     (all equal)
SetOperation/n=8/Go_Intersection-2                            26.0kB ± 0%    25.8kB ± 0%  -0.98%  (p=0.000 n=15+15)
SetOperation/n=8/Go_Difference-2                              26.2kB ± 0%    25.9kB ± 0%  -0.97%  (p=0.000 n=15+13)
SetOperation/n=8/Go_SymmetricDifference-2                     35.9kB ± 0%    35.6kB ± 0%  -0.71%  (p=0.000 n=15+15)
SetOperation/n=8/Go_Union-2                                   26.3kB ± 0%    26.1kB ± 0%  -0.97%  (p=0.000 n=15+15)
SetOperation/n=8/GEOS_Intersection-2                          3.34kB ± 0%    3.34kB ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_Difference-2                            3.50kB ± 0%    3.50kB ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-2                   13.0kB ± 0%    13.0kB ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_Union-2                                 3.62kB ± 0%    3.62kB ± 0%    ~     (all equal)
SetOperation/n=16/Go_Intersection-2                           36.0kB ± 0%    35.8kB ± 0%  -0.70%  (p=0.000 n=15+15)
SetOperation/n=16/Go_Difference-2                             39.2kB ± 0%    38.9kB ± 0%  -0.65%  (p=0.000 n=14+15)
SetOperation/n=16/Go_SymmetricDifference-2                    57.4kB ± 0%    57.2kB ± 0%  -0.45%  (p=0.000 n=14+14)
SetOperation/n=16/Go_Union-2                                  40.7kB ± 0%    40.4kB ± 0%  -0.63%  (p=0.000 n=15+15)
SetOperation/n=16/GEOS_Intersection-2                         3.88kB ± 0%    3.88kB ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_Difference-2                           6.68kB ± 0%    6.68kB ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-2                  24.7kB ± 0%    24.7kB ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_Union-2                                8.28kB ± 0%    8.28kB ± 0%    ~     (all equal)
SetOperation/n=32/Go_Intersection-2                           66.1kB ± 0%    65.8kB ± 0%  -0.39%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Difference-2                             68.7kB ± 0%    68.4kB ± 0%  -0.37%  (p=0.000 n=15+15)
SetOperation/n=32/Go_SymmetricDifference-2                    98.0kB ± 0%    97.7kB ± 0%  -0.26%  (p=0.000 n=15+15)
SetOperation/n=32/Go_Union-2                                  69.1kB ± 0%    68.9kB ± 0%  -0.37%  (p=0.000 n=15+15)
SetOperation/n=32/GEOS_Intersection-2                         8.86kB ± 0%    8.86kB ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_Difference-2                           10.7kB ± 0%    10.7kB ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-2                  38.9kB ± 0%    38.9kB ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_Union-2                                11.5kB ± 0%    11.5kB ± 0%    ~     (all equal)
SetOperation/n=64/Go_Intersection-2                            110kB ± 0%     110kB ± 0%  -0.23%  (p=0.000 n=15+15)
SetOperation/n=64/Go_Difference-2                              122kB ± 0%     122kB ± 0%  -0.21%  (p=0.000 n=13+15)
SetOperation/n=64/Go_SymmetricDifference-2                     188kB ± 0%     188kB ± 0%  -0.14%  (p=0.000 n=15+14)
SetOperation/n=64/Go_Union-2                                   126kB ± 0%     126kB ± 0%  -0.20%  (p=0.000 n=15+15)
SetOperation/n=64/GEOS_Intersection-2                         12.6kB ± 0%    12.6kB ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_Difference-2                           23.5kB ± 0%    23.5kB ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-2                  87.1kB ± 0%    87.1kB ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_Union-2                                28.0kB ± 0%    28.0kB ± 0%    ~     (all equal)
SetOperation/n=128/Go_Intersection-2                           225kB ± 0%     225kB ± 0%  -0.11%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Difference-2                             237kB ± 0%     237kB ± 0%  -0.11%  (p=0.000 n=15+15)
SetOperation/n=128/Go_SymmetricDifference-2                    347kB ± 0%     347kB ± 0%  -0.07%  (p=0.000 n=15+15)
SetOperation/n=128/Go_Union-2                                  239kB ± 0%     239kB ± 0%  -0.11%  (p=0.000 n=15+15)
SetOperation/n=128/GEOS_Intersection-2                        30.3kB ± 0%    30.3kB ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_Difference-2                          40.0kB ± 0%    40.0kB ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-2                  147kB ± 0%     147kB ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_Union-2                               43.1kB ± 0%    43.1kB ± 0%    ~     (all equal)
SetOperation/n=256/Go_Intersection-2                           399kB ± 0%     399kB ± 0%  -0.06%  (p=0.000 n=15+15)
SetOperation/n=256/Go_Difference-2                             447kB ± 0%     447kB ± 0%  -0.06%  (p=0.000 n=13+13)
SetOperation/n=256/Go_SymmetricDifference-2                    700kB ± 0%     700kB ± 0%  -0.04%  (p=0.000 n=15+13)
SetOperation/n=256/Go_Union-2                                  457kB ± 0%     457kB ± 0%  -0.06%  (p=0.000 n=15+15)
SetOperation/n=256/GEOS_Intersection-2                        48.2kB ± 0%    48.2kB ± 0%    ~     (all equal)
SetOperation/n=256/GEOS_Difference-2                          92.6kB ± 0%    92.6kB ± 0%    ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-2                  340kB ± 0%     340kB ± 0%    ~     (p=0.056 n=15+12)
SetOperation/n=256/GEOS_Union-2                                106kB ± 0%     106kB ± 0%    ~     (all equal)
SetOperation/n=512/Go_Intersection-2                           830kB ± 0%     830kB ± 0%  -0.03%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Difference-2                             878kB ± 0%     877kB ± 0%  -0.03%  (p=0.000 n=15+15)
SetOperation/n=512/Go_SymmetricDifference-2                   1.30MB ± 0%    1.30MB ± 0%  -0.02%  (p=0.000 n=15+15)
SetOperation/n=512/Go_Union-2                                  899kB ± 0%     899kB ± 0%  -0.03%  (p=0.000 n=15+15)
SetOperation/n=512/GEOS_Intersection-2                         115kB ± 0%     115kB ± 0%    ~     (all equal)
SetOperation/n=512/GEOS_Difference-2                           159kB ± 0%     159kB ± 0%    ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-2                  576kB ± 0%     576kB ± 0%  -0.00%  (p=0.002 n=15+12)
SetOperation/n=512/GEOS_Union-2                                171kB ± 0%     171kB ± 0%    ~     (all equal)
SetOperation/n=1024/Go_Intersection-2                         1.55MB ± 0%    1.55MB ± 0%  -0.02%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_Difference-2                           1.74MB ± 0%    1.74MB ± 0%  -0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_SymmetricDifference-2                  2.77MB ± 0%    2.77MB ± 0%  -0.01%  (p=0.000 n=15+15)
SetOperation/n=1024/Go_Union-2                                1.80MB ± 0%    1.80MB ± 0%  -0.01%  (p=0.000 n=15+14)
SetOperation/n=1024/GEOS_Intersection-2                        189kB ± 0%     189kB ± 0%    ~     (all equal)
SetOperation/n=1024/GEOS_Difference-2                          369kB ± 0%     369kB ± 0%    ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-2                1.38MB ± 0%    1.38MB ± 0%    ~     (p=0.307 n=14+13)
SetOperation/n=1024/GEOS_Union-2                               415kB ± 0%     415kB ± 0%    ~     (all equal)
SetOperation/n=2048/Go_Intersection-2                         3.41MB ± 0%    3.41MB ± 0%  -0.01%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Difference-2                           3.61MB ± 0%    3.61MB ± 0%  -0.01%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_SymmetricDifference-2                  5.34MB ± 0%    5.34MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=2048/Go_Union-2                                3.69MB ± 0%    3.69MB ± 0%  -0.01%  (p=0.000 n=15+15)
SetOperation/n=2048/GEOS_Intersection-2                        460kB ± 0%     460kB ± 0%    ~     (all equal)
SetOperation/n=2048/GEOS_Difference-2                          648kB ± 0%     648kB ± 0%    ~     (p=0.222 n=14+14)
SetOperation/n=2048/GEOS_SymmetricDifference-2                2.32MB ± 0%    2.32MB ± 0%    ~     (p=0.511 n=13+11)
SetOperation/n=2048/GEOS_Union-2                               689kB ± 0%     689kB ± 0%    ~     (all equal)
SetOperation/n=4096/Go_Intersection-2                         6.53MB ± 0%    6.53MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_Difference-2                           7.25MB ± 0%    7.25MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_SymmetricDifference-2                  11.3MB ± 0%    11.3MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=4096/Go_Union-2                                7.50MB ± 0%    7.50MB ± 0%  -0.00%  (p=0.000 n=13+15)
SetOperation/n=4096/GEOS_Intersection-2                        755kB ± 0%     755kB ± 0%    ~     (p=0.733 n=14+15)
SetOperation/n=4096/GEOS_Difference-2                         1.45MB ± 0%    1.45MB ± 0%    ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-2                5.34MB ± 0%    5.34MB ± 0%    ~     (all equal)
SetOperation/n=4096/GEOS_Union-2                              1.63MB ± 0%    1.63MB ± 0%    ~     (p=0.402 n=13+15)
SetOperation/n=8192/Go_Intersection-2                         14.0MB ± 0%    14.0MB ± 0%  -0.00%  (p=0.000 n=14+15)
SetOperation/n=8192/Go_Difference-2                           14.9MB ± 0%    14.9MB ± 0%  -0.00%  (p=0.000 n=14+15)
SetOperation/n=8192/Go_SymmetricDifference-2                  21.8MB ± 0%    21.8MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=8192/Go_Union-2                                15.2MB ± 0%    15.2MB ± 0%  -0.00%  (p=0.000 n=15+13)
SetOperation/n=8192/GEOS_Intersection-2                       1.76MB ± 0%    1.76MB ± 0%    ~     (p=0.763 n=14+14)
SetOperation/n=8192/GEOS_Difference-2                         2.47MB ± 0%    2.47MB ± 0%    ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-2                9.01MB ± 0%    9.01MB ± 0%    ~     (all equal)
SetOperation/n=8192/GEOS_Union-2                              2.66MB ± 0%    2.66MB ± 0%    ~     (all equal)
SetOperation/n=16384/Go_Intersection-2                        26.0MB ± 0%    26.0MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Difference-2                          28.8MB ± 0%    28.8MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_SymmetricDifference-2                 44.8MB ± 0%    44.8MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=16384/Go_Union-2                               29.8MB ± 0%    29.8MB ± 0%  -0.00%  (p=0.000 n=15+15)
SetOperation/n=16384/GEOS_Intersection-2                      2.92MB ± 0%    2.92MB ± 0%    ~     (p=0.567 n=13+15)
SetOperation/n=16384/GEOS_Difference-2                        5.68MB ± 0%    5.68MB ± 0%    ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-2               21.1MB ± 0%    21.1MB ± 0%    ~     (all equal)
SetOperation/n=16384/GEOS_Union-2                             6.45MB ± 0%    6.45MB ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:arm64
Delete/n=100-2                                                  712B ± 0%      712B ± 0%    ~     (all equal)
Delete/n=1000-2                                               26.1kB ± 0%    26.1kB ± 0%    ~     (all equal)
Delete/n=10000-2                                               412kB ± 0%     412kB ± 0%    ~     (all equal)
Bulk/n=10-2                                                   1.46kB ± 0%    1.46kB ± 0%    ~     (all equal)
Bulk/n=100-2                                                  19.9kB ± 0%    19.9kB ± 0%    ~     (all equal)
Bulk/n=1000-2                                                 98.2kB ± 0%    98.2kB ± 0%    ~     (all equal)
Bulk/n=10000-2                                                1.57MB ± 0%    1.57MB ± 0%    ~     (all equal)
Bulk/n=100000-2                                               20.4MB ± 0%    20.4MB ± 0%    ~     (all equal)
Insert/n=10-2                                                 1.44kB ± 0%    1.44kB ± 0%    ~     (all equal)
Insert/n=100-2                                                13.5kB ± 0%    13.5kB ± 0%    ~     (all equal)
Insert/n=1000-2                                                132kB ± 0%     132kB ± 0%    ~     (all equal)
Insert/n=10000-2                                              1.34MB ± 0%    1.34MB ± 0%    ~     (all equal)
Insert/n=100000-2                                             13.5MB ± 0%    13.5MB ± 0%    ~     (all equal)
RangeSearch/n=10-2                                             0.00B          0.00B         ~     (all equal)
RangeSearch/n=100-2                                            0.00B          0.00B         ~     (all equal)
RangeSearch/n=1000-2                                           0.00B          0.00B         ~     (all equal)
RangeSearch/n=10000-2                                          0.00B          0.00B         ~     (all equal)
RangeSearch/n=100000-2                                         0.00B          0.00B         ~     (all equal)

name                                                        old allocs/op  new allocs/op  delta
pkg:github.com/peterstace/simplefeatures/geom goos:linux goarch:arm64
LineEnvelope/0-2                                                0.00           0.00         ~     (all equal)
LineEnvelope/1-2                                                0.00           0.00         ~     (all equal)
LineEnvelope/2-2                                                0.00           0.00         ~     (all equal)
LineEnvelope/3-2                                                0.00           0.00         ~     (all equal)
MarshalWKB/polygon/n=10-2                                       6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MarshalWKB/polygon/n=100-2                                      6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MarshalWKB/polygon/n=1000-2                                     6.00 ± 0%      6.00 ± 0%    ~     (all equal)
MarshalWKB/polygon/n=10000-2                                    6.00 ± 0%      6.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10-2                                     7.00 ± 0%      7.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=100-2                                    7.00 ± 0%      7.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=1000-2                                   7.00 ± 0%      7.00 ± 0%    ~     (all equal)
UnmarshalWKB/polygon/n=10000-2                                  7.00 ± 0%      7.00 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=10-2                       9.00 ± 0%      9.00 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=100-2                      73.0 ± 0%      73.0 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=1000-2                      345 ± 0%       345 ± 0%    ~     (all equal)
IntersectsLineStringWithLineString/n=10000-2                   5.46k ± 0%     5.46k ± 0%    ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20-2                       1.00 ± 0%      1.00 ± 0%    ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=200-2                      7.00 ± 0%      7.00 ± 0%    ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=2000-2                     6.00 ± 0%      6.00 ± 0%    ~     (all equal)
IntersectsMultiPointWithMultiPoint/n=20000-2                    11.0 ± 0%      11.0 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10-2                              12.0 ± 0%      12.0 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=100-2                             76.0 ± 0%      76.0 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=1000-2                             348 ± 0%       348 ± 0%    ~     (all equal)
PolygonSingleRingValidation/n=10000-2                          5.47k ± 0%     5.47k ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4-2                            42.0 ± 0%      42.0 ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=36-2                            316 ± 0%       316 ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=400-2                         3.48k ± 0%     3.48k ± 0%    ~     (all equal)
PolygonMultipleRingsValidation/n=4096-2                        36.2k ± 0%     36.2k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10-2                             41.0 ± 0%      41.0 ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=100-2                             233 ± 0%       233 ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=1000-2                          1.05k ± 0%     1.05k ± 0%    ~     (all equal)
PolygonZigZagRingsValidation/n=10000-2                         16.4k ± 0%     16.4k ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=10-2                                 22.0 ± 0%      22.0 ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=100-2                                76.0 ± 0%      76.0 ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=1000-2                              1.00k ± 0%     1.00k ± 0%    ~     (all equal)
PolygonAnnulusValidation/n=10000-2                             10.3k ± 0%     10.3k ± 0%    ~     (all equal)
MultipolygonValidation/n=1-2                                    8.00 ± 0%      8.00 ± 0%    ~     (all equal)
MultipolygonValidation/n=4-2                                    11.0 ± 0%      11.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=16-2                                   27.0 ± 0%      27.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=64-2                                   91.0 ± 0%      91.0 ± 0%    ~     (all equal)
MultipolygonValidation/n=256-2                                   347 ± 0%       347 ± 0%    ~     (all equal)
MultipolygonValidation/n=1024-2                                1.37k ± 0%     1.37k ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10-2                                   29.0 ± 0%      29.0 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=100-2                                   157 ± 0%       157 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=1000-2                                  701 ± 0%       701 ± 0%    ~     (all equal)
MultiPolygonTwoCircles/n=10000-2                               10.9k ± 0%     10.9k ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=1-2                        51.0 ± 0%      51.0 ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=10-2                        298 ± 0%       298 ± 0%    ~     (all equal)
MultiPolygonMultipleTouchingPoints/n=100-2                     2.61k ± 0%     2.61k ± 0%    ~     (p=1.000 n=15+15)
MultiPolygonMultipleTouchingPoints/n=1000-2                    26.7k ± 0%     26.7k ± 0%    ~     (p=0.382 n=15+13)
WKTParsing/point-2                                              22.0 ± 0%      22.0 ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=false-2              234 ± 0%       234 ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=100_swap=true-2               234 ± 0%       234 ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2           2.10k ± 0%     2.10k ± 0%    ~     (all equal)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2            2.10k ± 0%     2.10k ± 0%    ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2       13.0 ± 0%      13.0 ± 0%    ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2        13.0 ± 0%      13.0 ± 0%    ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2      77.0 ± 0%      77.0 ± 0%    ~     (all equal)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2       77.0 ± 0%      77.0 ± 0%    ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=100-2                   371 ± 0%       371 ± 0%    ~     (all equal)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                3.34k ± 0%     3.34k ± 0%    ~     (all equal)
ForceCWandForceCCW/0-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/0#01-2                                       3.00 ± 0%      3.00 ± 0%    ~     (all equal)
ForceCWandForceCCW/1-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/1#01-2                                       3.00 ± 0%      3.00 ± 0%    ~     (all equal)
ForceCWandForceCCW/2-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/2#01-2                                       4.00 ± 0%      4.00 ± 0%    ~     (all equal)
ForceCWandForceCCW/3-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/3#01-2                                       4.00 ± 0%      4.00 ± 0%    ~     (all equal)
ForceCWandForceCCW/4-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/4#01-2                                       7.00 ± 0%      7.00 ± 0%    ~     (all equal)
ForceCWandForceCCW/5-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/5#01-2                                       7.00 ± 0%      7.00 ± 0%    ~     (all equal)
ForceCWandForceCCW/6-2                                          0.00           0.00         ~     (all equal)
ForceCWandForceCCW/6#01-2                                       12.0 ± 0%      12.0 ± 0%    ~     (all equal)
EnvelopeTransformXY-2                                           0.00           0.00         ~     (all equal)
WKBParse/0-2                                                    5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/1-2                                                    5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/2-2                                                    5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/3-2                                                    5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/4-2                                                    6.00 ± 0%      6.00 ± 0%    ~     (all equal)
WKBParse/5-2                                                    6.00 ± 0%      6.00 ± 0%    ~     (all equal)
WKBParse/6-2                                                    6.00 ± 0%      6.00 ± 0%    ~     (all equal)
WKBParse/7-2                                                    6.00 ± 0%      6.00 ± 0%    ~     (all equal)
WKBParse/8-2                                                    7.00 ± 0%      7.00 ± 0%    ~     (all equal)
WKBParse/9-2                                                    5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/10-2                                                   5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/11-2                                                   5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/12-2                                                   5.00 ± 0%      5.00 ± 0%    ~     (all equal)
WKBParse/13-2                                                   8.00 ± 0%      8.00 ± 0%    ~     (all equal)
WKBParse/14-2                                                   8.00 ± 0%      8.00 ± 0%    ~     (all equal)
WKBParse/15-2                                                   8.00 ± 0%      8.00 ± 0%    ~     (all equal)
WKBParse/16-2                                                   9.00 ± 0%      9.00 ± 0%    ~     (all equal)
WKBParse/17-2                                                   8.00 ± 0%      8.00 ± 0%    ~     (all equal)
WKBParse/18-2                                                   9.00 ± 0%      9.00 ± 0%    ~     (all equal)
WKBParse/19-2                                                   9.00 ± 0%      9.00 ± 0%    ~     (all equal)
WKBParse/20-2                                                   9.00 ± 0%      9.00 ± 0%    ~     (all equal)
WKBParse/21-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/22-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/23-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/24-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/25-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
WKBParse/26-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
WKBParse/27-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
WKBParse/28-2                                                   16.0 ± 0%      16.0 ± 0%    ~     (all equal)
WKBParse/29-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/30-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/31-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/32-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/33-2                                                   9.00 ± 0%      9.00 ± 0%    ~     (all equal)
WKBParse/34-2                                                   10.0 ± 0%      10.0 ± 0%    ~     (all equal)
WKBParse/35-2                                                   10.0 ± 0%      10.0 ± 0%    ~     (all equal)
WKBParse/36-2                                                   10.0 ± 0%      10.0 ± 0%    ~     (all equal)
WKBParse/37-2                                                   12.0 ± 0%      12.0 ± 0%    ~     (all equal)
WKBParse/38-2                                                   13.0 ± 0%      13.0 ± 0%    ~     (all equal)
WKBParse/39-2                                                   13.0 ± 0%      13.0 ± 0%    ~     (all equal)
WKBParse/40-2                                                   13.0 ± 0%      13.0 ± 0%    ~     (all equal)
WKBParse/41-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/42-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/43-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/44-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/45-2                                                   12.0 ± 0%      12.0 ± 0%    ~     (all equal)
WKBParse/46-2                                                   12.0 ± 0%      12.0 ± 0%    ~     (all equal)
WKBParse/47-2                                                   12.0 ± 0%      12.0 ± 0%    ~     (all equal)
WKBParse/48-2                                                   12.0 ± 0%      12.0 ± 0%    ~     (all equal)
WKBParse/49-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
WKBParse/50-2                                                   16.0 ± 0%      16.0 ± 0%    ~     (all equal)
WKBParse/51-2                                                   16.0 ± 0%      16.0 ± 0%    ~     (all equal)
WKBParse/52-2                                                   16.0 ± 0%      16.0 ± 0%    ~     (all equal)
WKBParse/53-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/54-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/55-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/56-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/57-2                                                   25.0 ± 0%      25.0 ± 0%    ~     (all equal)
WKBParse/58-2                                                   25.0 ± 0%      25.0 ± 0%    ~     (all equal)
WKBParse/59-2                                                   25.0 ± 0%      25.0 ± 0%    ~     (all equal)
WKBParse/60-2                                                   26.0 ± 0%      26.0 ± 0%    ~     (all equal)
WKBParse/61-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/62-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/63-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/64-2                                                   4.00 ± 0%      4.00 ± 0%    ~     (all equal)
WKBParse/65-2                                                   14.0 ± 0%      14.0 ± 0%    ~     (all equal)
WKBParse/66-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
WKBParse/67-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
WKBParse/68-2                                                   15.0 ± 0%      15.0 ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/geos goos:linux goarch:arm64
IntersectionWithoutValidation/n=10-2                            48.0 ± 0%      48.0 ± 0%    ~     (all equal)
IntersectionWithoutValidation/n=100-2                           48.0 ± 0%      48.0 ± 0%    ~     (all equal)
IntersectionWithoutValidation/n=1000-2                          48.0 ± 0%      48.0 ± 0%    ~     (all equal)
IntersectionWithoutValidation/n=10000-2                         48.0 ± 0%      48.0 ± 0%    ~     (all equal)
NoOp/n=10-2                                                     33.0 ± 0%      33.0 ± 0%    ~     (all equal)
NoOp/n=100-2                                                    33.0 ± 0%      33.0 ± 0%    ~     (all equal)
NoOp/n=1000-2                                                   33.0 ± 0%      33.0 ± 0%    ~     (all equal)
NoOp/n=10000-2                                                  33.0 ± 0%      33.0 ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/internal/perf goos:linux goarch:arm64
LineStringIsSimpleCircle/n=10-2                                 7.00 ± 0%      7.00 ± 0%    ~     (all equal)
LineStringIsSimpleCircle/n=100-2                                71.0 ± 0%      71.0 ± 0%    ~     (all equal)
LineStringIsSimpleCircle/n=1000-2                                343 ± 0%       343 ± 0%    ~     (all equal)
LineStringIsSimpleCircle/n=10000-2                             5.46k ± 0%     5.46k ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10-2                                   7.00 ± 0%      7.00 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/100-2                                  71.0 ± 0%      71.0 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/1000-2                                  343 ± 0%       343 ± 0%    ~     (all equal)
LineStringIsSimpleZigZag/10000-2                               5.46k ± 0%     5.46k ± 0%    ~     (all equal)
SetOperation/n=4/Go_Intersection-2                               268 ± 0%       268 ± 0%    ~     (all equal)
SetOperation/n=4/Go_Difference-2                                 272 ± 0%       272 ± 0%    ~     (all equal)
SetOperation/n=4/Go_SymmetricDifference-2                        370 ± 0%       370 ± 0%    ~     (all equal)
SetOperation/n=4/Go_Union-2                                      279 ± 0%       279 ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_Intersection-2                            52.0 ± 0%      52.0 ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_Difference-2                              55.0 ± 0%      55.0 ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_SymmetricDifference-2                      146 ± 0%       146 ± 0%    ~     (all equal)
SetOperation/n=4/GEOS_Union-2                                   56.0 ± 0%      56.0 ± 0%    ~     (all equal)
SetOperation/n=8/Go_Intersection-2                               284 ± 0%       284 ± 0%    ~     (all equal)
SetOperation/n=8/Go_Difference-2                                 285 ± 0%       285 ± 0%    ~     (p=0.115 n=14+15)
SetOperation/n=8/Go_SymmetricDifference-2                        379 ± 0%       379 ± 0%    ~     (all equal)
SetOperation/n=8/Go_Union-2                                      290 ± 0%       290 ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_Intersection-2                            56.0 ± 0%      56.0 ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_Difference-2                              56.0 ± 0%      56.0 ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_SymmetricDifference-2                      143 ± 0%       143 ± 0%    ~     (all equal)
SetOperation/n=8/GEOS_Union-2                                   56.0 ± 0%      56.0 ± 0%    ~     (all equal)
SetOperation/n=16/Go_Intersection-2                              296 ± 0%       296 ± 0%    ~     (all equal)
SetOperation/n=16/Go_Difference-2                                306 ± 0%       306 ± 0%    ~     (all equal)
SetOperation/n=16/Go_SymmetricDifference-2                       413 ± 0%       413 ± 0%    ~     (all equal)
SetOperation/n=16/Go_Union-2                                     315 ± 0%       315 ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_Intersection-2                           56.0 ± 0%      56.0 ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_Difference-2                             64.0 ± 0%      64.0 ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_SymmetricDifference-2                     169 ± 0%       169 ± 0%    ~     (all equal)
SetOperation/n=16/GEOS_Union-2                                  68.0 ± 0%      68.0 ± 0%    ~     (all equal)
SetOperation/n=32/Go_Intersection-2                              347 ± 0%       347 ± 0%    ~     (all equal)
SetOperation/n=32/Go_Difference-2                                353 ± 0%       353 ± 0%    ~     (all equal)
SetOperation/n=32/Go_SymmetricDifference-2                       485 ± 0%       485 ± 0%    ~     (all equal)
SetOperation/n=32/Go_Union-2                                     358 ± 0%       358 ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_Intersection-2                           68.0 ± 0%      68.0 ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_Difference-2                             72.0 ± 0%      72.0 ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_SymmetricDifference-2                     189 ± 0%       189 ± 0%    ~     (all equal)
SetOperation/n=32/GEOS_Union-2                                  72.0 ± 0%      72.0 ± 0%    ~     (all equal)
SetOperation/n=64/Go_Intersection-2                              388 ± 0%       388 ± 0%    ~     (all equal)
SetOperation/n=64/Go_Difference-2                                422 ± 0%       422 ± 0%    ~     (all equal)
SetOperation/n=64/Go_SymmetricDifference-2                       669 ± 0%       669 ± 0%    ~     (all equal)
SetOperation/n=64/Go_Union-2                                     435 ± 0%       435 ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_Intersection-2                           72.0 ± 0%      72.0 ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_Difference-2                              104 ± 0%       104 ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_SymmetricDifference-2                     335 ± 0%       335 ± 0%    ~     (all equal)
SetOperation/n=64/GEOS_Union-2                                   112 ± 0%       112 ± 0%    ~     (all equal)
SetOperation/n=128/Go_Intersection-2                             562 ± 0%       562 ± 0%    ~     (all equal)
SetOperation/n=128/Go_Difference-2                               588 ± 0%       588 ± 0%    ~     (all equal)
SetOperation/n=128/Go_SymmetricDifference-2                      914 ± 0%       914 ± 0%    ~     (all equal)
SetOperation/n=128/Go_Union-2                                    593 ± 0%       593 ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_Intersection-2                           112 ± 0%       112 ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_Difference-2                             136 ± 0%       136 ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_SymmetricDifference-2                    457 ± 0%       457 ± 0%    ~     (all equal)
SetOperation/n=128/GEOS_Union-2                                  136 ± 0%       136 ± 0%    ~     (all equal)
SetOperation/n=256/Go_Intersection-2                             721 ± 0%       721 ± 0%    ~     (all equal)
SetOperation/n=256/Go_Difference-2                               851 ± 0%       851 ± 0%    ~     (all equal)
SetOperation/n=256/Go_SymmetricDifference-2                    1.57k ± 0%     1.57k ± 0%    ~     (all equal)
SetOperation/n=256/Go_Union-2                                    880 ± 0%       880 ± 0%    ~     (all equal)
SetOperation/n=256/GEOS_Intersection-2                           136 ± 0%       136 ± 0%    ~     (all equal)
SetOperation/n=256/GEOS_Difference-2                             264 ± 0%       264 ± 0%    ~     (all equal)
SetOperation/n=256/GEOS_SymmetricDifference-2                    969 ± 0%       969 ± 0%    ~     (all equal)
SetOperation/n=256/GEOS_Union-2                                  288 ± 0%       288 ± 0%    ~     (all equal)
SetOperation/n=512/Go_Intersection-2                           1.39k ± 0%     1.39k ± 0%    ~     (all equal)
SetOperation/n=512/Go_Difference-2                             1.50k ± 0%     1.50k ± 0%    ~     (all equal)
SetOperation/n=512/Go_SymmetricDifference-2                    2.61k ± 0%     2.61k ± 0%    ~     (all equal)
SetOperation/n=512/Go_Union-2                                  1.50k ± 0%     1.50k ± 0%    ~     (all equal)
SetOperation/n=512/GEOS_Intersection-2                           288 ± 0%       288 ± 0%    ~     (all equal)
SetOperation/n=512/GEOS_Difference-2                             392 ± 0%       392 ± 0%    ~     (all equal)
SetOperation/n=512/GEOS_SymmetricDifference-2                  1.48k ± 0%     1.48k ± 0%    ~     (all equal)
SetOperation/n=512/GEOS_Union-2                                  392 ± 0%       392 ± 0%    ~     (all equal)
SetOperation/n=1024/Go_Intersection-2                          2.02k ± 0%     2.02k ± 0%    ~     (all equal)
SetOperation/n=1024/Go_Difference-2                            2.53k ± 0%     2.53k ± 0%    ~     (all equal)
SetOperation/n=1024/Go_SymmetricDifference-2                   5.18k ± 0%     5.18k ± 0%    ~     (all equal)
SetOperation/n=1024/Go_Union-2                                 2.63k ± 0%     2.63k ± 0%    ~     (all equal)
SetOperation/n=1024/GEOS_Intersection-2                          392 ± 0%       392 ± 0%    ~     (all equal)
SetOperation/n=1024/GEOS_Difference-2                            904 ± 0%       904 ± 0%    ~     (all equal)
SetOperation/n=1024/GEOS_SymmetricDifference-2                 3.52k ± 0%     3.52k ± 0%    ~     (all equal)
SetOperation/n=1024/GEOS_Union-2                                 992 ± 0%       992 ± 0%    ~     (all equal)
SetOperation/n=2048/Go_Intersection-2                          4.68k ± 0%     4.68k ± 0%    ~     (all equal)
SetOperation/n=2048/Go_Difference-2                            5.10k ± 0%     5.10k ± 0%    ~     (all equal)
SetOperation/n=2048/Go_SymmetricDifference-2                   9.28k ± 0%     9.28k ± 0%    ~     (all equal)
SetOperation/n=2048/Go_Union-2                                 5.11k ± 0%     5.11k ± 0%    ~     (all equal)
SetOperation/n=2048/GEOS_Intersection-2                          992 ± 0%       992 ± 0%    ~     (all equal)
SetOperation/n=2048/GEOS_Difference-2                          1.42k ± 0%     1.42k ± 0%    ~     (all equal)
SetOperation/n=2048/GEOS_SymmetricDifference-2                 5.58k ± 0%     5.58k ± 0%    ~     (all equal)
SetOperation/n=2048/GEOS_Union-2                               1.42k ± 0%     1.42k ± 0%    ~     (all equal)
SetOperation/n=4096/Go_Intersection-2                          7.16k ± 0%     7.16k ± 0%    ~     (all equal)
SetOperation/n=4096/Go_Difference-2                            9.21k ± 0%     9.21k ± 0%    ~     (all equal)
SetOperation/n=4096/Go_SymmetricDifference-2                   19.5k ± 0%     19.5k ± 0%    ~     (all equal)
SetOperation/n=4096/Go_Union-2                                 9.56k ± 0%     9.56k ± 0%    ~     (all equal)
SetOperation/n=4096/GEOS_Intersection-2                        1.42k ± 0%     1.42k ± 0%    ~     (all equal)
SetOperation/n=4096/GEOS_Difference-2                          3.46k ± 0%     3.46k ± 0%    ~     (all equal)
SetOperation/n=4096/GEOS_SymmetricDifference-2                 13.8k ± 0%     13.8k ± 0%    ~     (all equal)
SetOperation/n=4096/GEOS_Union-2                               3.81k ± 0%     3.81k ± 0%    ~     (all equal)
SetOperation/n=8192/Go_Intersection-2                          17.8k ± 0%     17.8k ± 0%    ~     (all equal)
SetOperation/n=8192/Go_Difference-2                            19.5k ± 0%     19.5k ± 0%    ~     (all equal)
SetOperation/n=8192/Go_SymmetricDifference-2                   35.9k ± 0%     35.9k ± 0%    ~     (all equal)
SetOperation/n=8192/Go_Union-2                                 19.5k ± 0%     19.5k ± 0%    ~     (all equal)
SetOperation/n=8192/GEOS_Intersection-2                        3.81k ± 0%     3.81k ± 0%    ~     (all equal)
SetOperation/n=8192/GEOS_Difference-2                          5.51k ± 0%     5.51k ± 0%    ~     (all equal)
SetOperation/n=8192/GEOS_SymmetricDifference-2                 22.0k ± 0%     22.0k ± 0%    ~     (all equal)
SetOperation/n=8192/GEOS_Union-2                               5.51k ± 0%     5.51k ± 0%    ~     (all equal)
SetOperation/n=16384/Go_Intersection-2                         27.7k ± 0%     27.7k ± 0%    ~     (all equal)
SetOperation/n=16384/Go_Difference-2                           35.9k ± 0%     35.9k ± 0%    ~     (all equal)
SetOperation/n=16384/Go_SymmetricDifference-2                  76.9k ± 0%     76.9k ± 0%    ~     (p=1.000 n=15+15)
SetOperation/n=16384/Go_Union-2                                37.2k ± 0%     37.2k ± 0%  -0.00%  (p=0.001 n=15+14)
SetOperation/n=16384/GEOS_Intersection-2                       5.51k ± 0%     5.51k ± 0%    ~     (all equal)
SetOperation/n=16384/GEOS_Difference-2                         13.7k ± 0%     13.7k ± 0%    ~     (all equal)
SetOperation/n=16384/GEOS_SymmetricDifference-2                54.7k ± 0%     54.7k ± 0%    ~     (all equal)
SetOperation/n=16384/GEOS_Union-2                              15.1k ± 0%     15.1k ± 0%    ~     (all equal)
pkg:github.com/peterstace/simplefeatures/rtree goos:linux goarch:arm64
Delete/n=100-2                                                  65.0 ± 0%      65.0 ± 0%    ~     (all equal)
Delete/n=1000-2                                                  480 ± 0%       480 ± 0%    ~     (all equal)
Delete/n=10000-2                                               7.62k ± 0%     7.62k ± 0%    ~     (all equal)
Bulk/n=10-2                                                     6.00 ± 0%      6.00 ± 0%    ~     (all equal)
Bulk/n=100-2                                                    70.0 ± 0%      70.0 ± 0%    ~     (all equal)
Bulk/n=1000-2                                                    342 ± 0%       342 ± 0%    ~     (all equal)
Bulk/n=10000-2                                                 5.46k ± 0%     5.46k ± 0%    ~     (all equal)
Bulk/n=100000-2                                                71.0k ± 0%     71.0k ± 0%    ~     (all equal)
Insert/n=10-2                                                   5.00 ± 0%      5.00 ± 0%    ~     (all equal)
Insert/n=100-2                                                  47.0 ± 0%      47.0 ± 0%    ~     (all equal)
Insert/n=1000-2                                                  457 ± 0%       457 ± 0%    ~     (all equal)
Insert/n=10000-2                                               4.65k ± 0%     4.65k ± 0%    ~     (all equal)
Insert/n=100000-2                                              46.8k ± 0%     46.8k ± 0%    ~     (all equal)
RangeSearch/n=10-2                                              0.00           0.00         ~     (all equal)
RangeSearch/n=100-2                                             0.00           0.00         ~     (all equal)
RangeSearch/n=1000-2                                            0.00           0.00         ~     (all equal)
RangeSearch/n=10000-2                                           0.00           0.00         ~     (all equal)
RangeSearch/n=100000-2                                          0.00           0.00         ~     (all equal)

```

</details>