### PR TITLE
Add `UnaryUnion` and `UnionMany`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   `GeometryCollection` inputs in `Union`, `Intersection`,
   `Difference`, `SymmetricDifference`, and `Relate` functions.
 
+- Add `UnaryUnion` and `UnionMany` functions.
+
+- Fix a bug where calling `Union`, `Difference`, or `SymmetricDifference` with
+  an empty geometry and a `GeometryCollection` containing multiple children
+  would return the `GeometryCollection` unaltered (rather than unioning it
+  together).
+
 ## v0.40.1
 
 2022-11-08

--- a/geom/alg_set_op.go
+++ b/geom/alg_set_op.go
@@ -8,10 +8,10 @@ func Union(a, b Geometry) (Geometry, error) {
 		return Geometry{}, nil
 	}
 	if a.IsEmpty() {
-		return b, nil
+		return UnaryUnion(b)
 	}
 	if b.IsEmpty() {
-		return a, nil
+		return UnaryUnion(a)
 	}
 	g, err := setOp(a, or, b)
 	return g, wrap(err, "executing union")
@@ -36,7 +36,7 @@ func Difference(a, b Geometry) (Geometry, error) {
 		return Geometry{}, nil
 	}
 	if b.IsEmpty() {
-		return a, nil
+		return UnaryUnion(a)
 	}
 	g, err := setOp(a, andNot, b)
 	return g, wrap(err, "executing difference")
@@ -50,13 +50,25 @@ func SymmetricDifference(a, b Geometry) (Geometry, error) {
 		return Geometry{}, nil
 	}
 	if a.IsEmpty() {
-		return b, nil
+		return UnaryUnion(b)
 	}
 	if b.IsEmpty() {
-		return a, nil
+		return UnaryUnion(a)
 	}
 	g, err := setOp(a, xor, b)
 	return g, wrap(err, "executing symmetric difference")
+}
+
+// UnaryUnion is a single input variant of the Union function, unioning
+// together the components of the input geometry.
+func UnaryUnion(g Geometry) (Geometry, error) {
+	return setOp(g, or, Geometry{})
+}
+
+// UnionMany unions together the input geometries.
+func UnionMany(gs []Geometry) (Geometry, error) {
+	gc := NewGeometryCollection(gs)
+	return UnaryUnion(gc.AsGeometry())
 }
 
 func setOp(a Geometry, include func([2]bool) bool, b Geometry) (Geometry, error) {


### PR DESCRIPTION
## Description

commit 2fd7d4f4d35715462be7d67ad1710f4d6b5ec961
Author: Peter Stace <peterstace@gmail.com>
Date:   Sat Nov 12 12:39:11 2022 +1100

    Add `UnaryUnion` and `UnionMany`
    
    Because the DCEL algorithm supports `GeometryCollections`, the
    `UnaryUnion` and `UnionMany` implementations are relatively trivial.
    
    This PR also fixes a bug where an empty geometry and geometry collection
    were input to `Union` or `(Symmetric)Difference`. The non-empty operand
    was returned unaltered. The fixed behaviour now unions together the
    non-empty geometry operand.


## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A, `UnaryUnion` and `UnionMany` not exposed by the GEOS C wrapper.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/476
- https://github.com/peterstace/simplefeatures/issues/464

## Benchmark Results

- N/A, new functionality.