### PR TITLE
Make DCEL geometry extraction ordering deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   would return the `GeometryCollection` unaltered (rather than unioning it
   together).
 
+- Make DCEL operation output ordering deterministic.
+
 ## v0.40.1
 
 2022-11-08

--- a/geom/alg_set_op_test.go
+++ b/geom/alg_set_op_test.go
@@ -1471,3 +1471,24 @@ func TestUnaryUnionAndUnionMany(t *testing.T) {
 		})
 	}
 }
+
+func TestBinaryOpOutputOrdering(t *testing.T) {
+	for i, tc := range []struct {
+		wkt string
+	}{
+		{"MULTIPOINT(1 2,2 3)"},
+		{"MULTILINESTRING((1 2,2 3),(3 4,4 5))"},
+		{"POLYGON((0 0,0 4,4 4,4 0,0 0),(1 1,1 2,2 2,2 1,1 1),(2 2,2 3,3 3,3 2,2 2))"},
+		{"MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((1 1,1 2,2 2,2 1,1 1)))"},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			in := geomFromWKT(t, tc.wkt)
+			got1, err := geom.Union(in, in)
+			expectNoErr(t, err)
+			got2, err := geom.Union(in, in)
+			expectNoErr(t, err)
+			// Ensure ordering is stable over multiple executions:
+			expectGeomEq(t, got1, got2)
+		})
+	}
+}

--- a/geom/dcel_extract_geometry.go
+++ b/geom/dcel_extract_geometry.go
@@ -1,6 +1,9 @@
 package geom
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // extractGeometry converts the DECL into a Geometry that represents it.
 func (d *doublyConnectedEdgeList) extractGeometry(include func([2]bool) bool) (Geometry, error) {
@@ -70,7 +73,6 @@ func (d *doublyConnectedEdgeList) extractPolygons(include func([2]bool) bool) ([
 		for f := range facesInPoly {
 			f.extracted = true
 			forEachEdgeInCycle(f.cycle, func(edge *halfEdgeRecord) {
-
 				// Mark all edges and vertices intersecting with the polygon as
 				// being extracted.  This will prevent them being considered
 				// during linear and point geometry extraction.
@@ -87,35 +89,34 @@ func (d *doublyConnectedEdgeList) extractPolygons(include func([2]bool) bool) ([
 					seen[edge] = true
 					return
 				}
-				seq := extractPolygonBoundary(facesInPoly, edge, seen)
-				ring, err := NewLineString(seq)
-				if err != nil {
-					panic(fmt.Sprintf("could not create LineString: %v", err))
-				}
+				ring := extractPolygonRing(facesInPoly, edge, seen)
 				rings = append(rings, ring)
 			})
 		}
 
 		// Construct the polygon.
-		orderCCWRingFirst(rings)
+		orderPolygonRings(rings)
 		poly, err := NewPolygon(rings)
 		if err != nil {
 			return nil, err
 		}
 		polys = append(polys, poly)
 	}
+
+	sort.Slice(polys, func(i, j int) bool {
+		seqI := polys[i].ExteriorRing().Coordinates()
+		seqJ := polys[j].ExteriorRing().Coordinates()
+		return seqI.less(seqJ)
+	})
 	return polys, nil
 }
 
-func extractPolygonBoundary(faceSet map[*faceRecord]bool, start *halfEdgeRecord, seen map[*halfEdgeRecord]bool) Sequence {
-	var coords []float64
+func extractPolygonRing(faceSet map[*faceRecord]bool, start *halfEdgeRecord, seen map[*halfEdgeRecord]bool) LineString {
+	var seqs []Sequence
 	e := start
 	for {
 		seen[e] = true
-		for i := 0; i < e.seq.Length()-1; i++ {
-			xy := e.seq.GetXY(i)
-			coords = append(coords, xy.X, xy.Y)
-		}
+		seqs = append(seqs, e.seq)
 
 		// Sweep through the edges around the vertex (in a counter-clockwise
 		// order) until we find the next edge that is part of the polygon
@@ -129,8 +130,68 @@ func extractPolygonBoundary(faceSet map[*faceRecord]bool, start *halfEdgeRecord,
 			break
 		}
 	}
+
+	// Reorder seqs such that one of them comes first in a deterministic
+	// manner. The sequences still have to form a ring, so they're rotated
+	// rather than sorted.
+	minI := 0
+	for i := range seqs {
+		if seqs[i].less(seqs[minI]) {
+			minI = i
+		}
+	}
+	rotateSeqs(seqs, len(seqs)-minI)
+
+	ring, err := NewLineString(buildRingSequence(seqs))
+	if err != nil {
+		panic(fmt.Sprintf("could not create LineString: %v", err))
+	}
+	return ring
+}
+
+func buildRingSequence(seqs []Sequence) Sequence {
+	// Calculate desired capacity.
+	var capacity int
+	for _, seq := range seqs {
+		capacity += 2 * seq.Length()
+	}
+	capacity -= 2 * len(seqs) // Account for shared point at start/end of each seq.
+	capacity += 2             // Account for repeated start/end point of ring.
+
+	// Build concatenated sequence.
+	coords := make([]float64, 0, capacity)
+	for _, seq := range seqs {
+		coords = seq.appendAllPoints(coords)
+		coords = coords[:len(coords)-2]
+	}
 	coords = append(coords, coords[:2]...)
-	return NewSequence(coords, DimXY)
+	seq := NewSequence(coords, DimXY)
+	seq.assertNoUnusedCapacity()
+	return seq
+}
+
+// rotateSeqs moves each sequence rotRight places to the right, wrapping around
+// the end of the slice to the start of the slice.
+//
+// TODO: use generics for this once we depend on Go 1.19.
+func rotateSeqs(seqs []Sequence, rotRight int) {
+	if rotRight == 0 || rotRight == len(seqs) {
+		return // Nothing to do (optimisation).
+	}
+	reverseSeqs(seqs)
+	reverseSeqs(seqs[:rotRight])
+	reverseSeqs(seqs[rotRight:])
+}
+
+// reverseSeqs reverses the order of the input slice.
+//
+// TODO: use generics for this once we depend on Go 1.19.
+func reverseSeqs(seqs []Sequence) {
+	n := len(seqs)
+	for i := 0; i < n/2; i++ {
+		j := n - i - 1
+		seqs[i], seqs[j] = seqs[j], seqs[i]
+	}
 }
 
 // findFacesMakingPolygon finds all faces that belong to the polygon that
@@ -166,21 +227,30 @@ func findFacesMakingPolygon(include func([2]bool) bool, start *faceRecord) map[*
 	return expanded
 }
 
-// orderCCWRingFirst reorders rings such that if it contains at least one CCW
-// ring, then a CCW ring is the first element.
-func orderCCWRingFirst(rings []LineString) {
+// orderPolygonRings reorders rings such that the outer (CCW) ring comes first,
+// and any inner (CW) rings are ordered afterwards in a stable way.
+func orderPolygonRings(rings []LineString) {
 	for i, r := range rings {
 		if ccw := signedAreaOfLinearRing(r, nil) > 0; ccw {
 			rings[i], rings[0] = rings[0], rings[i]
-			return
+			break
 		}
 	}
+	inners := rings[1:]
+	sort.Slice(inners, func(i, j int) bool {
+		seqI := inners[i].Coordinates()
+		seqJ := inners[j].Coordinates()
+		return seqI.less(seqJ)
+	})
 }
 
 func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]bool) bool) ([]LineString, error) {
 	var lss []LineString
 	for _, e := range d.halfEdges {
 		if shouldExtractLine(e, include) {
+			if e.twin.seq.less(e.seq) {
+				e = e.twin // Extract in deterministic order.
+			}
 			e.extracted = true
 			e.twin.extracted = true
 			e.origin.extracted = true
@@ -193,6 +263,11 @@ func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]bool) bool)
 			lss = append(lss, ls)
 		}
 	}
+	sort.Slice(lss, func(i, j int) bool {
+		seqI := lss[i].Coordinates()
+		seqJ := lss[j].Coordinates()
+		return seqI.less(seqJ)
+	})
 	return lss, nil
 }
 
@@ -207,16 +282,25 @@ func shouldExtractLine(e *halfEdgeRecord, include func([2]bool) bool) bool {
 // output geometry, but aren't yet represented as part of any previously
 // extracted geometries.
 func (d *doublyConnectedEdgeList) extractPoints(include func([2]bool) bool) ([]Point, error) {
-	var pts []Point
+	xys := make([]XY, 0, len(d.vertices))
 	for _, vert := range d.vertices {
 		if include(vert.inSet) && !vert.extracted {
 			vert.extracted = true
-			pt, err := vert.coords.AsPoint()
-			if err != nil {
-				return nil, err
-			}
-			pts = append(pts, pt)
+			xys = append(xys, vert.coords)
 		}
+	}
+
+	sort.Slice(xys, func(i, j int) bool {
+		return xys[i].Less(xys[j])
+	})
+
+	pts := make([]Point, 0, len(xys))
+	for _, xy := range xys {
+		pt, err := xy.AsPoint()
+		if err != nil {
+			return nil, err
+		}
+		pts = append(pts, pt)
 	}
 	return pts, nil
 }

--- a/geom/type_sequence.go
+++ b/geom/type_sequence.go
@@ -170,6 +170,22 @@ func (s Sequence) assertNoUnusedCapacity() {
 	}
 }
 
+// less gives a lexicographical ordering between sequences, considering only
+// the XY parts of each coordinate when they have Z or M components.
+func (s Sequence) less(o Sequence) bool {
+	oLen := o.Length()
+	for i := 0; i < s.Length(); i++ {
+		if i >= oLen {
+			return true
+		}
+		sxy, oxy := s.GetXY(i), o.GetXY(i)
+		if sxy != oxy {
+			return sxy.Less(oxy)
+		}
+	}
+	return false
+}
+
 // getLine extracts a 2D line segment from a sequence by joining together
 // adjacent locations in the sequence. It is designed to be called with i equal
 // to each index in the sequence (from 0 to n-1, both inclusive). The flag


### PR DESCRIPTION
## Description

commit 9c7dfea5f505ff5488334bc1e397c970703659f4
Author: Peter Stace <peterstace@gmail.com>
Date:   Sun Nov 13 05:45:29 2022 +1100

    Make DCEL geometry extraction ordering deterministic
    
    https://github.com/peterstace/simplefeatures/pull/472 introduced some
    fixes for `GeometryCollection` inputs for DCEL operations. This change
    modified the DCEL data structure to store most state in maps rather than
    slices.
    
    The geometry extraction phase of the DCEL algorithm iterates over all of
    the DCEL state, building up the output `Geometry`. Map iteration order
    in Go is non-deterministic, resulting in the ordering within the output
    `Geometry` also being non-deterministic.
    
    Specifically:
    
    - `Points` within `MultiPoint`s could occur in any order.
    
    - Each `LineString` could be in one of two orders (forward and
      reverse variants).
    
    - The `LineString` constituents in a `MultiLineString` could occur in
      any order.
    
    - `Polygon` inner rings could occur in any order.
    
    - `Polygon` rings (inner or outer) could start at any arbitrary point.
    
    - The `Polygon` constituents in a `MultiPolygon` could occur in any
      order.
    
    This PR makes the ordering of all geometry components mentioned above
    arbitrary but deterministic.


## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/478

## Benchmark Results

- Please paste benchmark results here. The benchmarks can be run using the
  `run_benchmarks.sh` script.

<details>

<summary>Click to expand</summary>

```
PASTE BENCHMARKS HERE
```

</details>