### PR TITLE
Make IgnoreOrder a func rather than a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Make `IgnoreOrder` a function rather than a global variable to prevent
+  consumers from erroneously altering its behaviour.
+
 ## v0.41.0
 
 2022-11-15

--- a/geom/alg_exact_equals.go
+++ b/geom/alg_exact_equals.go
@@ -44,8 +44,9 @@ func (c exactEqualsComparator) eq(a, b Coordinates) bool {
 	return true
 }
 
-// IgnoreOrder modifies the behaviour of the ExactEquals method by ignoring
-// ordering that doesn't have a material impact on geometries.
+// IgnoreOrder is an ExactEqualsOption that modifies the behaviour of the
+// ExactEquals method by ignoring ordering that doesn't have a material impact
+// on geometries.
 //
 // For Points, there is no ordering, so this option does nothing.
 //
@@ -59,12 +60,10 @@ func (c exactEqualsComparator) eq(a, b Coordinates) bool {
 // For collections (MultiPoint, MultiLineString, MultiPolygon, and
 // GeometryCollection), the ordering of constituent elements in the collection
 // are ignored.
-var IgnoreOrder = ExactEqualsOption(
-	func(c exactEqualsComparator) exactEqualsComparator {
-		c.ignoreOrder = true
-		return c
-	},
-)
+func IgnoreOrder(c exactEqualsComparator) exactEqualsComparator {
+	c.ignoreOrder = true
+	return c
+}
 
 // ExactEquals checks if two geometries are equal from a structural pointwise
 // equality perspective. Geometries that are structurally equal are defined by


### PR DESCRIPTION
## Description

The variable was a global variable, and could (theoretically) be changed by any user, altering its behaviour.

## Check List

Have you:

- Added unit tests? No, relies on existing.

- Add cmprefimpl tests? (if appropriate?). N/A.

- Updated release notes? (if appropriate?). Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/481

## Benchmark Results

N/A.