### PR TITLE
Simplify the `Type` method of the `Geometry` type

### DIFF
--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -54,26 +54,9 @@ func (t GeometryType) String() string {
 	}
 }
 
-// Type returns a string representation of the geometry's type.
+// Type returns the type of the Geometry.
 func (g Geometry) Type() GeometryType {
-	switch g.gtype {
-	case TypeGeometryCollection:
-		return g.MustAsGeometryCollection().Type()
-	case TypePoint:
-		return g.MustAsPoint().Type()
-	case TypeLineString:
-		return g.MustAsLineString().Type()
-	case TypePolygon:
-		return g.MustAsPolygon().Type()
-	case TypeMultiPoint:
-		return g.MustAsMultiPoint().Type()
-	case TypeMultiLineString:
-		return g.MustAsMultiLineString().Type()
-	case TypeMultiPolygon:
-		return g.MustAsMultiPolygon().Type()
-	default:
-		panic("unknown geometry: " + g.gtype.String())
-	}
+	return g.gtype
 }
 
 // IsGeometryCollection return true iff the Geometry is a GeometryCollection geometry.


### PR DESCRIPTION
## Description

No need for the switch statement since we already have direct access to the geometry type. The switch statement is likely a remnant of extracting out geometry type (a _long_ time ago). The only functional difference here is that if a Geometry is somehow constructed with an invalid geometry type (which should be impossible), then the `Type` method will no longer panic but instead just return the invalid geometry type.

## Check List

Have you:

- Added unit tests? Not needed, since there's no testable functional change.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) N/A, not a change that's visible to users.

## Related Issue

- N/A

## Benchmark Results

- Skipped, since this definitely won't have a performance impact.