### PR TITLE
Minor cleanup for radial sorting

### DIFF
--- a/geom/alg_exact_equals.go
+++ b/geom/alg_exact_equals.go
@@ -32,7 +32,7 @@ func (c exactEqualsComparator) eq(a, b Coordinates) bool {
 		return false
 	}
 	asb := a.XY.Sub(b.XY)
-	if asb.Dot(asb) > c.toleranceSq {
+	if asb.lengthSq() > c.toleranceSq {
 		return false
 	}
 	if a.Type.Is3D() && a.Z != b.Z {

--- a/geom/alg_point_on_surface.go
+++ b/geom/alg_point_on_surface.go
@@ -29,7 +29,7 @@ func (n *nearestPointAccumulator) consider(candidate Point) {
 	}
 
 	delta := targetXY.Sub(candidateXY)
-	candidateDist := delta.Dot(delta)
+	candidateDist := delta.lengthSq()
 	if n.point.IsEmpty() || candidateDist < n.dist {
 		n.dist = candidateDist
 		n.point = candidate

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -3,7 +3,6 @@ package geom
 import (
 	"database/sql/driver"
 	"fmt"
-	"math"
 	"unsafe"
 
 	"github.com/peterstace/simplefeatures/rtree"
@@ -334,7 +333,7 @@ func (s LineString) Length() float64 {
 		xyA := s.seq.GetXY(i)
 		xyB := s.seq.GetXY(i + 1)
 		delta := xyA.Sub(xyB)
-		sum += math.Sqrt(delta.Dot(delta))
+		sum += delta.Length()
 	}
 	return sum
 }

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -101,7 +101,7 @@ func (w XY) Length() float64 {
 	return math.Sqrt(w.lengthSq())
 }
 
-// lengthSq treads XY as a vector, and returns its squared length.
+// lengthSq treats XY as a vector, and returns its squared length.
 func (w XY) lengthSq() float64 {
 	return w.Dot(w)
 }

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -98,7 +98,12 @@ func (w XY) Unit() XY {
 
 // Length treats XY as a vector, and returns its length.
 func (w XY) Length() float64 {
-	return math.Sqrt(w.Dot(w))
+	return math.Sqrt(w.lengthSq())
+}
+
+// lengthSq treads XY as a vector, and returns its squared length.
+func (w XY) lengthSq() float64 {
+	return w.Dot(w)
 }
 
 // Less gives an ordering on XYs. If two XYs have different X values, then the


### PR DESCRIPTION
## Description

- The radial sort 'less' function is extracted out into its own standalone function, making the parent function (`fixVertex`) not need to know about the details of the sort.

- A new `XY` method `lengthSq` is added, that computes the square of the length of the distance between the origin and the XY value.

- The `Cross` and `lengthSq` methods are used for radial sorting rather than reimplementing the logic for those computations.

## Check List

Have you:

- Added unit tests? N/A, relies on existing.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/474

## Benchmark Results

Not run yet.