### PR TITLE
Orient Polygon and MultiPolygon rings before GeoJSON marshalling

### DIFF
--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -307,6 +307,7 @@ func (m MultiPolygon) ConvexHull() Geometry {
 // MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (m MultiPolygon) MarshalJSON() ([]byte, error) {
+	m = m.ForceCCW()
 	var dst []byte
 	dst = append(dst, `{"type":"MultiPolygon","coordinates":`...)
 	dst = appendGeoJSONSequenceMatrix(dst, m.Coordinates())

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -299,6 +299,7 @@ func (p Polygon) ConvexHull() Geometry {
 // MarshalJSON implements the encoding/json.Marshaler interface by encoding
 // this geometry as a GeoJSON geometry object.
 func (p Polygon) MarshalJSON() ([]byte, error) {
+	p = p.ForceCCW()
 	var dst []byte
 	dst = append(dst, `{"type":"Polygon","coordinates":`...)
 	dst = appendGeoJSONSequences(dst, p.Coordinates())


### PR DESCRIPTION
## Description

This is to better follow RFC7946. See https://datatracker.ietf.org/doc/html/rfc7946 and linked issue for details.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?)

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/482