### PR TITLE
Fixes for `aarch64` CI

### DIFF
--- a/.ci/docker-compose-cmppg.yml
+++ b/.ci/docker-compose-cmppg.yml
@@ -1,7 +1,9 @@
 version: "2.1"
 services:
   postgis:
-    image: mdillon/postgis
+    image: ghcr.io/baosystems/postgis
+    environment:
+      POSTGRES_PASSWORD: password
     healthcheck:
       test: "pg_isready -U postgres"
       interval: '100ms'

--- a/.ci/docker-compose-cmppg.yml
+++ b/.ci/docker-compose-cmppg.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   postgis:
-    image: ghcr.io/baosystems/postgis:11
+    image: ghcr.io/baosystems/postgis:15
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:

--- a/.ci/docker-compose-cmppg.yml
+++ b/.ci/docker-compose-cmppg.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   postgis:
-    image: ghcr.io/baosystems/postgis
+    image: ghcr.io/baosystems/postgis:11
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:

--- a/.ci/docker-compose-pgscan.yml
+++ b/.ci/docker-compose-pgscan.yml
@@ -1,7 +1,9 @@
 version: "2.1"
 services:
   postgis:
-    image: mdillon/postgis
+    image: ghcr.io/baosystems/postgis
+    environment:
+      POSTGRES_PASSWORD: password
     healthcheck:
       test: "pg_isready -U postgres"
       interval: '100ms'

--- a/.ci/docker-compose-pgscan.yml
+++ b/.ci/docker-compose-pgscan.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   postgis:
-    image: ghcr.io/baosystems/postgis:11
+    image: ghcr.io/baosystems/postgis:15
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:

--- a/.ci/docker-compose-pgscan.yml
+++ b/.ci/docker-compose-pgscan.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   postgis:
-    image: ghcr.io/baosystems/postgis
+    image: ghcr.io/baosystems/postgis:11
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:

--- a/.ci/run_ci.sh
+++ b/.ci/run_ci.sh
@@ -5,11 +5,11 @@ set -eo pipefail
 start="$(date +%s.%N)"
 here="$(dirname "$(readlink -f "$0")")"
 
-docker-compose -f "$here/docker-compose-lint.yml"    up --abort-on-container-exit
-docker-compose -f "$here/docker-compose-unit.yml"    up --abort-on-container-exit
-docker-compose -f "$here/docker-compose-geos.yml"    up --abort-on-container-exit
-docker-compose -f "$here/docker-compose-pgscan.yml"  up --abort-on-container-exit
-docker-compose -f "$here/docker-compose-cmppg.yml"   up --abort-on-container-exit
-docker-compose -f "$here/docker-compose-cmpgeos.yml" up --abort-on-container-exit
+docker-compose -p sf-lint    -f "$here/docker-compose-lint.yml"    up --abort-on-container-exit
+docker-compose -p sf-unit    -f "$here/docker-compose-unit.yml"    up --abort-on-container-exit
+docker-compose -p sf-geos    -f "$here/docker-compose-geos.yml"    up --abort-on-container-exit
+docker-compose -p sf-pgscan  -f "$here/docker-compose-pgscan.yml"  up --abort-on-container-exit
+docker-compose -p sf-cmppg   -f "$here/docker-compose-cmppg.yml"   up --abort-on-container-exit
+docker-compose -p sf-cmpgeos -f "$here/docker-compose-cmpgeos.yml" up --abort-on-container-exit
 
 printf "\nduration: %.1f seconds\n" "$(echo "$(date +%s.%N) - $start" | bc)"

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -732,7 +732,14 @@ func TestBuffer(t *testing.T) {
 			t.Logf("WKT: %v", g.AsText())
 			got, err := Buffer(g, tt.radius, tt.opts...)
 			expectNoErr(t, err)
-			expectGeomEq(t, got, geomFromWKT(t, tt.want), geom.IgnoreOrder)
+			expectGeomEq(t, got, geomFromWKT(t, tt.want),
+				// Different versions of GEOS can output geometry parts in
+				// different orders, but there is no semantic difference.
+				geom.IgnoreOrder,
+				// Account for some slight differences in GEOS behaviour
+				// between `x86_64` and `aarch64`:
+				geom.ToleranceXY(1e-15),
+			)
 		})
 	}
 }

--- a/internal/cmprefimpl/cmppg/fuzz_test.go
+++ b/internal/cmprefimpl/cmppg/fuzz_test.go
@@ -39,6 +39,9 @@ func TestFuzz(t *testing.T) {
 				t.Skip("Causes unmarshalling to fail for derivative geometry")
 			}
 
+			if isMultiPointWithEmptyPoint(g) {
+				t.Skip("PostGIS cannot handle MultiPoints that contain empty Points")
+			}
 			want, err := BatchPostGIS(pg).Unary(g)
 			if err != nil {
 				t.Fatalf("could not get result from postgis: %v", err)
@@ -157,4 +160,17 @@ func convertToGeometries(t *testing.T, candidates []string) []geom.Geometry {
 	}
 
 	return geoms
+}
+
+func isMultiPointWithEmptyPoint(g geom.Geometry) bool {
+	mp, ok := g.AsMultiPoint()
+	if !ok {
+		return false
+	}
+	for i := 0; i < mp.NumPoints(); i++ {
+		if mp.PointN(i).IsEmpty() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cmprefimpl/cmppg/pg.go
+++ b/internal/cmprefimpl/cmppg/pg.go
@@ -48,6 +48,11 @@ const (
 
 // Unary runs a batch of unary operations on a geometry.
 func (p BatchPostGIS) Unary(g geom.Geometry) (UnaryResult, error) {
+	// Retry several times because requests to PostGIS can intermittently fail.
+	// Requests to PostGIS could fail for many reasons. For example, a previous
+	// test case could cause PostGIS to segfault, causing it to restart (so it
+	// may not yet be ready to accept connections by the time this test
+	// executes).
 	var i int
 	for {
 		u, err := p.tryUnary(g)


### PR DESCRIPTION
## Description

These fixes will allow CI to execute for `aarch64` architecture:

- Use a multi-arch image for `postgis`.

- Add XY tolerance when comparing buffer outputs in GEOS reference implementation tests (because `aarch64` and `x86_64` provide slightly different outputs).

- Adds project names for each docker-compose step, to prevent warnings about orphaned containers (not strictly required for `aarch64`).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/364