### PR TITLE
Trigger Github Actions only once per commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: build
 on:
   push:
-  pull_request:
-  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Previously, CI via Github Actions would be triggered multiple times per push if there is an open PR for the corresponding branch. When a developer pushes a new commit, the first run would be triggered by the `push` event, and the second run triggered by the `pull_request` event (because pushing new commits _alters_ the pull request).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

- N/A