### PR TITLE
Fix incorrect line/line intersection on `aarch64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fix a bug affecting only `aarch64` that caused wrong results to be given for
+  line/line intersections. The bug did **not** effect `x64_64`.
+
+## Unreleased
+
 - Make `IgnoreOrder` a function rather than a global variable to prevent
   consumers from erroneously altering its behaviour.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Fix a bug affecting only `aarch64` that caused wrong results to be given for
+  line/line intersections. The bug did **not** effect `x64_64`.
+
 ## v0.42.0
 
 2023-04-02
 
 __Special thanks to Lachlan Patrick and Albert Teoh for contributing to this release.__
-
-- Fix a bug affecting only `aarch64` that caused wrong results to be given for
-  line/line intersections. The bug did **not** effect `x64_64`.
-
-## Unreleased
 
 - Make `IgnoreOrder` a function rather than a global variable to prevent
   consumers from erroneously altering its behaviour.

--- a/geom/alg_intersects_test.go
+++ b/geom/alg_intersects_test.go
@@ -125,6 +125,7 @@ func TestIntersects(t *testing.T) {
 		{"LINESTRING(0 0,1 0)", "LINESTRING(0 0,1 0)", true},
 		{"LINESTRING(1 1,2 2)", "LINESTRING(0 0,3 3)", true},
 		{"LINESTRING(3 1,2 2)", "LINESTRING(1 3,2 2)", true},
+		{"LINESTRING(-1 1,1 -1)", "LINESTRING(-0.5 0.5,-0.1 0.1)", true},
 
 		// Line/LineString
 		{"LINESTRING(0 0,1 1)", "LINESTRING EMPTY", false},

--- a/geom/alg_set_op_test.go
+++ b/geom/alg_set_op_test.go
@@ -1138,6 +1138,11 @@ func TestBinaryOp(t *testing.T) {
 			input2: "POLYGON EMPTY",
 			union:  "POLYGON((0 0,0 1,1 1,1 0,0 0))",
 		},
+		{
+			input1: "LINESTRING(0 0,0 0,0 1,1 0,0 0)",
+			input2: "LINESTRING(0.1 0.1,0.5 0.5)",
+			inter:  "POINT(0.5 0.5)",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g1 := geomFromWKT(t, geomCase.input1)

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -183,6 +183,7 @@ func TestIsSimple(t *testing.T) {
 		{"MULTILINESTRING((0 0,1 0),(0 1,1 1))", true},
 		{"MULTILINESTRING((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))", true},
 		{"MULTILINESTRING((1 1,1 0,0 0),(1 1,0 1,0 0))", true},
+		{"MULTILINESTRING((0 0,0.1 0.1),(0.1 0.1,1 1))", true},
 
 		// Cases for behaviour around duplicated lines.
 		{"MULTILINESTRING((1 1,2 2),(1 1,2 2))", false},

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -78,9 +78,9 @@ func (w XY) Scale(s float64) XY {
 // Cross returns the 2D cross product of this and another XY. This is defined
 // as the 'z' coordinate of the regular 3D cross product.
 func (w XY) Cross(o XY) float64 {
-	// Avoid fused multi-add by explicitly converting intermediate products to
-	// float64. This ensures that the cross product is *exactly* zero for all
-	// non linearly independent inputs.
+	// Avoid fused multiply-add by explicitly converting intermediate products
+	// to float64. This ensures that the cross product is *exactly* zero for
+	// all linearly dependent inputs.
 	return float64(w.X*o.Y) - float64(w.Y*o.X)
 }
 

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -78,7 +78,10 @@ func (w XY) Scale(s float64) XY {
 // Cross returns the 2D cross product of this and another XY. This is defined
 // as the 'z' coordinate of the regular 3D cross product.
 func (w XY) Cross(o XY) float64 {
-	return (w.X * o.Y) - (w.Y * o.X)
+	// Avoid fused multi-add by explicitly converting intermediate products to
+	// float64. This ensures that the cross product is *exactly* zero for all
+	// non linearly independent inputs.
+	return float64(w.X*o.Y) - float64(w.Y*o.X)
 }
 
 // Midpoint returns the midpoint of this and another XY.

--- a/geom/xy_test.go
+++ b/geom/xy_test.go
@@ -66,7 +66,7 @@ func TestXYCross(t *testing.T) {
 		{u: xy(1, 1), v: xy(0, 0), want: 0},
 		{u: xy(0.1, 0.1), v: xy(0, 0), want: 0},
 
-		// Not linearly independent:
+		// Linearly dependent:
 		{u: xy(1, 1), v: xy(2, 2), want: 0},
 		{u: xy(-1, -1), v: xy(2, 2), want: 0},
 

--- a/geom/xy_test.go
+++ b/geom/xy_test.go
@@ -2,6 +2,7 @@ package geom_test
 
 import (
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -49,6 +50,43 @@ func TestXYUnit(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			got := tc.input.Unit()
 			expectXYWithinTolerance(t, got, tc.output, 0.0000001)
+		})
+	}
+}
+
+func TestXYCross(t *testing.T) {
+	xy := func(x, y float64) geom.XY {
+		return geom.XY{X: x, Y: y}
+	}
+	for i, tc := range []struct {
+		u, v geom.XY
+		want float64
+	}{
+		// Contains zero:
+		{u: xy(1, 1), v: xy(0, 0), want: 0},
+		{u: xy(0.1, 0.1), v: xy(0, 0), want: 0},
+
+		// Not linearly independent:
+		{u: xy(1, 1), v: xy(2, 2), want: 0},
+		{u: xy(-1, -1), v: xy(2, 2), want: 0},
+
+		// Reproduces numeric precision bug that occurred on aarch64 but *not* x86_64.
+		{u: xy(0.2, 0.2), v: xy(0.1, 0.1), want: 0},
+
+		// Linearly independent:
+		{u: xy(1, 0), v: xy(0, 1), want: 1},
+		{u: xy(0, 2), v: xy(1, 0), want: -2},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Run("fwd", func(t *testing.T) {
+				got := tc.u.Cross(tc.v)
+				expectFloat64Eq(t, got, tc.want)
+			})
+			t.Run("rev", func(t *testing.T) {
+				got := tc.v.Cross(tc.u)
+				want := -tc.want // Cross product is anti-commutative.
+				expectFloat64Eq(t, got, want)
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes a bug where the result of intersecting two lines segments is sometimes incorrect.

The bug only occurs in `aarch64` and is due to an unanticipated [fused multiply-add](https://en.wikipedia.org/wiki/Multiply%E2%80%93accumulate_operation) (FMA) operation. The FMA causes the cross product method to return very small but non-zero results for linearly dependent inputs (i.e. two vectors that are scaled versions of each other).

The bug does **not** occur on `x64_64`.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?)

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/364