### PR TITLE
Add CoverageUnion wrapper to `geos` package

### DIFF
--- a/geos/entrypoints.go
+++ b/geos/entrypoints.go
@@ -348,9 +348,20 @@ func MakeValid(g geom.Geometry, opts ...geom.ConstructorOption) (geom.Geometry, 
 	return result, wrap(err, "executing GEOSMakeValid_r")
 }
 
-// CoverageUnion unions together polygonal inputs (typically held in a
-// GeometryCollection). The inputs must be correctly noded and not overlap. An
-// error will be returned if those constraints are not met.
+// The CoverageUnion function is used to union polygonal inputs that form a
+// coverage, which are typically provided as a GeometryCollection. This method
+// is much faster than other unioning methods, but there are some constraints
+// that must be met by the inputs to form a valid polygonal coverage. These
+// constraints are:
+//
+//  1. all input geometries must be polygonal,
+//  2. the inputs must not overlap, and
+//  3. the input boundaries must be noded in the same way.
+//
+// It should be noted that while CoverageUnion may detect constraint violations
+// and return an error, but this is not guaranteed, and an invalid result may
+// be returned without an error. It is the responsibility of the caller to
+// ensure that the constraints are met before using this function.
 func CoverageUnion(g geom.Geometry, opts ...geom.ConstructorOption) (geom.Geometry, error) {
 	if C.COVERAGE_UNION_MISSING != 0 {
 		return geom.Geometry{}, unsupportedGEOSVersionError{

--- a/geos/entrypoints.go
+++ b/geos/entrypoints.go
@@ -355,8 +355,8 @@ func MakeValid(g geom.Geometry, opts ...geom.ConstructorOption) (geom.Geometry, 
 // constraints are:
 //
 //  1. all input geometries must be polygonal,
-//  2. the inputs must not overlap, and
-//  3. the input boundaries must be noded in the same way.
+//  2. the interiors of the inputs must not intersect, and
+//  3. the common boundaries of adjacent polygons have the same set of vertices in both polygons.
 //
 // It should be noted that while CoverageUnion may detect constraint violations
 // and return an error, but this is not guaranteed, and an invalid result may

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -823,11 +823,28 @@ func TestCoverageUnion(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			// Noded correctly (shared edge).
 			input: `GEOMETRYCOLLECTION(
 				POLYGON((0 0,0 1,1 0,0 0)),
 				POLYGON((1 1,0 1,1 0,1 1))
 			)`,
 			output: `POLYGON((0 0,0 1,1 1,1 0,0 0))`,
+		},
+		{
+			// Noded correctly (shared vertex but no shared edge).
+			input: `GEOMETRYCOLLECTION(
+				POLYGON((0 0,0 1,1 1,1 0,0 0)),
+				POLYGON((1 1,1 2,2 2,2 1,1 1))
+			)`,
+			output: `MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((1 1,1 2,2 2,2 1,1 1)))`,
+		},
+		{
+			// Noded correctly (completely disjoint).
+			input: `GEOMETRYCOLLECTION(
+				POLYGON((0 0,0 1,1 1,1 0,0 0)),
+				POLYGON((2 2,2 3,3 3,3 2,2 2))
+			)`,
+			output: `MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 2,2 3,3 3,3 2,2 2)))`,
 		},
 		{
 			// Input constraint violated: inputs overlap.

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -853,6 +853,11 @@ func TestCoverageUnion(t *testing.T) {
 			)`,
 			wantErr: true,
 		},
+		{
+			// Input constraint violation: not everything is a polygon.
+			input:   `GEOMETRYCOLLECTION(POINT(1 2),POLYGON((0 0,0 1,1 0,0 0)))`,
+			wantErr: true,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			in := geomFromWKT(t, tc.input)

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -823,17 +823,34 @@ func TestCoverageUnion(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			input:  `GEOMETRYCOLLECTION(POLYGON((0 0,0 1,1 0,0 0)),POLYGON((1 1,0 1,1 0,1 1)))`,
+			input: `GEOMETRYCOLLECTION(
+				POLYGON((0 0,0 1,1 0,0 0)),
+				POLYGON((1 1,0 1,1 0,1 1))
+			)`,
 			output: `POLYGON((0 0,0 1,1 1,1 0,0 0))`,
 		},
 		{
 			// Input constraint violated: inputs overlap.
-			input:   `GEOMETRYCOLLECTION(POLYGON((0 0,0 1,1 0,0 0)),POLYGON((0 0,0 1,1 1,0 0)))`,
+			input: `GEOMETRYCOLLECTION(
+				POLYGON((0 0,0 1,1 0,0 0)),
+				POLYGON((0 0,0 1,1 1,1 0,0 0))
+			)`,
+			wantErr: true,
+		},
+		{
+			// Input constraint violated: inputs overlap and not noded correctly.
+			input: `GEOMETRYCOLLECTION(
+				POLYGON((0 0,0 1,1 0,0 0)),
+				POLYGON((0 0,0 1,1 1,0 0))
+			)`,
 			wantErr: true,
 		},
 		{
 			// Input constraint violated: not noded correctly.
-			input:   `GEOMETRYCOLLECTION(POLYGON((0 0,0 1,1 0,0 0)),POLYGON((0 0,2 0,0 -2,0 0)))`,
+			input: `GEOMETRYCOLLECTION(
+				POLYGON((0 0,0 1,1 1,1 0,0 0)),
+				POLYGON((0 1,2 1,2 2,0 2,0 1))
+			)`,
 			wantErr: true,
 		},
 	} {


### PR DESCRIPTION
## Description

- Add CoverageUnion wrapper to `geos` package. This is useful for when you want to union together geometries that are noded together and don't overlap because it's much faster than regular union.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?): Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/505