### PR TITLE
Wrap GEOS's Unary Union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleases
+
+- Adds a wrapper in the `geos` package for the `GEOSUnaryUnion_r` function
+  (exposed as `UnaryUnion`).
+
 ## v0.42.1
 
 2023-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleases
+## Unreleased
 
 - Adds a wrapper in the `geos` package for the `GEOSUnaryUnion_r` function
   (exposed as `UnaryUnion`).

--- a/geos/entrypoints.go
+++ b/geos/entrypoints.go
@@ -337,3 +337,13 @@ func MakeValid(g geom.Geometry, opts ...geom.ConstructorOption) (geom.Geometry, 
 	})
 	return result, wrap(err, "executing GEOSMakeValid_r")
 }
+
+// UnaryUnion is a single argument version of Union. It is most useful when
+// supplied with a GeometryCollection, resulting in the union of the
+// GeometryCollection's child geometries.
+func UnaryUnion(g geom.Geometry, opts ...geom.ConstructorOption) (geom.Geometry, error) {
+	result, err := unaryOpG(g, opts, func(ctx C.GEOSContextHandle_t, g *C.GEOSGeometry) *C.GEOSGeometry {
+		return C.GEOSUnaryUnion_r(ctx, g)
+	})
+	return result, wrap(err, "executing GEOSUnaryUnion_r")
+}

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -829,3 +829,21 @@ func TestMakeValid(t *testing.T) {
 		})
 	}
 }
+
+func TestUnaryUnion(t *testing.T) {
+	for i, tt := range []struct {
+		input      string
+		wantOutput string
+	}{
+		{
+			"GEOMETRYCOLLECTION(POLYGON((0 0,0 2,2 2,2 0,0 0)),POLYGON((1 1,1 3,3 3,3 1,1 1)))",
+			"POLYGON((0 0,2 0,2 1,3 1,3 3,1 3,1 2,0 2,0 0))",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got, err := UnaryUnion(geomFromWKT(t, tt.input))
+			expectNoErr(t, err)
+			expectGeomEq(t, got, geomFromWKT(t, tt.wantOutput), geom.IgnoreOrder)
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Wraps GEOS's Unary Union function, which is useful for unioning together many geometries as the child geometries of a GeometryCollection.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A