### PR TITLE
Upgrade `actions/checkout` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: CI
       run: |
         "$GITHUB_WORKSPACE/.ci/run_ci.sh"


### PR DESCRIPTION
## Description


In particular, this uses Node 16 rather than Node 12 (which has been deprecated on Github).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/499