### PR TITLE
Remove `isLeaf` flag from rtree nodes

### DIFF
--- a/rtree/bulk.go
+++ b/rtree/bulk.go
@@ -27,7 +27,7 @@ func bulkInsert(items []BulkItem) *node {
 
 	// 4 or fewer items can fit into a single node.
 	if len(items) <= 4 {
-		n := &node{isLeaf: true, numEntries: len(items)}
+		n := &node{numEntries: len(items)}
 		for i, item := range items {
 			n.entries[i] = entry{
 				box:      item.Box,
@@ -53,10 +53,7 @@ func bulkInsert(items []BulkItem) *node {
 }
 
 func bulkNode(parts ...[]BulkItem) *node {
-	root := &node{
-		numEntries: len(parts),
-		isLeaf:     false,
-	}
+	root := &node{numEntries: len(parts)}
 	for i, part := range parts {
 		child := bulkInsert(part)
 		root.entries[i].child = child

--- a/rtree/golden_test.go
+++ b/rtree/golden_test.go
@@ -139,7 +139,7 @@ func checksum(n *node) uint64 {
 	var entries []string
 	for i := 0; i < n.numEntries; i++ {
 		var entry string
-		if n.isLeaf {
+		if n.entries[i].child == nil {
 			entry = strconv.Itoa(n.entries[i].recordID)
 		} else {
 			entry = strconv.FormatUint(checksum(n.entries[i].child), 10)

--- a/rtree/rtree.go
+++ b/rtree/rtree.go
@@ -5,22 +5,23 @@ import (
 )
 
 const (
-	minChildren = 2
-	maxChildren = 4
+	minEntries = 2
+	maxEntries = 4
 )
 
-// node is a node in an R-Tree. nodes can either be leaf nodes holding entries
-// for terminal items, or intermediate nodes holding entries for more nodes.
+// node is a node in an R-Tree, holding user record IDs and/or links to deeper
+// nodes in the tree.
 type node struct {
-	entries    [maxChildren]entry
+	entries    [maxEntries]entry
 	numEntries int
 }
 
-// entry is an entry under a node, leading either to terminal items, or more nodes.
+// entry is an entry contained inside a node. An entry can either hold a user
+// record ID, or point to a deeper node in the tree (but not both). Because 0
+// is a valid record ID, the child pointer should be used to distinguish
+// between the two types of entries.
 type entry struct {
-	box Box
-
-	// For leaf nodes, recordID is populated. For non-leaf nodes, child is populated.
+	box      Box
 	child    *node
 	recordID int
 }

--- a/rtree/rtree.go
+++ b/rtree/rtree.go
@@ -14,7 +14,6 @@ const (
 type node struct {
 	entries    [maxChildren]entry
 	numEntries int
-	isLeaf     bool
 }
 
 // entry is an entry under a node, leading either to terminal items, or more nodes.
@@ -35,7 +34,7 @@ type RTree struct {
 	count int
 }
 
-// Stop is a special sentinal error that can be used to stop a search operation
+// Stop is a special sentinel error that can be used to stop a search operation
 // without any error.
 var Stop = errors.New("stop")
 
@@ -43,7 +42,7 @@ var Stop = errors.New("stop")
 // bounding box. The callback is called with the record ID for each found item.
 // If an error is returned from the callback then the search is terminated
 // early.  Any error returned from the callback is returned by RangeSearch,
-// except for the case where the special Stop sentinal error is returned (in
+// except for the case where the special Stop sentinel error is returned (in
 // which case nil will be returned from RangeSearch).
 func (t *RTree) RangeSearch(box Box, callback func(recordID int) error) error {
 	if t.root == nil {
@@ -56,7 +55,7 @@ func (t *RTree) RangeSearch(box Box, callback func(recordID int) error) error {
 			if !overlap(entry.box, box) {
 				continue
 			}
-			if n.isLeaf {
+			if entry.child == nil {
 				if err := callback(entry.recordID); err == Stop {
 					return nil
 				} else if err != nil {

--- a/rtree/rtree_test.go
+++ b/rtree/rtree_test.go
@@ -139,9 +139,6 @@ func checkInvariants(t *testing.T, rt *RTree, boxes []Box) {
 			if e.child == nil {
 				minLeafLevel = min(minLeafLevel, level)
 				maxLeafLevel = max(maxLeafLevel, level)
-				if e.child != nil {
-					t.Fatalf("leaf node has child (entry %d)", i)
-				}
 				if _, ok := unfound[e.recordID]; !ok {
 					t.Fatal("record ID found in tree but wasn't in unfound map")
 				}
@@ -162,12 +159,12 @@ func checkInvariants(t *testing.T, rt *RTree, boxes []Box) {
 		}
 		for i := current.numEntries; i < len(current.entries); i++ {
 			e := current.entries[i]
-			if e.box != (Box{}) || e.child != nil || e.recordID != 0 {
+			if e != (entry{}) {
 				t.Fatal("entry past numEntries is not the zero value")
 			}
 		}
-		if current.numEntries > maxChildren ||
-			(current != rt.root && current.numEntries < minChildren) {
+		if current.numEntries > maxEntries ||
+			(current != rt.root && current.numEntries < minEntries) {
 			t.Fatalf("%p: unexpected number of entries", current)
 		}
 	}

--- a/rtree/rtree_test.go
+++ b/rtree/rtree_test.go
@@ -101,16 +101,13 @@ func randomBox(rnd *rand.Rand, maxStart, maxWidth float64) Box {
 func checkInvariants(t *testing.T, rt *RTree, boxes []Box) {
 	var recurse func(*node, string)
 	recurse = func(current *node, indent string) {
-		t.Logf("%sNode addr=%p leaf=%t numEntries=%d", indent, current, current.isLeaf, current.numEntries)
+		t.Logf("%sNode addr=%p numEntries=%d", indent, current, current.numEntries)
 		indent += "\t"
-		if current.isLeaf {
-			for i := 0; i < current.numEntries; i++ {
-				e := current.entries[i]
+		for i := 0; i < current.numEntries; i++ {
+			e := current.entries[i]
+			if e.child == nil {
 				t.Logf("%sEntry[%d] recordID=%d box=%v", indent, i, e.recordID, e.box)
-			}
-		} else {
-			for i := 0; i < current.numEntries; i++ {
-				e := &current.entries[i]
+			} else {
 				t.Logf("%sEntry[%d] box=%v", indent, i, e.box)
 				recurse(e.child, indent+"\t")
 			}
@@ -137,12 +134,11 @@ func checkInvariants(t *testing.T, rt *RTree, boxes []Box) {
 	maxLeafLevel := math.MinInt
 	var check func(n *node, level int)
 	check = func(current *node, level int) {
-		if current.isLeaf {
-			minLeafLevel = min(minLeafLevel, level)
-			maxLeafLevel = max(maxLeafLevel, level)
-
-			for i := 0; i < current.numEntries; i++ {
-				e := current.entries[i]
+		for i := 0; i < current.numEntries; i++ {
+			e := current.entries[i]
+			if e.child == nil {
+				minLeafLevel = min(minLeafLevel, level)
+				maxLeafLevel = max(maxLeafLevel, level)
 				if e.child != nil {
 					t.Fatalf("leaf node has child (entry %d)", i)
 				}
@@ -150,10 +146,7 @@ func checkInvariants(t *testing.T, rt *RTree, boxes []Box) {
 					t.Fatal("record ID found in tree but wasn't in unfound map")
 				}
 				delete(unfound, e.recordID)
-			}
-		} else {
-			for i := 0; i < current.numEntries; i++ {
-				e := &current.entries[i]
+			} else {
 				if e.recordID != 0 {
 					t.Fatal("non-leaf has recordID")
 				}


### PR DESCRIPTION
## Description

The flag previously indicated that a node was a leaf (i.e. has no children). However, this information can just as easily be obtained on a per node-entry basis by examining whether the `child` pointer is `nil` or not.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- N/A

## Benchmark Results

No real difference:

<details>

<summary>Click to expand</summary>

```
goos: linux
goarch: arm64
pkg: github.com/peterstace/simplefeatures/geom
                                                           │ /tmp/tmp.WtGzXnDBiu │          /tmp/tmp.S0S0fYjdZK          │
                                                           │       sec/op        │     sec/op      vs base               │
LineEnvelope/0-2                                                   2.121n ±   8%    2.145n ±   4%       ~ (p=0.151 n=15)
LineEnvelope/1-2                                                   2.131n ±   1%    2.115n ±   1%       ~ (p=0.075 n=15)
LineEnvelope/2-2                                                   2.096n ±   1%    2.097n ±   1%       ~ (p=0.659 n=15)
LineEnvelope/3-2                                                   2.103n ±   1%    2.097n ±   1%       ~ (p=0.244 n=15)
MarshalWKB/polygon/n=10-2                                          92.92n ±   1%    92.79n ±   1%       ~ (p=0.486 n=15)
MarshalWKB/polygon/n=100-2                                         235.1n ±   5%    238.2n ±   2%       ~ (p=0.361 n=15)
MarshalWKB/polygon/n=1000-2                                        1.588µ ±   7%    1.674µ ±   6%       ~ (p=0.177 n=15)
MarshalWKB/polygon/n=10000-2                                       40.80µ ±  10%    42.95µ ±  37%       ~ (p=0.486 n=15)
UnmarshalWKB/polygon/n=10-2                                        158.6n ±   1%    156.7n ±   1%  -1.20% (p=0.034 n=15)
UnmarshalWKB/polygon/n=100-2                                       300.9n ±   4%    304.1n ±   6%       ~ (p=0.532 n=15)
UnmarshalWKB/polygon/n=1000-2                                      1.863µ ±   6%    1.796µ ±   4%       ~ (p=0.123 n=15)
UnmarshalWKB/polygon/n=10000-2                                     48.58µ ±  23%    46.32µ ±  17%       ~ (p=0.935 n=15)
IntersectsLineStringWithLineString/n=10-2                          714.6n ±   1%    719.3n ±   1%       ~ (p=0.546 n=15)
IntersectsLineStringWithLineString/n=100-2                         10.51µ ±   2%    10.53µ ±   1%       ~ (p=0.653 n=15)
IntersectsLineStringWithLineString/n=1000-2                        136.4µ ±   4%    139.0µ ±   5%       ~ (p=0.436 n=15)
IntersectsLineStringWithLineString/n=10000-2                       2.078m ±  11%    2.136m ±   7%       ~ (p=0.389 n=15)
IntersectsMultiPointWithMultiPoint/n=20-2                          557.5n ±   1%    559.3n ±   1%       ~ (p=0.910 n=15)
IntersectsMultiPointWithMultiPoint/n=200-2                         7.497µ ±   1%    7.528µ ±   0%       ~ (p=0.992 n=15)
IntersectsMultiPointWithMultiPoint/n=2000-2                        71.70µ ±   1%    71.43µ ±   1%       ~ (p=0.806 n=15)
IntersectsMultiPointWithMultiPoint/n=20000-2                       780.8µ ±   1%    779.0µ ±   0%       ~ (p=0.744 n=15)
PolygonSingleRingValidation/n=10-2                                 1.233µ ±   1%    1.228µ ±   2%       ~ (p=0.466 n=15)
PolygonSingleRingValidation/n=100-2                                17.99µ ±   2%    17.83µ ±   1%       ~ (p=0.752 n=15)
PolygonSingleRingValidation/n=1000-2                               282.0µ ±   1%    283.7µ ±   1%       ~ (p=0.089 n=15)
PolygonSingleRingValidation/n=10000-2                              3.407m ±   1%    3.442m ±   1%  +1.02% (p=0.019 n=15)
PolygonMultipleRingsValidation/n=4-2                               3.500µ ±   1%    3.483µ ±   0%       ~ (p=0.602 n=15)
PolygonMultipleRingsValidation/n=36-2                              29.73µ ±   2%    29.79µ ±   2%       ~ (p=0.838 n=15)
PolygonMultipleRingsValidation/n=400-2                             385.9µ ±   3%    386.8µ ±   1%       ~ (p=0.486 n=15)
PolygonMultipleRingsValidation/n=4096-2                            4.541m ±   1%    4.574m ±   1%       ~ (p=0.148 n=15)
PolygonZigZagRingsValidation/n=10-2                                5.939µ ±   1%    5.919µ ±   1%       ~ (p=0.285 n=15)
PolygonZigZagRingsValidation/n=100-2                               68.79µ ±   2%    69.86µ ±   1%       ~ (p=0.089 n=15)
PolygonZigZagRingsValidation/n=1000-2                              981.1µ ±   2%   1001.4µ ±   2%       ~ (p=0.106 n=15)
PolygonZigZagRingsValidation/n=10000-2                             12.62m ±   2%    12.64m ±   1%       ~ (p=0.870 n=15)
PolygonAnnulusValidation/n=10-2                                    1.867µ ±   1%    1.871µ ±   1%       ~ (p=0.927 n=15)
PolygonAnnulusValidation/n=100-2                                   18.78µ ±   4%    18.87µ ±   1%       ~ (p=0.911 n=15)
PolygonAnnulusValidation/n=1000-2                                  304.3µ ±   1%    306.3µ ±   1%       ~ (p=0.389 n=15)
PolygonAnnulusValidation/n=10000-2                                 4.316m ±   2%    4.326m ±   2%       ~ (p=0.305 n=15)
MultipolygonValidation/n=1-2                                       198.5n ±   1%    197.5n ±   1%       ~ (p=0.660 n=15)
MultipolygonValidation/n=4-2                                       473.4n ±   1%    475.0n ±   1%       ~ (p=0.766 n=15)
MultipolygonValidation/n=16-2                                      2.095µ ±   1%    2.096µ ±   2%       ~ (p=0.455 n=15)
MultipolygonValidation/n=64-2                                      10.19µ ±   2%    10.14µ ±   4%       ~ (p=0.512 n=15)
MultipolygonValidation/n=256-2                                     59.42µ ±   4%    58.43µ ±   1%  -1.66% (p=0.000 n=15)
MultipolygonValidation/n=1024-2                                    339.9µ ±   3%    346.1µ ±   6%       ~ (p=0.126 n=15)
MultiPolygonTwoCircles/n=10-2                                      1.828µ ±   1%    1.825µ ±   1%       ~ (p=0.879 n=15)
MultiPolygonTwoCircles/n=100-2                                     20.14µ ±   2%    20.29µ ±   2%       ~ (p=0.595 n=15)
MultiPolygonTwoCircles/n=1000-2                                    280.5µ ±   2%    285.4µ ±   4%       ~ (p=0.187 n=15)
MultiPolygonTwoCircles/n=10000-2                                   4.734m ±   8%    4.731m ±  11%       ~ (p=0.713 n=15)
MultiPolygonMultipleTouchingPoints/n=1-2                           2.532µ ±   1%    2.529µ ±   1%       ~ (p=0.798 n=15)
MultiPolygonMultipleTouchingPoints/n=10-2                          20.62µ ±   1%    20.45µ ±   1%       ~ (p=0.559 n=15)
MultiPolygonMultipleTouchingPoints/n=100-2                         259.2µ ±   1%    259.8µ ±   3%       ~ (p=0.345 n=15)
MultiPolygonMultipleTouchingPoints/n=1000-2                        3.208m ±   2%    3.180m ±   1%       ~ (p=0.202 n=15)
WKTParsing/point-2                                                 1.124µ ±   1%    1.193µ ±   2%  +6.14% (p=0.000 n=15)
DistancePolygonToPolygonOrdering/n=100_swap=false-2                25.09µ ±   2%    24.78µ ±   2%       ~ (p=0.148 n=15)
DistancePolygonToPolygonOrdering/n=100_swap=true-2                 24.82µ ±   2%    25.00µ ±   1%       ~ (p=0.870 n=15)
DistancePolygonToPolygonOrdering/n=1000_swap=false-2               464.5µ ±   3%    463.4µ ±   1%       ~ (p=0.233 n=15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2                463.6µ ±   2%    461.7µ ±   2%       ~ (p=0.389 n=15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2          3.131µ ±   3%    3.123µ ±   0%       ~ (p=0.878 n=15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2           3.129µ ±   2%    3.122µ ±   1%       ~ (p=0.361 n=15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2         33.11µ ±   2%    33.38µ ±   3%       ~ (p=0.281 n=15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2          33.16µ ±   5%    33.22µ ±   1%       ~ (p=0.480 n=15)
MultiLineStringIsSimpleManyLineStrings/n=100-2                     23.43µ ±   2%    23.68µ ±   4%  +1.09% (p=0.045 n=15)
MultiLineStringIsSimpleManyLineStrings/n=1000-2                    306.9µ ±   3%    308.0µ ±   2%       ~ (p=0.389 n=15)
ForceCWandForceCCW/0-2                                             16.11n ±   2%    16.12n ±   1%       ~ (p=0.690 n=15)
ForceCWandForceCCW/0#01-2                                          101.3n ±   1%    101.3n ±   2%       ~ (p=0.690 n=15)
ForceCWandForceCCW/1-2                                             16.20n ± 517%    16.25n ±   1%       ~ (p=0.262 n=15)
ForceCWandForceCCW/1#01-2                                          100.8n ±  84%    102.1n ±   2%       ~ (p=0.100 n=15)
ForceCWandForceCCW/2-2                                             29.68n ±   1%    29.89n ± 421%  +0.71% (p=0.003 n=15)
ForceCWandForceCCW/2#01-2                                          155.4n ±   1%    155.0n ±  81%       ~ (p=0.546 n=15)
ForceCWandForceCCW/3-2                                             29.77n ± 420%    29.89n ±   0%       ~ (p=0.736 n=15)
ForceCWandForceCCW/3#01-2                                          155.3n ±  76%    156.8n ±   2%       ~ (p=0.104 n=15)
ForceCWandForceCCW/4-2                                             43.27n ±   0%    43.42n ±   1%  +0.35% (p=0.027 n=15)
ForceCWandForceCCW/4#01-2                                          240.2n ±   0%    240.4n ±   1%       ~ (p=0.943 n=15)
ForceCWandForceCCW/5-2                                             43.33n ±  79%    43.51n ±   1%       ~ (p=0.184 n=15)
ForceCWandForceCCW/5#01-2                                          240.0n ±   1%    240.6n ±   2%       ~ (p=0.705 n=15)
ForceCWandForceCCW/6-2                                             62.36n ±   1%    62.50n ±   1%       ~ (p=0.713 n=15)
ForceCWandForceCCW/6#01-2                                          390.5n ±   3%    387.3n ±   1%       ~ (p=0.237 n=15)
EnvelopeTransformXY-2                                              140.4n ±   1%    139.6n ±   1%       ~ (p=0.108 n=15)
WKBParse/0-2                                                       422.2n ±   1%    422.2n ±   1%       ~ (p=0.862 n=15)
WKBParse/1-2                                                       421.2n ±   2%    418.6n ±   1%       ~ (p=0.233 n=15)
WKBParse/2-2                                                       484.8n ±   1%    485.7n ±   1%       ~ (p=0.721 n=15)
WKBParse/3-2                                                       486.7n ±   1%    484.0n ±   1%       ~ (p=0.705 n=15)
WKBParse/4-2                                                       557.6n ±   2%    559.9n ±   1%       ~ (p=0.976 n=15)
WKBParse/5-2                                                       429.3n ±   1%    426.8n ±   1%       ~ (p=0.767 n=15)
WKBParse/6-2                                                       503.2n ±   7%    499.8n ±   1%       ~ (p=0.237 n=15)
WKBParse/7-2                                                       487.1n ±   3%    488.1n ±   1%       ~ (p=0.976 n=15)
WKBParse/8-2                                                       586.3n ±   1%    582.1n ±   1%       ~ (p=0.361 n=15)
WKBParse/9-2                                                       311.2n ±   3%    312.3n ±   1%       ~ (p=0.506 n=15)
WKBParse/10-2                                                      311.5n ±   2%    313.5n ±   1%       ~ (p=0.911 n=15)
WKBParse/11-2                                                      313.5n ±   1%    312.0n ±   1%       ~ (p=0.406 n=15)
WKBParse/12-2                                                      306.6n ±   1%    307.6n ±   1%       ~ (p=0.329 n=15)
WKBParse/13-2                                                      596.6n ±   1%    594.8n ±   1%       ~ (p=0.798 n=15)
WKBParse/14-2                                                      712.4n ±   2%    708.3n ±   1%       ~ (p=0.205 n=15)
WKBParse/15-2                                                      716.0n ±   1%    716.8n ±   1%       ~ (p=0.783 n=15)
WKBParse/16-2                                                      852.5n ±   1%    848.1n ±   1%       ~ (p=0.493 n=15)
WKBParse/17-2                                                      705.4n ±   1%    700.8n ±   1%       ~ (p=0.300 n=15)
WKBParse/18-2                                                      909.9n ±   2%    915.5n ±   1%       ~ (p=0.675 n=15)
WKBParse/19-2                                                      908.7n ±   2%    904.2n ±   1%       ~ (p=0.202 n=15)
WKBParse/20-2                                                      1.094µ ±   5%    1.090µ ±   0%       ~ (p=0.349 n=15)
WKBParse/21-2                                                      302.6n ±   1%    300.5n ±   1%       ~ (p=0.602 n=15)
WKBParse/22-2                                                      304.4n ±   1%    303.8n ±   1%       ~ (p=0.720 n=15)
WKBParse/23-2                                                      304.5n ±   1%    300.7n ±   2%  -1.25% (p=0.029 n=15)
WKBParse/24-2                                                      298.3n ±   1%    297.5n ±   1%       ~ (p=0.300 n=15)
WKBParse/25-2                                                      1.567µ ±   3%    1.575µ ±   1%       ~ (p=0.506 n=15)
WKBParse/26-2                                                      1.979µ ±   1%    1.984µ ±   1%       ~ (p=0.645 n=15)
WKBParse/27-2                                                      1.983µ ±   1%    1.979µ ±   0%       ~ (p=0.304 n=15)
WKBParse/28-2                                                      2.464µ ±   1%    2.458µ ±   0%       ~ (p=0.674 n=15)
WKBParse/29-2                                                      301.1n ±   2%    301.8n ±   1%       ~ (p=0.546 n=15)
WKBParse/30-2                                                      304.1n ±   1%    303.1n ±   1%       ~ (p=0.830 n=15)
WKBParse/31-2                                                      304.2n ±   1%    302.7n ±   1%       ~ (p=0.721 n=15)
WKBParse/32-2                                                      299.0n ±   1%    298.8n ±   1%       ~ (p=0.467 n=15)
WKBParse/33-2                                                      570.0n ±   1%    570.0n ±   2%       ~ (p=0.480 n=15)
WKBParse/34-2                                                      664.0n ±   1%    664.0n ±   1%       ~ (p=0.660 n=15)
WKBParse/35-2                                                      659.2n ±   1%    653.6n ±   1%       ~ (p=0.233 n=15)
WKBParse/36-2                                                      721.7n ±   1%    712.8n ±   2%       ~ (p=0.412 n=15)
WKBParse/37-2                                                      811.0n ±   1%    810.3n ±   1%       ~ (p=0.838 n=15)
WKBParse/38-2                                                      969.0n ±   2%    975.3n ±   1%       ~ (p=0.505 n=15)
WKBParse/39-2                                                      968.8n ±   1%    970.5n ±   1%       ~ (p=0.519 n=15)
WKBParse/40-2                                                      1.091µ ±   1%    1.088µ ±   1%       ~ (p=0.289 n=15)
WKBParse/41-2                                                      303.4n ±   1%    303.5n ±   1%       ~ (p=0.506 n=15)
WKBParse/42-2                                                      303.6n ±   2%    307.2n ±   1%       ~ (p=0.213 n=15)
WKBParse/43-2                                                      304.7n ±   1%    306.5n ±   1%       ~ (p=0.546 n=15)
WKBParse/44-2                                                      301.8n ±   2%    299.1n ±   1%       ~ (p=0.631 n=15)
WKBParse/45-2                                                      896.0n ±   1%    888.1n ±   2%       ~ (p=0.798 n=15)
WKBParse/46-2                                                      1.086µ ±   1%    1.080µ ±   1%       ~ (p=0.783 n=15)
WKBParse/47-2                                                      1.082µ ±   2%    1.083µ ±   1%       ~ (p=0.927 n=15)
WKBParse/48-2                                                      1.244µ ±   1%    1.238µ ±   1%       ~ (p=0.645 n=15)
WKBParse/49-2                                                      1.278µ ±   2%    1.271µ ±   1%       ~ (p=0.493 n=15)
WKBParse/50-2                                                      1.602µ ±   1%    1.616µ ±   1%       ~ (p=0.383 n=15)
WKBParse/51-2                                                      1.609µ ±   2%    1.604µ ±   1%       ~ (p=0.198 n=15)
WKBParse/52-2                                                      1.874µ ±   1%    1.876µ ±   1%       ~ (p=0.846 n=15)
WKBParse/53-2                                                      303.2n ±   2%    302.3n ±   1%       ~ (p=0.345 n=15)
WKBParse/54-2                                                      307.4n ±   1%    304.6n ±   1%       ~ (p=0.134 n=15)
WKBParse/55-2                                                      305.8n ±   1%    303.3n ±   1%       ~ (p=0.063 n=15)
WKBParse/56-2                                                      302.4n ±   1%    300.9n ±   1%       ~ (p=0.129 n=15)
WKBParse/57-2                                                      1.931µ ±   1%    1.931µ ±   1%       ~ (p=0.660 n=15)
WKBParse/58-2                                                      2.375µ ±   1%    2.368µ ±   1%       ~ (p=0.546 n=15)
WKBParse/59-2                                                      2.367µ ±   1%    2.367µ ±   0%       ~ (p=0.846 n=15)
WKBParse/60-2                                                      2.864µ ±   1%    2.855µ ±   0%       ~ (p=0.069 n=15)
WKBParse/61-2                                                      302.8n ±   1%    301.8n ±   1%       ~ (p=0.751 n=15)
WKBParse/62-2                                                      305.6n ±   1%    303.6n ±   1%       ~ (p=0.406 n=15)
WKBParse/63-2                                                      303.6n ±   1%    302.5n ±   1%       ~ (p=0.300 n=15)
WKBParse/64-2                                                      299.6n ±   1%    301.3n ±   1%       ~ (p=0.894 n=15)
WKBParse/65-2                                                      881.9n ±   1%    883.2n ±   1%       ~ (p=0.838 n=15)
WKBParse/66-2                                                      1.035µ ±   1%    1.028µ ±   1%       ~ (p=0.205 n=15)
WKBParse/67-2                                                      1.017µ ±   1%    1.018µ ±   1%       ~ (p=0.689 n=15)
WKBParse/68-2                                                      1.142µ ±   1%    1.142µ ±   1%       ~ (p=0.959 n=15)
geomean                                                            1.912µ           1.914µ         +0.08%

                                                           │ /tmp/tmp.WtGzXnDBiu │          /tmp/tmp.S0S0fYjdZK          │
                                                           │        B/op         │     B/op      vs base                 │
LineEnvelope/0-2                                                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
LineEnvelope/1-2                                                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
LineEnvelope/2-2                                                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
LineEnvelope/3-2                                                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=10-2                                           232.0 ± 0%       232.0 ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=100-2                                        1.789Ki ± 0%     1.789Ki ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=1000-2                                       16.04Ki ± 0%     16.04Ki ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=10000-2                                      160.0Ki ± 0%     160.0Ki ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=10-2                                         284.0 ± 0%       284.0 ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=100-2                                      1.855Ki ± 0%     1.855Ki ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=1000-2                                     16.11Ki ± 0%     16.11Ki ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=10000-2                                    160.1Ki ± 0%     160.1Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=10-2                         1.953Ki ± 0%     1.953Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=100-2                        21.02Ki ± 0%     21.02Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=1000-2                       173.3Ki ± 0%     173.3Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=10000-2                      2.091Mi ± 0%     2.091Mi ± 0%       ~ (p=0.100 n=15)
IntersectsMultiPointWithMultiPoint/n=20-2                           324.0 ± 0%       324.0 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsMultiPointWithMultiPoint/n=200-2                        2.992Ki ± 0%     2.994Ki ± 0%       ~ (p=0.275 n=15)
IntersectsMultiPointWithMultiPoint/n=2000-2                       48.13Ki ± 0%     48.13Ki ± 0%       ~ (p=0.449 n=15)
IntersectsMultiPointWithMultiPoint/n=20000-2                      330.7Ki ± 0%     330.7Ki ± 0%       ~ (p=0.910 n=15)
PolygonSingleRingValidation/n=10-2                                1.734Ki ± 0%     1.734Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=100-2                               15.08Ki ± 0%     15.08Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=1000-2                              109.6Ki ± 0%     109.6Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=10000-2                             1.466Mi ± 0%     1.466Mi ± 0%       ~ (p=1.000 n=15)
PolygonMultipleRingsValidation/n=4-2                              5.359Ki ± 0%     5.359Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=36-2                             43.50Ki ± 0%     43.50Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=400-2                            473.6Ki ± 0%     473.6Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=4096-2                           4.576Mi ± 0%     4.576Mi ± 0%       ~ (p=0.131 n=15)
PolygonZigZagRingsValidation/n=10-2                               7.797Ki ± 0%     7.797Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonZigZagRingsValidation/n=100-2                              59.64Ki ± 0%     59.64Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonZigZagRingsValidation/n=1000-2                             457.6Ki ± 0%     457.6Ki ± 0%       ~ (p=0.483 n=15)
PolygonZigZagRingsValidation/n=10000-2                            5.650Mi ± 0%     5.650Mi ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=10-2                                   3.156Ki ± 0%     3.156Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=100-2                                  22.70Ki ± 0%     22.70Ki ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=1000-2                                 222.2Ki ± 0%     222.2Ki ± 0%       ~ (p=1.000 n=15)
PolygonAnnulusValidation/n=10000-2                                2.787Mi ± 0%     2.787Mi ± 0%       ~ (p=0.321 n=15)
MultipolygonValidation/n=1-2                                        385.0 ± 0%       385.0 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=4-2                                        884.0 ± 0%       884.0 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=16-2                                     3.656Ki ± 0%     3.656Ki ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=64-2                                     14.95Ki ± 0%     14.95Ki ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=256-2                                    59.52Ki ± 0%     59.52Ki ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=1024-2                                   238.3Ki ± 0%     238.3Ki ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=10-2                                     4.158Ki ± 0%     4.158Ki ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=100-2                                    36.47Ki ± 0%     36.47Ki ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=1000-2                                   283.2Ki ± 0%     283.2Ki ± 0%       ~ (p=0.483 n=15)
MultiPolygonTwoCircles/n=10000-2                                  3.558Mi ± 0%     3.558Mi ± 0%       ~ (p=0.228 n=15)
MultiPolygonMultipleTouchingPoints/n=1-2                          3.502Ki ± 0%     3.502Ki ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonMultipleTouchingPoints/n=10-2                         19.52Ki ± 0%     19.52Ki ± 0%       ~ (p=0.708 n=15)
MultiPolygonMultipleTouchingPoints/n=100-2                        164.4Ki ± 0%     164.4Ki ± 0%       ~ (p=0.645 n=15)
MultiPolygonMultipleTouchingPoints/n=1000-2                       1.671Mi ± 0%     1.671Mi ± 0%       ~ (p=0.814 n=15)
WKTParsing/point-2                                                1.841Ki ± 0%     1.841Ki ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=100_swap=false-2               30.67Ki ± 0%     30.67Ki ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=100_swap=true-2                30.67Ki ± 0%     30.67Ki ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=1000_swap=false-2              325.1Ki ± 0%     325.1Ki ± 0%       ~ (p=0.533 n=15)
DistancePolygonToPolygonOrdering/n=1000_swap=true-2               325.1Ki ± 0%     325.1Ki ± 0%       ~ (p=0.447 n=15)
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2         4.984Ki ± 0%     4.984Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2          4.984Ki ± 0%     4.984Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2        50.02Ki ± 0%     50.02Ki ± 0%  -0.00% (p=0.017 n=15)
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2         50.02Ki ± 0%     50.02Ki ± 0%       ~ (p=1.000 n=15)
MultiLineStringIsSimpleManyLineStrings/n=100-2                    39.77Ki ± 0%     39.77Ki ± 0%       ~ (p=1.000 n=15) ¹
MultiLineStringIsSimpleManyLineStrings/n=1000-2                   359.3Ki ± 0%     359.3Ki ± 0%       ~ (p=1.000 n=15) ¹
ForceCWandForceCCW/0-2                                              0.000 ± 0%       0.000 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/0#01-2                                           144.0 ± 0%       144.0 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/1-2                                              0.000 ±  ?       0.000 ± 0%       ~ (p=0.651 n=15)
ForceCWandForceCCW/1#01-2                                           144.0 ±  ?       144.0 ± 0%       ~ (p=0.651 n=15)
ForceCWandForceCCW/2-2                                              0.000 ± 0%       0.000 ±  ?       ~ (p=0.169 n=15)
ForceCWandForceCCW/2#01-2                                           256.0 ± 0%       256.0 ±  ?       ~ (p=0.169 n=15)
ForceCWandForceCCW/3-2                                              0.000 ±  ?       0.000 ± 0%       ~ (p=0.100 n=15)
ForceCWandForceCCW/3#01-2                                           256.0 ±  ?       256.0 ± 0%       ~ (p=0.100 n=15)
ForceCWandForceCCW/4-2                                              0.000 ± 0%       0.000 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/4#01-2                                           416.0 ± 0%       416.0 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/5-2                                              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15)
ForceCWandForceCCW/5#01-2                                           416.0 ± 0%       416.0 ± 0%       ~ (p=1.000 n=15)
ForceCWandForceCCW/6-2                                              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15)
ForceCWandForceCCW/6#01-2                                           624.0 ± 0%       624.0 ± 0%       ~ (p=1.000 n=15)
EnvelopeTransformXY-2                                               0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/0-2                                                        112.0 ± 0%       112.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/1-2                                                        112.0 ± 0%       112.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/2-2                                                        112.0 ± 0%       112.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/3-2                                                        112.0 ± 0%       112.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/4-2                                                        176.0 ± 0%       176.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/5-2                                                        120.0 ± 0%       120.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/6-2                                                        120.0 ± 0%       120.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/7-2                                                        120.0 ± 0%       120.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/8-2                                                        184.0 ± 0%       184.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/9-2                                                        72.00 ± 0%       72.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/10-2                                                       72.00 ± 0%       72.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/11-2                                                       72.00 ± 0%       72.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/12-2                                                       72.00 ± 0%       72.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/13-2                                                       200.0 ± 0%       200.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/14-2                                                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/15-2                                                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/16-2                                                       360.0 ± 0%       360.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/17-2                                                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/18-2                                                       376.0 ± 0%       376.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/19-2                                                       376.0 ± 0%       376.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/20-2                                                       392.0 ± 0%       392.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/21-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/22-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/23-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/24-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/25-2                                                       808.0 ± 0%       808.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/26-2                                                       872.0 ± 0%       872.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/27-2                                                       872.0 ± 0%       872.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/28-2                                                     1.414Ki ± 0%     1.414Ki ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/29-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/30-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/31-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/32-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/33-2                                                       248.0 ± 0%       248.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/34-2                                                       312.0 ± 0%       312.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/35-2                                                       312.0 ± 0%       312.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/36-2                                                       312.0 ± 0%       312.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/37-2                                                       456.0 ± 0%       456.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/38-2                                                       584.0 ± 0%       584.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/39-2                                                       584.0 ± 0%       584.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/40-2                                                       584.0 ± 0%       584.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/41-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/42-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/43-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/44-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/45-2                                                       440.0 ± 0%       440.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/46-2                                                       472.0 ± 0%       472.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/47-2                                                       472.0 ± 0%       472.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/48-2                                                       488.0 ± 0%       488.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/49-2                                                       568.0 ± 0%       568.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/50-2                                                       872.0 ± 0%       872.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/51-2                                                       872.0 ± 0%       872.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/52-2                                                       904.0 ± 0%       904.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/53-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/54-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/55-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/56-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/57-2                                                     1.047Ki ± 0%     1.047Ki ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/58-2                                                     1.109Ki ± 0%     1.109Ki ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/59-2                                                     1.109Ki ± 0%     1.109Ki ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/60-2                                                     1.672Ki ± 0%     1.672Ki ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/61-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/62-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/63-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/64-2                                                       64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/65-2                                                       424.0 ± 0%       424.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/66-2                                                       552.0 ± 0%       552.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/67-2                                                       552.0 ± 0%       552.0 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/68-2                                                       552.0 ± 0%       552.0 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                                                        ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                           │ /tmp/tmp.WtGzXnDBiu │         /tmp/tmp.S0S0fYjdZK          │
                                                           │      allocs/op      │  allocs/op   vs base                 │
LineEnvelope/0-2                                                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
LineEnvelope/1-2                                                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
LineEnvelope/2-2                                                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
LineEnvelope/3-2                                                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=10-2                                           6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=100-2                                          6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=1000-2                                         6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
MarshalWKB/polygon/n=10000-2                                        6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=10-2                                         7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=100-2                                        7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=1000-2                                       7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
UnmarshalWKB/polygon/n=10000-2                                      7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=10-2                           8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=100-2                          56.00 ± 0%      56.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=1000-2                         344.0 ± 0%      344.0 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsLineStringWithLineString/n=10000-2                       5.464k ± 0%     5.464k ± 0%       ~ (p=1.000 n=15) ¹
IntersectsMultiPointWithMultiPoint/n=20-2                           1.000 ± 0%      1.000 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsMultiPointWithMultiPoint/n=200-2                          7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsMultiPointWithMultiPoint/n=2000-2                         6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
IntersectsMultiPointWithMultiPoint/n=20000-2                        11.00 ± 0%      11.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=10-2                                  10.00 ± 0%      10.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=100-2                                 58.00 ± 0%      58.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=1000-2                                346.0 ± 0%      346.0 ± 0%       ~ (p=1.000 n=15) ¹
PolygonSingleRingValidation/n=10000-2                              5.466k ± 0%     5.466k ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=4-2                                32.00 ± 0%      32.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=36-2                               242.0 ± 0%      242.0 ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=400-2                             2.618k ± 0%     2.618k ± 0%       ~ (p=1.000 n=15) ¹
PolygonMultipleRingsValidation/n=4096-2                            25.95k ± 0%     25.95k ± 0%       ~ (p=1.000 n=15) ¹
PolygonZigZagRingsValidation/n=10-2                                 34.00 ± 0%      34.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonZigZagRingsValidation/n=100-2                                178.0 ± 0%      178.0 ± 0%       ~ (p=1.000 n=15) ¹
PolygonZigZagRingsValidation/n=1000-2                              1.042k ± 0%     1.042k ± 0%       ~ (p=1.000 n=15) ¹
PolygonZigZagRingsValidation/n=10000-2                             16.40k ± 0%     16.40k ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=10-2                                     18.00 ± 0%      18.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=100-2                                    72.00 ± 0%      72.00 ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=1000-2                                   648.0 ± 0%      648.0 ± 0%       ~ (p=1.000 n=15) ¹
PolygonAnnulusValidation/n=10000-2                                 9.528k ± 0%     9.528k ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=1-2                                        7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=4-2                                        10.00 ± 0%      10.00 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=16-2                                       26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=64-2                                       90.00 ± 0%      90.00 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=256-2                                      346.0 ± 0%      346.0 ± 0%       ~ (p=1.000 n=15) ¹
MultipolygonValidation/n=1024-2                                    1.370k ± 0%     1.370k ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=10-2                                       28.00 ± 0%      28.00 ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=100-2                                      124.0 ± 0%      124.0 ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=1000-2                                     700.0 ± 0%      700.0 ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonTwoCircles/n=10000-2                                   10.94k ± 0%     10.94k ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonMultipleTouchingPoints/n=1-2                            50.00 ± 0%      50.00 ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonMultipleTouchingPoints/n=10-2                           291.0 ± 0%      291.0 ± 0%       ~ (p=1.000 n=15) ¹
MultiPolygonMultipleTouchingPoints/n=100-2                         2.613k ± 0%     2.613k ± 0%       ~ (p=0.700 n=15)
MultiPolygonMultipleTouchingPoints/n=1000-2                        25.80k ± 0%     25.80k ± 0%       ~ (p=0.521 n=15)
WKTParsing/point-2                                                  22.00 ± 0%      22.00 ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=100_swap=false-2                 217.0 ± 0%      217.0 ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=100_swap=true-2                  217.0 ± 0%      217.0 ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=1000_swap=false-2               2.087k ± 0%     2.087k ± 0%       ~ (p=1.000 n=15) ¹
DistancePolygonToPolygonOrdering/n=1000_swap=true-2                2.087k ± 0%     2.087k ± 0%       ~ (p=1.000 n=15) ¹
IntersectionPolygonWithPolygonOrdering/n=100_swap=false-2           12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectionPolygonWithPolygonOrdering/n=100_swap=true-2            12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectionPolygonWithPolygonOrdering/n=1000_swap=false-2          60.00 ± 0%      60.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectionPolygonWithPolygonOrdering/n=1000_swap=true-2           60.00 ± 0%      60.00 ± 0%       ~ (p=1.000 n=15) ¹
MultiLineStringIsSimpleManyLineStrings/n=100-2                      254.0 ± 0%      254.0 ± 0%       ~ (p=1.000 n=15) ¹
MultiLineStringIsSimpleManyLineStrings/n=1000-2                    2.342k ± 0%     2.342k ± 0%       ~ (p=1.000 n=15) ¹
ForceCWandForceCCW/0-2                                              0.000 ± 0%      0.000 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/0#01-2                                           3.000 ± 0%      3.000 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/1-2                                              0.000 ±  ?      0.000 ± 0%       ~ (p=0.651 n=15)
ForceCWandForceCCW/1#01-2                                           3.000 ±  ?      3.000 ± 0%       ~ (p=0.651 n=15)
ForceCWandForceCCW/2-2                                              0.000 ± 0%      0.000 ±  ?       ~ (p=0.169 n=15)
ForceCWandForceCCW/2#01-2                                           4.000 ± 0%      4.000 ±  ?       ~ (p=0.169 n=15)
ForceCWandForceCCW/3-2                                              0.000 ±  ?      0.000 ± 0%       ~ (p=0.100 n=15)
ForceCWandForceCCW/3#01-2                                           4.000 ±  ?      4.000 ± 0%       ~ (p=0.100 n=15)
ForceCWandForceCCW/4-2                                              0.000 ± 0%      0.000 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/4#01-2                                           7.000 ± 0%      7.000 ± 0%       ~ (p=0.598 n=15)
ForceCWandForceCCW/5-2                                              0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15)
ForceCWandForceCCW/5#01-2                                           7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15)
ForceCWandForceCCW/6-2                                              0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15)
ForceCWandForceCCW/6#01-2                                           12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15)
EnvelopeTransformXY-2                                               0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/0-2                                                        5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/1-2                                                        5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/2-2                                                        5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/3-2                                                        5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/4-2                                                        6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/5-2                                                        6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/6-2                                                        6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/7-2                                                        6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/8-2                                                        7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/9-2                                                        5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/10-2                                                       5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/11-2                                                       5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/12-2                                                       5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/13-2                                                       8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/14-2                                                       8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/15-2                                                       8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/16-2                                                       9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/17-2                                                       8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/18-2                                                       9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/19-2                                                       9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/20-2                                                       9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/21-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/22-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/23-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/24-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/25-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/26-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/27-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/28-2                                                       16.00 ± 0%      16.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/29-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/30-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/31-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/32-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/33-2                                                       9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/34-2                                                       10.00 ± 0%      10.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/35-2                                                       10.00 ± 0%      10.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/36-2                                                       10.00 ± 0%      10.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/37-2                                                       12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/38-2                                                       13.00 ± 0%      13.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/39-2                                                       13.00 ± 0%      13.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/40-2                                                       13.00 ± 0%      13.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/41-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/42-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/43-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/44-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/45-2                                                       12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/46-2                                                       12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/47-2                                                       12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/48-2                                                       12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/49-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/50-2                                                       16.00 ± 0%      16.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/51-2                                                       16.00 ± 0%      16.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/52-2                                                       16.00 ± 0%      16.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/53-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/54-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/55-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/56-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/57-2                                                       25.00 ± 0%      25.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/58-2                                                       25.00 ± 0%      25.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/59-2                                                       25.00 ± 0%      25.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/60-2                                                       26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/61-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/62-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/63-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/64-2                                                       4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/65-2                                                       14.00 ± 0%      14.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/66-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/67-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
WKBParse/68-2                                                       15.00 ± 0%      15.00 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                                                        ²                +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

pkg: github.com/peterstace/simplefeatures/geos
                                        │ /tmp/tmp.WtGzXnDBiu │        /tmp/tmp.S0S0fYjdZK         │
                                        │       sec/op        │   sec/op     vs base               │
IntersectionWithoutValidation/n=10-2              13.32µ ± 1%   13.27µ ± 2%       ~ (p=0.838 n=15)
IntersectionWithoutValidation/n=100-2             28.96µ ± 1%   28.92µ ± 2%       ~ (p=0.624 n=15)
IntersectionWithoutValidation/n=1000-2            148.9µ ± 1%   148.8µ ± 1%       ~ (p=0.806 n=15)
IntersectionWithoutValidation/n=10000-2           1.390m ± 2%   1.402m ± 3%       ~ (p=0.345 n=15)
NoOp/n=10-2                                       2.226µ ± 1%   2.220µ ± 2%       ~ (p=0.442 n=15)
NoOp/n=100-2                                      5.752µ ± 1%   5.731µ ± 1%       ~ (p=0.072 n=15)
NoOp/n=1000-2                                     39.99µ ± 1%   40.03µ ± 1%       ~ (p=0.935 n=15)
NoOp/n=10000-2                                    451.7µ ± 5%   429.6µ ± 7%       ~ (p=0.074 n=15)
geomean                                           45.53µ        45.23µ       -0.65%

                                        │ /tmp/tmp.WtGzXnDBiu │          /tmp/tmp.S0S0fYjdZK          │
                                        │        B/op         │     B/op      vs base                 │
IntersectionWithoutValidation/n=10-2             1.289Ki ± 0%   1.289Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectionWithoutValidation/n=100-2            6.305Ki ± 0%   6.305Ki ± 0%       ~ (p=1.000 n=15) ¹
IntersectionWithoutValidation/n=1000-2           53.80Ki ± 0%   53.80Ki ± 0%       ~ (p=1.000 n=15)
IntersectionWithoutValidation/n=10000-2          544.6Ki ± 0%   544.6Ki ± 0%       ~ (p=0.523 n=15)
NoOp/n=10-2                                        952.0 ± 0%     952.0 ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=100-2                                     5.633Ki ± 0%   5.633Ki ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=1000-2                                    48.38Ki ± 0%   48.38Ki ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=10000-2                                   480.4Ki ± 0%   480.4Ki ± 0%       ~ (p=0.483 n=15)
geomean                                          20.31Ki        20.31Ki       +0.00%
¹ all samples are equal

                                        │ /tmp/tmp.WtGzXnDBiu │         /tmp/tmp.S0S0fYjdZK         │
                                        │      allocs/op      │ allocs/op   vs base                 │
IntersectionWithoutValidation/n=10-2               48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectionWithoutValidation/n=100-2              48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectionWithoutValidation/n=1000-2             48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=15) ¹
IntersectionWithoutValidation/n=10000-2            48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=10-2                                        33.00 ± 0%   33.00 ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=100-2                                       33.00 ± 0%   33.00 ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=1000-2                                      33.00 ± 0%   33.00 ± 0%       ~ (p=1.000 n=15) ¹
NoOp/n=10000-2                                     33.00 ± 0%   33.00 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                            39.80        39.80       +0.00%
¹ all samples are equal

pkg: github.com/peterstace/simplefeatures/internal/perf
                                                │ /tmp/tmp.WtGzXnDBiu │         /tmp/tmp.S0S0fYjdZK         │
                                                │       sec/op        │    sec/op     vs base               │
LineStringIsSimpleCircle/n=10-2                         1.023µ ±   1%   1.024µ ±  0%       ~ (p=0.454 n=15)
LineStringIsSimpleCircle/n=100-2                        15.57µ ±   1%   15.60µ ±  1%       ~ (p=0.713 n=15)
LineStringIsSimpleCircle/n=1000-2                       252.7µ ±   0%   253.9µ ±  1%  +0.50% (p=0.045 n=15)
LineStringIsSimpleCircle/n=10000-2                      3.450m ±   3%   3.434m ±  5%       ~ (p=0.567 n=15)
LineStringIsSimpleZigZag/10-2                           916.8n ±   1%   924.2n ±  1%       ~ (p=0.595 n=15)
LineStringIsSimpleZigZag/100-2                          15.37µ ±   1%   15.36µ ±  1%       ~ (p=0.418 n=15)
LineStringIsSimpleZigZag/1000-2                         234.8µ ±   1%   235.2µ ±  1%       ~ (p=0.713 n=15)
LineStringIsSimpleZigZag/10000-2                        3.625m ±  10%   3.671m ±  7%       ~ (p=0.775 n=15)
SetOperation/n=4/Go_Intersection-2                      18.00µ ±   2%   18.07µ ±  1%       ~ (p=0.744 n=15)
SetOperation/n=4/Go_Difference-2                        18.92µ ±   1%   18.94µ ±  1%       ~ (p=0.383 n=15)
SetOperation/n=4/Go_SymmetricDifference-2               24.87µ ±   1%   25.08µ ±  1%       ~ (p=0.814 n=15)
SetOperation/n=4/Go_Union-2                             19.59µ ±   1%   19.62µ ±  1%       ~ (p=0.838 n=15)
SetOperation/n=4/GEOS_Intersection-2                    11.42µ ±   1%   11.41µ ±  2%       ~ (p=0.830 n=15)
SetOperation/n=4/GEOS_Difference-2                      12.42µ ±   2%   12.37µ ±  1%       ~ (p=0.736 n=15)
SetOperation/n=4/GEOS_SymmetricDifference-2             17.95µ ±   1%   18.06µ ±  1%       ~ (p=0.519 n=15)
SetOperation/n=4/GEOS_Union-2                           12.85µ ±   1%   12.80µ ±  2%       ~ (p=0.838 n=15)
SetOperation/n=8/Go_Intersection-2                      23.34µ ±   1%   23.57µ ±  2%       ~ (p=0.285 n=15)
SetOperation/n=8/Go_Difference-2                        24.31µ ±   2%   24.47µ ±  1%       ~ (p=0.567 n=15)
SetOperation/n=8/Go_SymmetricDifference-2               32.52µ ±   1%   33.05µ ±  2%       ~ (p=0.056 n=15)
SetOperation/n=8/Go_Union-2                             24.70µ ±   1%   24.91µ ±  1%       ~ (p=0.109 n=15)
SetOperation/n=8/GEOS_Intersection-2                    15.90µ ±   1%   15.90µ ±  2%       ~ (p=1.000 n=15)
SetOperation/n=8/GEOS_Difference-2                      15.99µ ±   2%   16.07µ ±  2%       ~ (p=1.000 n=15)
SetOperation/n=8/GEOS_SymmetricDifference-2             22.38µ ±   1%   22.27µ ±  1%       ~ (p=0.838 n=15)
SetOperation/n=8/GEOS_Union-2                           16.03µ ±   1%   15.91µ ±  1%       ~ (p=0.367 n=15)
SetOperation/n=16/Go_Intersection-2                     34.21µ ±   1%   34.48µ ±  2%       ~ (p=0.468 n=15)
SetOperation/n=16/Go_Difference-2                       36.05µ ±   1%   36.29µ ±  1%       ~ (p=1.000 n=15)
SetOperation/n=16/Go_SymmetricDifference-2              48.03µ ±   1%   48.50µ ±  2%       ~ (p=0.217 n=15)
SetOperation/n=16/Go_Union-2                            37.34µ ±   3%   38.10µ ±  2%       ~ (p=0.713 n=15)
SetOperation/n=16/GEOS_Intersection-2                   18.25µ ±   1%   18.29µ ±  1%       ~ (p=0.902 n=15)
SetOperation/n=16/GEOS_Difference-2                     19.55µ ±   2%   19.65µ ±  1%       ~ (p=0.838 n=15)
SetOperation/n=16/GEOS_SymmetricDifference-2            28.62µ ±   2%   28.10µ ±  2%       ~ (p=0.233 n=15)
SetOperation/n=16/GEOS_Union-2                          19.85µ ±   2%   19.94µ ±  2%       ~ (p=0.838 n=15)
SetOperation/n=32/Go_Intersection-2                     56.11µ ±   2%   56.43µ ±  2%       ~ (p=0.217 n=15)
SetOperation/n=32/Go_Difference-2                       58.68µ ±   1%   58.76µ ±  2%       ~ (p=0.233 n=15)
SetOperation/n=32/Go_SymmetricDifference-2              79.58µ ±   1%   80.34µ ±  1%       ~ (p=0.653 n=15)
SetOperation/n=32/Go_Union-2                            61.87µ ±   1%   62.82µ ±  2%       ~ (p=0.109 n=15)
SetOperation/n=32/GEOS_Intersection-2                   23.46µ ±   2%   23.45µ ±  2%       ~ (p=0.967 n=15)
SetOperation/n=32/GEOS_Difference-2                     26.18µ ±   1%   26.07µ ±  2%       ~ (p=0.595 n=15)
SetOperation/n=32/GEOS_SymmetricDifference-2            41.28µ ±   2%   41.36µ ±  2%       ~ (p=0.870 n=15)
SetOperation/n=32/GEOS_Union-2                          28.79µ ±   1%   28.72µ ±  1%       ~ (p=0.838 n=15)
SetOperation/n=64/Go_Intersection-2                     108.7µ ±   2%   108.8µ ±  1%       ~ (p=0.870 n=15)
SetOperation/n=64/Go_Difference-2                       112.1µ ±   1%   112.7µ ±  1%       ~ (p=0.838 n=15)
SetOperation/n=64/Go_SymmetricDifference-2              152.3µ ±   1%   152.1µ ±  2%       ~ (p=0.870 n=15)
SetOperation/n=64/Go_Union-2                            123.8µ ±   2%   124.8µ ±  1%       ~ (p=0.683 n=15)
SetOperation/n=64/GEOS_Intersection-2                   34.93µ ±   1%   34.94µ ±  1%       ~ (p=0.345 n=15)
SetOperation/n=64/GEOS_Difference-2                     40.40µ ±   1%   40.55µ ±  1%       ~ (p=0.267 n=15)
SetOperation/n=64/GEOS_SymmetricDifference-2            66.01µ ±   2%   65.74µ ±  1%       ~ (p=0.775 n=15)
SetOperation/n=64/GEOS_Union-2                          46.92µ ±   1%   46.85µ ±  1%       ~ (p=0.486 n=15)
SetOperation/n=128/Go_Intersection-2                    219.7µ ±   1%   219.9µ ±  1%       ~ (p=0.683 n=15)
SetOperation/n=128/Go_Difference-2                      227.6µ ±   2%   228.4µ ±  0%       ~ (p=0.683 n=15)
SetOperation/n=128/Go_SymmetricDifference-2             319.5µ ±   1%   319.4µ ±  4%       ~ (p=0.267 n=15)
SetOperation/n=128/Go_Union-2                           243.1µ ±   1%   244.8µ ±  2%       ~ (p=0.174 n=15)
SetOperation/n=128/GEOS_Intersection-2                  57.77µ ±   1%   57.54µ ±  1%       ~ (p=0.461 n=15)
SetOperation/n=128/GEOS_Difference-2                    68.50µ ±   1%   68.62µ ±  2%       ~ (p=0.862 n=15)
SetOperation/n=128/GEOS_SymmetricDifference-2           128.3µ ±   2%   127.9µ ±  1%       ~ (p=0.624 n=15)
SetOperation/n=128/GEOS_Union-2                         81.13µ ±   1%   80.39µ ±  1%       ~ (p=0.187 n=15)
SetOperation/n=256/Go_Intersection-2                    485.5µ ±   2%   485.4µ ±  2%       ~ (p=1.000 n=15)
SetOperation/n=256/Go_Difference-2                      504.9µ ±   1%   509.8µ ±  2%       ~ (p=0.074 n=15)
SetOperation/n=256/Go_SymmetricDifference-2             690.9µ ±   4%   693.8µ ±  1%       ~ (p=0.174 n=15)
SetOperation/n=256/Go_Union-2                           542.5µ ±   1%   546.7µ ±  0%       ~ (p=0.233 n=15)
SetOperation/n=256/GEOS_Intersection-2                  99.26µ ±   1%   99.82µ ±  2%       ~ (p=0.713 n=15)
SetOperation/n=256/GEOS_Difference-2                    128.2µ ±   1%   129.0µ ±  2%       ~ (p=0.713 n=15)
SetOperation/n=256/GEOS_SymmetricDifference-2           262.2µ ±   1%   262.9µ ±  1%       ~ (p=1.000 n=15)
SetOperation/n=256/GEOS_Union-2                         164.2µ ±   1%   164.7µ ±  1%       ~ (p=0.325 n=15)
SetOperation/n=512/Go_Intersection-2                   1007.3µ ±   3%   999.3µ ±  6%       ~ (p=0.902 n=15)
SetOperation/n=512/Go_Difference-2                      1.028m ±   3%   1.039m ±  1%       ~ (p=0.512 n=15)
SetOperation/n=512/Go_SymmetricDifference-2             1.413m ±   1%   1.418m ±  1%       ~ (p=0.367 n=15)
SetOperation/n=512/Go_Union-2                           1.105m ±   3%   1.110m ±  1%       ~ (p=0.935 n=15)
SetOperation/n=512/GEOS_Intersection-2                  195.7µ ±   1%   195.1µ ±  1%       ~ (p=0.838 n=15)
SetOperation/n=512/GEOS_Difference-2                    259.7µ ±   1%   261.6µ ±  1%       ~ (p=0.217 n=15)
SetOperation/n=512/GEOS_SymmetricDifference-2           569.4µ ±   1%   569.1µ ±  1%       ~ (p=0.645 n=15)
SetOperation/n=512/GEOS_Union-2                         323.3µ ±   1%   327.8µ ±  4%  +1.38% (p=0.010 n=15)
SetOperation/n=1024/Go_Intersection-2                   2.085m ±  12%   2.283m ± 10%  +9.51% (p=0.026 n=15)
SetOperation/n=1024/Go_Difference-2                     2.065m ±   4%   2.102m ±  3%       ~ (p=0.202 n=15)
SetOperation/n=1024/Go_SymmetricDifference-2            2.773m ±   6%   2.796m ±  0%       ~ (p=0.512 n=15)
SetOperation/n=1024/Go_Union-2                          2.181m ±   3%   2.182m ±  1%       ~ (p=0.744 n=15)
SetOperation/n=1024/GEOS_Intersection-2                 397.6µ ±   1%   397.8µ ±  2%       ~ (p=0.567 n=15)
SetOperation/n=1024/GEOS_Difference-2                   542.2µ ±   4%   547.2µ ±  4%       ~ (p=0.116 n=15)
SetOperation/n=1024/GEOS_SymmetricDifference-2          1.205m ±   3%   1.197m ±  6%       ~ (p=0.653 n=15)
SetOperation/n=1024/GEOS_Union-2                        690.9µ ±   1%   696.6µ ±  1%       ~ (p=0.412 n=15)
SetOperation/n=2048/Go_Intersection-2                   4.003m ±   4%   4.163m ±  4%  +4.00% (p=0.045 n=15)
SetOperation/n=2048/Go_Difference-2                     4.239m ±   3%   4.180m ± 14%       ~ (p=0.838 n=15)
SetOperation/n=2048/Go_SymmetricDifference-2            6.188m ±   5%   6.012m ±  1%  -2.86% (p=0.026 n=15)
SetOperation/n=2048/Go_Union-2                          4.535m ±   4%   4.479m ±  4%       ~ (p=0.967 n=15)
SetOperation/n=2048/GEOS_Intersection-2                 840.0µ ±   4%   848.8µ ±  2%       ~ (p=0.567 n=15)
SetOperation/n=2048/GEOS_Difference-2                   1.136m ±   2%   1.143m ±  1%       ~ (p=0.713 n=15)
SetOperation/n=2048/GEOS_SymmetricDifference-2          2.720m ±   6%   2.703m ±  7%       ~ (p=0.870 n=15)
SetOperation/n=2048/GEOS_Union-2                        1.440m ±   4%   1.477m ±  3%       ~ (p=0.137 n=15)
SetOperation/n=4096/Go_Intersection-2                   10.11m ±   8%   10.04m ± 17%       ~ (p=0.436 n=15)
SetOperation/n=4096/Go_Difference-2                     10.78m ±  12%   10.97m ±  8%       ~ (p=0.870 n=15)
SetOperation/n=4096/Go_SymmetricDifference-2            14.98m ±   9%   16.37m ±  5%       ~ (p=0.050 n=15)
SetOperation/n=4096/Go_Union-2                          10.16m ±  10%   10.47m ± 14%       ~ (p=0.217 n=15)
SetOperation/n=4096/GEOS_Intersection-2                 1.666m ±   2%   1.673m ±  2%       ~ (p=0.345 n=15)
SetOperation/n=4096/GEOS_Difference-2                   2.307m ±   3%   2.317m ±  4%       ~ (p=0.902 n=15)
SetOperation/n=4096/GEOS_SymmetricDifference-2          5.010m ±   4%   5.010m ±  3%       ~ (p=0.744 n=15)
SetOperation/n=4096/GEOS_Union-2                        2.917m ±   2%   2.971m ±  4%       ~ (p=0.050 n=15)
SetOperation/n=8192/Go_Intersection-2                   17.73m ±   6%   18.38m ±  7%       ~ (p=0.250 n=15)
SetOperation/n=8192/Go_Difference-2                     19.04m ±   6%   18.32m ±  3%       ~ (p=0.486 n=15)
SetOperation/n=8192/Go_SymmetricDifference-2            27.65m ±   9%   27.96m ±  9%       ~ (p=0.967 n=15)
SetOperation/n=8192/Go_Union-2                          19.06m ±   5%   19.63m ±  6%       ~ (p=0.137 n=15)
SetOperation/n=8192/GEOS_Intersection-2                 3.524m ±   5%   3.553m ±  3%       ~ (p=0.512 n=15)
SetOperation/n=8192/GEOS_Difference-2                   4.747m ±   4%   4.904m ±  6%       ~ (p=0.081 n=15)
SetOperation/n=8192/GEOS_SymmetricDifference-2          10.34m ±   4%   11.34m ± 20%  +9.72% (p=0.005 n=15)
SetOperation/n=8192/GEOS_Union-2                        5.971m ±   2%   5.984m ±  2%       ~ (p=0.325 n=15)
SetOperation/n=16384/Go_Intersection-2                  41.50m ± 127%   38.95m ± 37%       ~ (p=0.595 n=15)
SetOperation/n=16384/Go_Difference-2                    42.54m ±  23%   42.58m ± 42%       ~ (p=0.935 n=15)
SetOperation/n=16384/Go_SymmetricDifference-2           57.26m ±  11%   57.45m ± 11%       ~ (p=0.486 n=15)
SetOperation/n=16384/Go_Union-2                         46.87m ±  13%   42.34m ± 23%       ~ (p=0.486 n=15)
SetOperation/n=16384/GEOS_Intersection-2                8.250m ±  12%   7.236m ±  8%       ~ (p=0.056 n=15)
SetOperation/n=16384/GEOS_Difference-2                  9.811m ±   4%   9.834m ± 10%       ~ (p=0.624 n=15)
SetOperation/n=16384/GEOS_SymmetricDifference-2         25.32m ±  10%   24.80m ± 11%       ~ (p=0.935 n=15)
SetOperation/n=16384/GEOS_Union-2                       12.81m ±   1%   12.84m ±  1%       ~ (p=0.595 n=15)
geomean                                                 333.8µ          335.0µ        +0.34%

                                                │ /tmp/tmp.WtGzXnDBiu │          /tmp/tmp.S0S0fYjdZK          │
                                                │        B/op         │     B/op      vs base                 │
LineStringIsSimpleCircle/n=10-2                          1.422Ki ± 0%   1.422Ki ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleCircle/n=100-2                         14.77Ki ± 0%   14.77Ki ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleCircle/n=1000-2                        109.3Ki ± 0%   109.3Ki ± 0%       ~ (p=1.000 n=15)
LineStringIsSimpleCircle/n=10000-2                       1.466Mi ± 0%   1.466Mi ± 0%       ~ (p=1.000 n=15)
LineStringIsSimpleZigZag/10-2                            1.391Ki ± 0%   1.391Ki ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/100-2                           14.77Ki ± 0%   14.77Ki ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/1000-2                          109.3Ki ± 0%   109.3Ki ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/10000-2                         1.466Mi ± 0%   1.466Mi ± 0%       ~ (p=0.741 n=15)
SetOperation/n=4/Go_Intersection-2                       16.07Ki ± 0%   16.07Ki ± 0%       ~ (p=0.766 n=15)
SetOperation/n=4/Go_Difference-2                         16.74Ki ± 0%   16.74Ki ± 0%       ~ (p=0.610 n=15)
SetOperation/n=4/Go_SymmetricDifference-2                23.07Ki ± 0%   23.07Ki ± 0%       ~ (p=0.059 n=15)
SetOperation/n=4/Go_Union-2                              16.93Ki ± 0%   16.93Ki ± 0%       ~ (p=0.781 n=15)
SetOperation/n=4/GEOS_Intersection-2                     1.539Ki ± 0%   1.539Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_Difference-2                       2.086Ki ± 0%   2.086Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_SymmetricDifference-2              8.172Ki ± 0%   8.172Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_Union-2                            2.227Ki ± 0%   2.227Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/Go_Intersection-2                       19.76Ki ± 0%   19.76Ki ± 0%       ~ (p=0.910 n=15)
SetOperation/n=8/Go_Difference-2                         20.45Ki ± 0%   20.44Ki ± 0%       ~ (p=0.893 n=15)
SetOperation/n=8/Go_SymmetricDifference-2                28.91Ki ± 0%   28.92Ki ± 0%       ~ (p=0.188 n=15)
SetOperation/n=8/Go_Union-2                              20.62Ki ± 0%   20.62Ki ± 0%       ~ (p=0.175 n=15)
SetOperation/n=8/GEOS_Intersection-2                     2.352Ki ± 0%   2.352Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/GEOS_Difference-2                       2.914Ki ± 0%   2.914Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/GEOS_SymmetricDifference-2              11.11Ki ± 0%   11.11Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/GEOS_Union-2                            3.039Ki ± 0%   3.039Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/Go_Intersection-2                      29.36Ki ± 0%   29.36Ki ± 0%       ~ (p=0.878 n=15)
SetOperation/n=16/Go_Difference-2                        30.72Ki ± 0%   30.71Ki ± 0%       ~ (p=0.133 n=15)
SetOperation/n=16/Go_SymmetricDifference-2               43.30Ki ± 0%   43.29Ki ± 0%       ~ (p=0.505 n=15)
SetOperation/n=16/Go_Union-2                             31.95Ki ± 0%   31.95Ki ± 0%       ~ (p=0.959 n=15)
SetOperation/n=16/GEOS_Intersection-2                    3.289Ki ± 0%   3.289Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_Difference-2                      4.586Ki ± 0%   4.586Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_SymmetricDifference-2             17.09Ki ± 0%   17.09Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_Union-2                           5.836Ki ± 0%   5.836Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/Go_Intersection-2                      49.25Ki ± 0%   49.25Ki ± 0%       ~ (p=0.261 n=15)
SetOperation/n=32/Go_Difference-2                        50.75Ki ± 0%   50.75Ki ± 0%       ~ (p=0.268 n=15)
SetOperation/n=32/Go_SymmetricDifference-2               71.41Ki ± 0%   71.41Ki ± 0%       ~ (p=0.532 n=15)
SetOperation/n=32/Go_Union-2                             52.21Ki ± 0%   52.20Ki ± 0%       ~ (p=0.269 n=15)
SetOperation/n=32/GEOS_Intersection-2                    6.398Ki ± 0%   6.398Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_Difference-2                      7.898Ki ± 0%   7.898Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_SymmetricDifference-2             28.80Ki ± 0%   28.80Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_Union-2                           9.461Ki ± 0%   9.461Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/Go_Intersection-2                      89.66Ki ± 0%   89.67Ki ± 0%       ~ (p=0.846 n=15)
SetOperation/n=64/Go_Difference-2                        91.88Ki ± 0%   91.88Ki ± 0%       ~ (p=0.491 n=15)
SetOperation/n=64/Go_SymmetricDifference-2               124.0Ki ± 0%   124.0Ki ± 0%       ~ (p=0.959 n=15)
SetOperation/n=64/Go_Union-2                             99.40Ki ± 0%   99.40Ki ± 0%       ~ (p=0.306 n=15)
SetOperation/n=64/GEOS_Intersection-2                    10.59Ki ± 0%   10.59Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_Difference-2                      13.02Ki ± 0%   13.02Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_SymmetricDifference-2             45.84Ki ± 0%   45.84Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_Union-2                           20.84Ki ± 0%   20.84Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/Go_Intersection-2                     166.2Ki ± 0%   166.2Ki ± 0%       ~ (p=0.095 n=15)
SetOperation/n=128/Go_Difference-2                       169.2Ki ± 0%   169.2Ki ± 0%       ~ (p=0.339 n=15)
SetOperation/n=128/Go_SymmetricDifference-2              234.8Ki ± 0%   234.8Ki ± 0%       ~ (p=0.546 n=15)
SetOperation/n=128/Go_Union-2                            177.2Ki ± 0%   177.2Ki ± 0%       ~ (p=0.329 n=15)
SetOperation/n=128/GEOS_Intersection-2                   23.09Ki ± 0%   23.09Ki ± 0%       ~ (p=1.000 n=15)
SetOperation/n=128/GEOS_Difference-2                     26.65Ki ± 0%   26.65Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/GEOS_SymmetricDifference-2            94.34Ki ± 0%   94.34Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/GEOS_Union-2                          35.34Ki ± 0%   35.34Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/Go_Intersection-2                     323.7Ki ± 0%   323.7Ki ± 0%       ~ (p=0.751 n=15)
SetOperation/n=256/Go_Difference-2                       330.3Ki ± 0%   330.3Ki ± 0%       ~ (p=0.782 n=15)
SetOperation/n=256/Go_SymmetricDifference-2              443.0Ki ± 0%   443.0Ki ± 0%       ~ (p=0.830 n=15)
SetOperation/n=256/Go_Union-2                            360.1Ki ± 0%   360.1Ki ± 0%       ~ (p=0.145 n=15)
SetOperation/n=256/GEOS_Intersection-2                   40.34Ki ± 0%   40.34Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/GEOS_Difference-2                     48.52Ki ± 0%   48.52Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/GEOS_SymmetricDifference-2            165.3Ki ± 0%   165.3Ki ± 0%       ~ (p=0.483 n=15)
SetOperation/n=256/GEOS_Union-2                          79.59Ki ± 0%   79.59Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/Go_Intersection-2                     605.9Ki ± 0%   605.9Ki ± 0%       ~ (p=0.675 n=15)
SetOperation/n=512/Go_Difference-2                       617.4Ki ± 0%   617.4Ki ± 0%       ~ (p=0.139 n=15)
SetOperation/n=512/Go_SymmetricDifference-2              862.0Ki ± 0%   862.0Ki ± 0%       ~ (p=0.675 n=15)
SetOperation/n=512/Go_Union-2                            652.2Ki ± 0%   652.1Ki ± 0%       ~ (p=0.066 n=15)
SetOperation/n=512/GEOS_Intersection-2                   88.59Ki ± 0%   88.59Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/GEOS_Difference-2                     103.1Ki ± 0%   103.1Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/GEOS_SymmetricDifference-2            356.1Ki ± 0%   356.1Ki ± 0%       ~ (p=1.000 n=15)
SetOperation/n=512/GEOS_Union-2                          140.6Ki ± 0%   140.6Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/Go_Intersection-2                    1.221Mi ± 0%   1.221Mi ± 0%       ~ (p=0.783 n=15)
SetOperation/n=1024/Go_Difference-2                      1.248Mi ± 0%   1.248Mi ± 0%       ~ (p=0.992 n=15)
SetOperation/n=1024/Go_SymmetricDifference-2             1.693Mi ± 0%   1.693Mi ± 0%       ~ (p=0.290 n=15)
SetOperation/n=1024/Go_Union-2                           1.362Mi ± 0%   1.362Mi ± 0%       ~ (p=0.361 n=15)
SetOperation/n=1024/GEOS_Intersection-2                  158.1Ki ± 0%   158.1Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/GEOS_Difference-2                    190.9Ki ± 0%   190.9Ki ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/GEOS_SymmetricDifference-2           668.1Ki ± 0%   668.1Ki ± 0%       ~ (p=0.066 n=15)
SetOperation/n=1024/GEOS_Union-2                         314.1Ki ± 0%   314.1Ki ± 0%       ~ (p=1.000 n=15)
SetOperation/n=2048/Go_Intersection-2                    2.438Mi ± 0%   2.438Mi ± 0%       ~ (p=0.271 n=15)
SetOperation/n=2048/Go_Difference-2                      2.486Mi ± 0%   2.486Mi ± 0%       ~ (p=0.675 n=15)
SetOperation/n=2048/Go_SymmetricDifference-2             3.437Mi ± 0%   3.437Mi ± 0%       ~ (p=0.926 n=15)
SetOperation/n=2048/Go_Union-2                           2.618Mi ± 0%   2.618Mi ± 0%       ~ (p=0.690 n=15)
SetOperation/n=2048/GEOS_Intersection-2                  358.1Ki ± 0%   358.1Ki ± 0%       ~ (p=0.483 n=15)
SetOperation/n=2048/GEOS_Difference-2                    422.9Ki ± 0%   422.9Ki ± 0%       ~ (p=1.000 n=15)
SetOperation/n=2048/GEOS_SymmetricDifference-2           1.395Mi ± 0%   1.395Mi ± 0%       ~ (p=0.686 n=15)
SetOperation/n=2048/GEOS_Union-2                         566.1Ki ± 0%   566.1Ki ± 0%       ~ (p=1.000 n=15)
SetOperation/n=4096/Go_Intersection-2                    5.171Mi ± 0%   5.171Mi ± 0%       ~ (p=0.602 n=15)
SetOperation/n=4096/Go_Difference-2                      5.251Mi ± 0%   5.250Mi ± 0%       ~ (p=0.660 n=15)
SetOperation/n=4096/Go_SymmetricDifference-2             6.897Mi ± 0%   6.897Mi ± 0%       ~ (p=0.595 n=15)
SetOperation/n=4096/Go_Union-2                           5.719Mi ± 0%   5.719Mi ± 0%       ~ (p=0.894 n=15)
SetOperation/n=4096/GEOS_Intersection-2                  630.1Ki ± 0%   630.1Ki ± 0%       ~ (p=0.753 n=15)
SetOperation/n=4096/GEOS_Difference-2                    734.9Ki ± 0%   734.9Ki ± 0%       ~ (p=0.335 n=15)
SetOperation/n=4096/GEOS_SymmetricDifference-2           2.426Mi ± 0%   2.426Mi ± 0%       ~ (p=0.864 n=15)
SetOperation/n=4096/GEOS_Union-2                         1.201Mi ± 0%   1.201Mi ± 0%       ~ (p=1.000 n=15)
SetOperation/n=8192/Go_Intersection-2                    10.08Mi ± 0%   10.08Mi ± 0%       ~ (p=0.943 n=15)
SetOperation/n=8192/Go_Difference-2                      10.23Mi ± 0%   10.23Mi ± 0%       ~ (p=0.814 n=15)
SetOperation/n=8192/Go_SymmetricDifference-2             13.88Mi ± 0%   13.88Mi ± 0%       ~ (p=0.975 n=15)
SetOperation/n=8192/Go_Union-2                           10.78Mi ± 0%   10.78Mi ± 0%       ~ (p=0.163 n=15)
SetOperation/n=8192/GEOS_Intersection-2                  1.326Mi ± 0%   1.326Mi ± 0%       ~ (p=1.000 n=15)
SetOperation/n=8192/GEOS_Difference-2                    1.530Mi ± 0%   1.530Mi ± 0%       ~ (p=0.544 n=15)
SetOperation/n=8192/GEOS_SymmetricDifference-2           5.301Mi ± 0%   5.301Mi ± 0%       ~ (p=0.741 n=15)
SetOperation/n=8192/GEOS_Union-2                         2.115Mi ± 0%   2.115Mi ± 0%       ~ (p=1.000 n=15)
SetOperation/n=16384/Go_Intersection-2                   20.38Mi ± 0%   20.38Mi ± 0%       ~ (p=0.464 n=15)
SetOperation/n=16384/Go_Difference-2                     20.68Mi ± 0%   20.68Mi ± 0%       ~ (p=0.910 n=15)
SetOperation/n=16384/Go_SymmetricDifference-2            27.11Mi ± 0%   27.11Mi ± 0%       ~ (p=0.942 n=15)
SetOperation/n=16384/Go_Union-2                          22.59Mi ± 0%   22.59Mi ± 0%       ~ (p=0.630 n=15)
SetOperation/n=16384/GEOS_Intersection-2                 2.365Mi ± 0%   2.365Mi ± 0%       ~ (p=0.215 n=15)
SetOperation/n=16384/GEOS_Difference-2                   2.749Mi ± 0%   2.749Mi ± 0%       ~ (p=0.235 n=15)
SetOperation/n=16384/GEOS_SymmetricDifference-2          9.426Mi ± 0%   9.426Mi ± 0%       ~ (p=0.483 n=15)
SetOperation/n=16384/GEOS_Union-2                        4.733Mi ± 0%   4.733Mi ± 0%       ~ (p=0.483 n=15)
geomean                                                  171.3Ki        171.3Ki       -0.00%
¹ all samples are equal

                                                │ /tmp/tmp.WtGzXnDBiu │         /tmp/tmp.S0S0fYjdZK          │
                                                │      allocs/op      │  allocs/op   vs base                 │
LineStringIsSimpleCircle/n=10-2                            6.000 ± 0%    6.000 ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleCircle/n=100-2                           54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleCircle/n=1000-2                          342.0 ± 0%    342.0 ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleCircle/n=10000-2                        5.462k ± 0%   5.462k ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/10-2                              6.000 ± 0%    6.000 ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/100-2                             54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/1000-2                            342.0 ± 0%    342.0 ± 0%       ~ (p=1.000 n=15) ¹
LineStringIsSimpleZigZag/10000-2                          5.462k ± 0%   5.462k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/Go_Intersection-2                         211.0 ± 0%    211.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/Go_Difference-2                           215.0 ± 0%    215.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/Go_SymmetricDifference-2                  310.0 ± 0%    310.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/Go_Union-2                                220.0 ± 0%    220.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_Intersection-2                       50.00 ± 0%    50.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_Difference-2                         52.00 ± 0%    52.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_SymmetricDifference-2                139.0 ± 0%    139.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4/GEOS_Union-2                              52.00 ± 0%    52.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/Go_Intersection-2                         218.0 ± 0%    218.0 ± 0%       ~ (p=0.224 n=15)
SetOperation/n=8/Go_Difference-2                           222.0 ± 0%    222.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=8/Go_SymmetricDifference-2                  325.0 ± 0%    325.0 ± 0%       ~ (p=0.598 n=15)
SetOperation/n=8/Go_Union-2                                227.0 ± 0%    227.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=8/GEOS_Intersection-2                       52.00 ± 0%    52.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/GEOS_Difference-2                         54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/GEOS_SymmetricDifference-2                147.0 ± 0%    147.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8/GEOS_Union-2                              54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/Go_Intersection-2                        232.0 ± 0%    232.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/Go_Difference-2                          238.0 ± 0%    238.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/Go_SymmetricDifference-2                 353.0 ± 0%    353.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/Go_Union-2                               247.0 ± 0%    247.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_Intersection-2                      54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_Difference-2                        58.00 ± 0%    58.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_SymmetricDifference-2               164.0 ± 0%    164.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16/GEOS_Union-2                             62.00 ± 0%    62.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/Go_Intersection-2                        253.0 ± 0%    253.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/Go_Difference-2                          259.0 ± 0%    259.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/Go_SymmetricDifference-2                 397.0 ± 0%    397.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/Go_Union-2                               268.0 ± 0%    268.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_Intersection-2                      62.00 ± 0%    62.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_Difference-2                        66.00 ± 0%    66.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_SymmetricDifference-2               195.0 ± 0%    195.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=32/GEOS_Union-2                             70.00 ± 0%    70.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/Go_Intersection-2                        297.0 ± 0%    297.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/Go_Difference-2                          303.0 ± 0%    303.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/Go_SymmetricDifference-2                 466.0 ± 0%    466.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=64/Go_Union-2                               336.0 ± 0%    336.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_Intersection-2                      70.00 ± 0%    70.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_Difference-2                        74.00 ± 0%    74.00 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_SymmetricDifference-2               228.0 ± 0%    228.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=64/GEOS_Union-2                             102.0 ± 0%    102.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/Go_Intersection-2                       366.0 ± 0%    366.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/Go_Difference-2                         372.0 ± 0%    372.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/Go_SymmetricDifference-2                631.0 ± 0%    631.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/Go_Union-2                              405.0 ± 0%    405.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/GEOS_Intersection-2                     102.0 ± 0%    102.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/GEOS_Difference-2                       106.0 ± 0%    106.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/GEOS_SymmetricDifference-2              356.0 ± 0%    356.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=128/GEOS_Union-2                            134.0 ± 0%    134.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/Go_Intersection-2                       532.0 ± 0%    532.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=256/Go_Difference-2                         538.0 ± 0%    538.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=256/Go_SymmetricDifference-2                893.0 ± 0%    893.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=256/Go_Union-2                              667.0 ± 0%    667.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=256/GEOS_Intersection-2                     134.0 ± 0%    134.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/GEOS_Difference-2                       138.0 ± 0%    138.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/GEOS_SymmetricDifference-2              484.0 ± 0%    484.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=256/GEOS_Union-2                            262.0 ± 0%    262.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/Go_Intersection-2                       793.0 ± 0%    793.0 ± 0%       ~ (p=0.483 n=15)
SetOperation/n=512/Go_Difference-2                         799.0 ± 0%    799.0 ± 0%       ~ (p=0.100 n=15)
SetOperation/n=512/Go_SymmetricDifference-2               1.538k ± 0%   1.538k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=512/Go_Union-2                              928.0 ± 0%    928.0 ± 0%       ~ (p=1.000 n=15)
SetOperation/n=512/GEOS_Intersection-2                     262.0 ± 0%    262.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/GEOS_Difference-2                       266.0 ± 0%    266.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/GEOS_SymmetricDifference-2              996.0 ± 0%    996.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=512/GEOS_Union-2                            390.0 ± 0%    390.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/Go_Intersection-2                     1.442k ± 0%   1.442k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=1024/Go_Difference-2                       1.448k ± 0%   1.448k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=1024/Go_SymmetricDifference-2              2.571k ± 0%   2.571k ± 0%       ~ (p=0.483 n=15)
SetOperation/n=1024/Go_Union-2                            1.961k ± 0%   1.961k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=1024/GEOS_Intersection-2                    390.0 ± 0%    390.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/GEOS_Difference-2                      394.0 ± 0%    394.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/GEOS_SymmetricDifference-2            1.508k ± 0%   1.508k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=1024/GEOS_Union-2                           902.0 ± 0%    902.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/Go_Intersection-2                     2.474k ± 0%   2.474k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/Go_Difference-2                       2.480k ± 0%   2.480k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/Go_SymmetricDifference-2              5.139k ± 0%   5.139k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/Go_Union-2                            2.993k ± 0%   2.993k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/GEOS_Intersection-2                    902.0 ± 0%    902.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/GEOS_Difference-2                      906.0 ± 0%    906.0 ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/GEOS_SymmetricDifference-2            3.556k ± 0%   3.556k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=2048/GEOS_Union-2                          1.414k ± 0%   1.414k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4096/Go_Intersection-2                     5.043k ± 0%   5.043k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4096/Go_Difference-2                       5.049k ± 0%   5.049k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=4096/Go_SymmetricDifference-2              9.244k ± 0%   9.244k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=4096/Go_Union-2                            7.098k ± 0%   7.098k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4096/GEOS_Intersection-2                   1.414k ± 0%   1.414k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4096/GEOS_Difference-2                     1.418k ± 0%   1.418k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4096/GEOS_SymmetricDifference-2            5.604k ± 0%   5.604k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=4096/GEOS_Union-2                          3.462k ± 0%   3.462k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8192/Go_Intersection-2                     9.149k ± 0%   9.149k ± 0%       ~ (p=0.598 n=15)
SetOperation/n=8192/Go_Difference-2                       9.155k ± 0%   9.155k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=8192/Go_SymmetricDifference-2              19.49k ± 0%   19.49k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=8192/Go_Union-2                            11.20k ± 0%   11.20k ± 0%       ~ (p=0.330 n=15)
SetOperation/n=8192/GEOS_Intersection-2                   3.462k ± 0%   3.462k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8192/GEOS_Difference-2                     3.466k ± 0%   3.466k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8192/GEOS_SymmetricDifference-2            13.80k ± 0%   13.80k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=8192/GEOS_Union-2                          5.510k ± 0%   5.510k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16384/Go_Intersection-2                    19.40k ± 0%   19.40k ± 0%       ~ (p=0.750 n=15)
SetOperation/n=16384/Go_Difference-2                      19.40k ± 0%   19.40k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=16384/Go_SymmetricDifference-2             35.89k ± 0%   35.89k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=16384/Go_Union-2                           27.60k ± 0%   27.60k ± 0%       ~ (p=1.000 n=15)
SetOperation/n=16384/GEOS_Intersection-2                  5.510k ± 0%   5.510k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16384/GEOS_Difference-2                    5.514k ± 0%   5.514k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16384/GEOS_SymmetricDifference-2           21.99k ± 0%   21.99k ± 0%       ~ (p=1.000 n=15) ¹
SetOperation/n=16384/GEOS_Union-2                         13.70k ± 0%   13.70k ± 0%       ~ (p=1.000 n=15) ¹
geomean                                                    597.9         597.9       +0.00%
¹ all samples are equal

pkg: github.com/peterstace/simplefeatures/rtree
                       │ /tmp/tmp.WtGzXnDBiu │        /tmp/tmp.S0S0fYjdZK         │
                       │       sec/op        │   sec/op     vs base               │
Bulk/n=10-2                      400.8n ± 2%   400.2n ± 1%       ~ (p=0.631 n=15)
Bulk/n=100-2                     8.801µ ± 1%   8.656µ ± 1%  -1.65% (p=0.000 n=15)
Bulk/n=1000-2                    185.3µ ± 0%   185.1µ ± 3%       ~ (p=0.775 n=15)
Bulk/n=10000-2                   2.521m ± 2%   2.503m ± 2%       ~ (p=0.744 n=15)
Bulk/n=100000-2                  30.26m ± 1%   30.43m ± 1%       ~ (p=0.137 n=15)
RangeSearch/n=10-2               10.37n ± 1%   10.43n ± 1%       ~ (p=0.329 n=15)
RangeSearch/n=100-2              42.93n ± 0%   43.11n ± 0%  +0.42% (p=0.044 n=15)
RangeSearch/n=1000-2             160.4n ± 1%   162.2n ± 2%  +1.12% (p=0.000 n=15)
RangeSearch/n=10000-2            573.8n ± 1%   561.6n ± 2%  -2.13% (p=0.000 n=15)
RangeSearch/n=100000-2           4.822µ ± 2%   4.818µ ± 2%       ~ (p=0.806 n=15)
geomean                          5.005µ        4.994µ       -0.22%

                       │ /tmp/tmp.WtGzXnDBiu │          /tmp/tmp.S0S0fYjdZK          │
                       │        B/op         │     B/op      vs base                 │
Bulk/n=10-2                   1.016Ki ± 0%     1.016Ki ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=100-2                  10.77Ki ± 0%     10.77Ki ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=1000-2                 69.27Ki ± 0%     69.27Ki ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=10000-2                1.083Mi ± 0%     1.083Mi ± 0%       ~ (p=0.473 n=15)
Bulk/n=100000-2               10.83Mi ± 0%     10.83Mi ± 0%       ~ (p=1.000 n=15)
RangeSearch/n=10-2              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=100-2             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=1000-2            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=10000-2           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=100000-2          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                    ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                       │ /tmp/tmp.WtGzXnDBiu │         /tmp/tmp.S0S0fYjdZK          │
                       │      allocs/op      │  allocs/op   vs base                 │
Bulk/n=10-2                     5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=100-2                    53.00 ± 0%      53.00 ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=1000-2                   341.0 ± 0%      341.0 ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=10000-2                 5.461k ± 0%     5.461k ± 0%       ~ (p=1.000 n=15) ¹
Bulk/n=100000-2                54.61k ± 0%     54.61k ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=10-2              0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=100-2             0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=1000-2            0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=10000-2           0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
RangeSearch/n=100000-2          0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                    ²                +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

</details>