### PR TITLE
Export `AsBox` method on `Envelope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 - R-tree improvements that reduce the amount of memory they use.
 
-- Exposes a `Box() rtree.Box` method on the `geom.Envelope` type, that converts
-  the envelope to an `rtree.Box`.
+- Exposes an `AsBox() rtree.Box` method on the `geom.Envelope` type, that
+  converts the envelope to an `rtree.Box`.
 
 ## v0.43.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 - R-tree improvements that reduce the amount of memory they use.
 
+- Exposes a `Box() rtree.Box` method on the `geom.Envelope` type, that converts
+  the envelope to an `rtree.Box`.
+
 ## v0.43.0
 
 2023-06-05

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -287,7 +287,8 @@ func (e Envelope) TransformXY(fn func(XY) XY) (Envelope, error) {
 	return NewEnvelope([]XY{fn(min), fn(max)})
 }
 
-func (e Envelope) box() (rtree.Box, bool) {
+// Box converts this Envelope to an rtree.Box.
+func (e Envelope) Box() (rtree.Box, bool) {
 	return rtree.Box{
 		MinX: e.minX(),
 		MinY: e.minY,

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -287,8 +287,8 @@ func (e Envelope) TransformXY(fn func(XY) XY) (Envelope, error) {
 	return NewEnvelope([]XY{fn(min), fn(max)})
 }
 
-// Box converts this Envelope to an rtree.Box.
-func (e Envelope) Box() (rtree.Box, bool) {
+// AsBox converts this Envelope to an rtree.Box.
+func (e Envelope) AsBox() (rtree.Box, bool) {
 	return rtree.Box{
 		MinX: e.minX(),
 		MinY: e.minY,

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/rtree"
 )
 
 func onePtEnv(x, y float64) Envelope {
@@ -608,4 +609,16 @@ func TestBoundingDiagonal(t *testing.T) {
 			expectGeomEqWKT(t, got, tc.want)
 		})
 	}
+}
+
+func TestEnvelopeEmptyAsBox(t *testing.T) {
+	_, ok := Envelope{}.AsBox()
+	expectFalse(t, ok)
+}
+
+func TestEnvelopeNonEmptyAsBox(t *testing.T) {
+	got, ok := twoPtEnv(1, 2, 3, 4).AsBox()
+	expectTrue(t, ok)
+	want := rtree.Box{MinX: 1, MinY: 2, MaxX: 3, MaxY: 4}
+	expectTrue(t, got == want)
 }

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -65,7 +65,7 @@ func validateMultiPolygon(polys []Polygon, opts ctorOptionSet) error {
 	boxes := make([]rtree.Box, len(polys))
 	items := make([]rtree.BulkItem, 0, len(polys))
 	for i, p := range polys {
-		if box, ok := p.Envelope().Box(); ok {
+		if box, ok := p.Envelope().AsBox(); ok {
 			boxes[i] = box
 			item := rtree.BulkItem{Box: boxes[i], RecordID: i}
 			items = append(items, item)

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -65,7 +65,7 @@ func validateMultiPolygon(polys []Polygon, opts ctorOptionSet) error {
 	boxes := make([]rtree.Box, len(polys))
 	items := make([]rtree.BulkItem, 0, len(polys))
 	for i, p := range polys {
-		if box, ok := p.Envelope().box(); ok {
+		if box, ok := p.Envelope().Box(); ok {
 			boxes[i] = box
 			item := rtree.BulkItem{Box: boxes[i], RecordID: i}
 			items = append(items, item)

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -80,7 +80,7 @@ func validatePolygon(rings []LineString, opts ctorOptionSet) error {
 	boxes := make([]rtree.Box, len(rings))
 	items := make([]rtree.BulkItem, len(rings))
 	for i, r := range rings {
-		box, ok := r.Envelope().box()
+		box, ok := r.Envelope().Box()
 		if !ok {
 			// Cannot occur, because we have already checked to ensure rings
 			// are closed. Closed rings by definition are non-empty.

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -80,7 +80,7 @@ func validatePolygon(rings []LineString, opts ctorOptionSet) error {
 	boxes := make([]rtree.Box, len(rings))
 	items := make([]rtree.BulkItem, len(rings))
 	for i, r := range rings {
-		box, ok := r.Envelope().Box()
+		box, ok := r.Envelope().AsBox()
 		if !ok {
 			// Cannot occur, because we have already checked to ensure rings
 			// are closed. Closed rings by definition are non-empty.


### PR DESCRIPTION
## Description

This is a helper method that converts a `geom.Envelope` to an `rtree.Box`. Without this helper, users have to call `MinMaxXYs()` to get the two extreme points from the `Envelope`, and then construct the `rtree.Box` manually.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/513

## Benchmark Results

N/A