### PR TITLE
Add a `String() string` method to `Envelope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - R-tree improvements that reduce the amount of memory they use.
 
+- Adds a `String() string` method to the `geom.Envelope` type.
+
 ## v0.43.0
 
 2023-06-05

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -326,7 +326,7 @@ func (e Envelope) BoundingDiagonal() Geometry {
 // pseudo-WKT style.
 func (e Envelope) String() string {
 	var sb strings.Builder
-	sb.WriteString("ENV")
+	sb.WriteString("ENVELOPE")
 	if e.IsEmpty() {
 		sb.WriteString(" EMPTY")
 		return sb.String()

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -3,6 +3,8 @@ package geom
 import (
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 
 	"github.com/peterstace/simplefeatures/rtree"
 )
@@ -318,4 +320,25 @@ func (e Envelope) BoundingDiagonal() Geometry {
 		panic("programming error: validations disabled by LineString validation failed")
 	}
 	return ls.AsGeometry()
+}
+
+// String implements the fmt.Stringer interface by printing the envelope in a
+// pseudo-WKT style.
+func (e Envelope) String() string {
+	var sb strings.Builder
+	sb.WriteString("ENV")
+	if e.IsEmpty() {
+		sb.WriteString(" EMPTY")
+		return sb.String()
+	}
+	sb.WriteRune('(')
+	add := func(f float64, r rune) {
+		sb.WriteString(strconv.FormatFloat(f, 'f', -1, 64))
+		sb.WriteRune(r)
+	}
+	add(e.minX(), ' ')
+	add(e.minY, ',')
+	add(e.maxX, ' ')
+	add(e.maxY, ')')
+	return sb.String()
 }

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -609,3 +609,19 @@ func TestBoundingDiagonal(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvelopeString(t *testing.T) {
+	for i, tc := range []struct {
+		env  Envelope
+		want string
+	}{
+		{Envelope{}, "ENV EMPTY"},
+		{twoPtEnv(1.5, 2.5, 3.5, 4.5), "ENV(1.5 2.5,3.5 4.5)"},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := fmt.Sprintf("%v", tc.env)
+			t.Log(got)
+			expectTrue(t, got == tc.want)
+		})
+	}
+}

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -615,8 +615,8 @@ func TestEnvelopeString(t *testing.T) {
 		env  Envelope
 		want string
 	}{
-		{Envelope{}, "ENV EMPTY"},
-		{twoPtEnv(1.5, 2.5, 3.5, 4.5), "ENV(1.5 2.5,3.5 4.5)"},
+		{Envelope{}, "ENVELOPE EMPTY"},
+		{twoPtEnv(1.5, 2.5, 3.5, 4.5), "ENVELOPE(1.5 2.5,3.5 4.5)"},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := fmt.Sprintf("%v", tc.env)


### PR DESCRIPTION
## Description

This is mainly so that users see a useful representation of `Envelope` when they try to print it out. Otherwise they see something quite ugly that reveals the internal implementation of the `Envelope` (e.g. the "XOR NaN" optimisation).

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/517