### PR TITLE
Remove constructor options from TransformXY methods

### DIFF
--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -454,8 +454,7 @@ func TestTransformXY(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			g := geomFromWKT(t, tt.wktIn)
-			got, err := g.TransformXY(transform)
-			expectNoErr(t, err)
+			got := g.TransformXY(transform)
 			want := geomFromWKT(t, tt.wktOut)
 			expectGeomEq(t, got, want)
 		})

--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -78,22 +78,13 @@ func reNodeGeometries(g1, g2 Geometry, mls MultiLineString) (Geometry, Geometry,
 
 	// Snap vertices together if they are very close.
 	nodes := newNodeSet(maxULPSize, xyCount)
-	var err error
-	g1, err = g1.TransformXY(nodes.insertOrGet, DisableAllValidations)
-	if err != nil {
-		return Geometry{}, Geometry{}, MultiLineString{}, err
-	}
-	g2, err = g2.TransformXY(nodes.insertOrGet, DisableAllValidations)
-	if err != nil {
-		return Geometry{}, Geometry{}, MultiLineString{}, err
-	}
-	mls, err = mls.TransformXY(nodes.insertOrGet, DisableAllValidations)
-	if err != nil {
-		return Geometry{}, Geometry{}, MultiLineString{}, err
-	}
+	g1 = g1.TransformXY(nodes.insertOrGet)
+	g2 = g2.TransformXY(nodes.insertOrGet)
+	mls = mls.TransformXY(nodes.insertOrGet)
 
 	// Create additional nodes for crossings.
 	cut := newCutSet(all)
+	var err error
 	g1, err = reNodeGeometry(g1, cut, nodes)
 	if err != nil {
 		return Geometry{}, Geometry{}, MultiLineString{}, err

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -9,12 +9,6 @@ func wrap(err error, format string, args ...interface{}) error {
 	return fmt.Errorf(format+": %w", append(args, err)...)
 }
 
-// wrapTransformed wraps errors to indicate that they occurred as the result of
-// pointwise-transforming a geometry.
-func wrapTransformed(err error) error {
-	return wrap(err, "transformed geometry")
-}
-
 // wrapSimplified wraps errors to indicate that they occurred as a result of no
 // longer being valid after simplification.
 func wrapSimplified(err error) error {

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -281,13 +281,12 @@ func (e Envelope) Distance(o Envelope) (float64, bool) {
 }
 
 // TransformXY transforms this Envelope into another Envelope according to fn.
-// TODO: remove the error here as well.
-func (e Envelope) TransformXY(fn func(XY) XY) (Envelope, error) {
+func (e Envelope) TransformXY(fn func(XY) XY) Envelope {
 	min, max, ok := e.MinMaxXYs()
 	if !ok {
-		return Envelope{}, nil
+		return Envelope{}
 	}
-	return NewEnvelope([]XY{fn(min), fn(max)})
+	return newUncheckedEnvelope(fn(min), fn(max))
 }
 
 // AsBox converts this Envelope to an rtree.Box.

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -281,6 +281,7 @@ func (e Envelope) Distance(o Envelope) (float64, bool) {
 }
 
 // TransformXY transforms this Envelope into another Envelope according to fn.
+// TODO: remove the error here as well.
 func (e Envelope) TransformXY(fn func(XY) XY) (Envelope, error) {
 	min, max, ok := e.MinMaxXYs()
 	if !ok {
@@ -318,7 +319,7 @@ func (e Envelope) BoundingDiagonal() Geometry {
 	seq := NewSequence(coords, DimXY)
 	ls, err := NewLineString(seq, DisableAllValidations)
 	if err != nil {
-		panic("programming error: validations disabled by LineString validation failed")
+		panic("non-validating ctor failed: " + err.Error())
 	}
 	return ls.AsGeometry()
 }

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -566,8 +566,7 @@ func TestEnvelopeTransformXY(t *testing.T) {
 		{twoPtEnv(1, 2, 3, 4), twoPtEnv(1.5, 5, 4.5, 10)},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got, err := tc.input.TransformXY(transform)
-			expectNoErr(t, err)
+			got := tc.input.TransformXY(transform)
 			expectEnvEq(t, got, tc.want)
 		})
 	}
@@ -577,10 +576,9 @@ func BenchmarkEnvelopeTransformXY(b *testing.B) {
 	input := twoPtEnv(1, 2, 3, 4)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := input.TransformXY(func(in XY) XY {
+		input.TransformXY(func(in XY) XY {
 			return XY{in.X * 1.5, in.Y * 2.5}
 		})
-		expectNoErr(b, err)
 	}
 }
 

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -516,34 +516,26 @@ func (g Geometry) ConvexHull() Geometry {
 }
 
 // TransformXY transforms this Geometry into another geometry according the
-// mapping provided by the XY function. Some classes of mappings (such as
-// affine transformations) will preserve the validity this Geometry in the
-// transformed Geometry, in which case no error will be returned. Other
-// types of transformations may result in a validation error if their
-// mapping results in an invalid Geometry.
-func (g Geometry) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Geometry, error) {
+// mapping provided by the XY function. Because the mapping is arbitrary, it
+// has the potential to create an invalid geometry. This can be checked by
+// calling the Validate method on the result. Most mappings useful for GIS
+// applications will preserve validity.
+func (g Geometry) TransformXY(fn func(XY) XY) Geometry {
 	switch g.gtype {
 	case TypeGeometryCollection:
-		gt, err := g.MustAsGeometryCollection().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsGeometryCollection().TransformXY(fn).AsGeometry()
 	case TypePoint:
-		gt, err := g.MustAsPoint().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsPoint().TransformXY(fn).AsGeometry()
 	case TypeLineString:
-		gt, err := g.MustAsLineString().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsLineString().TransformXY(fn).AsGeometry()
 	case TypePolygon:
-		gt, err := g.MustAsPolygon().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsPolygon().TransformXY(fn).AsGeometry()
 	case TypeMultiPoint:
-		gt, err := g.MustAsMultiPoint().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsMultiPoint().TransformXY(fn).AsGeometry()
 	case TypeMultiLineString:
-		gt, err := g.MustAsMultiLineString().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsMultiLineString().TransformXY(fn).AsGeometry()
 	case TypeMultiPolygon:
-		gt, err := g.MustAsMultiPolygon().TransformXY(fn, opts...)
-		return gt.AsGeometry(), err
+		return g.MustAsMultiPolygon().TransformXY(fn).AsGeometry()
 	default:
 		panic("unknown geometry: " + g.gtype.String())
 	}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -237,16 +237,12 @@ func (c *GeometryCollection) UnmarshalJSON(buf []byte) error {
 }
 
 // TransformXY transforms this GeometryCollection into another GeometryCollection according to fn.
-func (c GeometryCollection) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (GeometryCollection, error) {
+func (c GeometryCollection) TransformXY(fn func(XY) XY) GeometryCollection {
 	transformed := make([]Geometry, len(c.geoms))
 	for i := range c.geoms {
-		var err error
-		transformed[i], err = c.geoms[i].TransformXY(fn, opts...)
-		if err != nil {
-			return GeometryCollection{}, wrapTransformed(err)
-		}
+		transformed[i] = c.geoms[i].TransformXY(fn)
 	}
-	return GeometryCollection{transformed, c.ctype}, nil
+	return GeometryCollection{transformed, c.ctype}
 }
 
 // Reverse in the case of GeometryCollection reverses each component and also

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -304,10 +304,13 @@ func (s LineString) Coordinates() Sequence {
 }
 
 // TransformXY transforms this LineString into another LineString according to fn.
-func (s LineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (LineString, error) {
+func (s LineString) TransformXY(fn func(XY) XY) LineString {
 	transformed := transformSequence(s.seq, fn)
-	ls, err := NewLineString(transformed, opts...)
-	return ls, wrapTransformed(err)
+	ls, err := NewLineString(transformed, DisableAllValidations)
+	if err != nil {
+		panic("non-validating ctor failed: " + err.Error())
+	}
+	return ls
 }
 
 // IsRing returns true iff this LineString is both simple and closed (i.e. is a

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -332,23 +332,23 @@ func (m MultiLineString) Coordinates() []Sequence {
 }
 
 // TransformXY transforms this MultiLineString into another MultiLineString according to fn.
-func (m MultiLineString) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (MultiLineString, error) {
+func (m MultiLineString) TransformXY(fn func(XY) XY) MultiLineString {
 	n := m.NumLineStrings()
 	if n == 0 {
-		return MultiLineString{}.ForceCoordinatesType(m.CoordinatesType()), nil
+		return MultiLineString{}.ForceCoordinatesType(m.CoordinatesType())
 	}
 	transformed := make([]LineString, n)
 	for i := 0; i < n; i++ {
 		var err error
 		transformed[i], err = NewLineString(
 			transformSequence(m.LineStringN(i).Coordinates(), fn),
-			opts...,
+			DisableAllValidations,
 		)
 		if err != nil {
-			return MultiLineString{}, wrapTransformed(err)
+			panic("non-validating ctor failed: " + err.Error())
 		}
 	}
-	return NewMultiLineString(transformed, opts...), nil
+	return NewMultiLineString(transformed)
 }
 
 // Length gives the sum of the lengths of the constituent members of the multi

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -220,24 +220,24 @@ func (m MultiPoint) Coordinates() Sequence {
 }
 
 // TransformXY transforms this MultiPoint into another MultiPoint according to fn.
-func (m MultiPoint) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (MultiPoint, error) {
+func (m MultiPoint) TransformXY(fn func(XY) XY) MultiPoint {
 	if len(m.points) == 0 {
-		return MultiPoint{}.ForceCoordinatesType(m.CoordinatesType()), nil
+		return MultiPoint{}.ForceCoordinatesType(m.CoordinatesType())
 	}
 	txPoints := make([]Point, len(m.points))
 	for i, pt := range m.points {
 		if c, ok := pt.Coordinates(); ok {
 			c.XY = fn(c.XY)
 			var err error
-			txPoints[i], err = NewPoint(c, opts...)
+			txPoints[i], err = NewPoint(c, DisableAllValidations)
 			if err != nil {
-				return MultiPoint{}, err
+				panic("non-validating ctor failed: " + err.Error())
 			}
 		} else {
 			txPoints[i] = pt
 		}
 	}
-	return NewMultiPoint(txPoints), nil
+	return NewMultiPoint(txPoints)
 }
 
 // Centroid gives the centroid of the coordinates of the MultiPoint.

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -347,17 +347,16 @@ func (m MultiPolygon) Coordinates() [][]Sequence {
 }
 
 // TransformXY transforms this MultiPolygon into another MultiPolygon according to fn.
-func (m MultiPolygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (MultiPolygon, error) {
+func (m MultiPolygon) TransformXY(fn func(XY) XY) MultiPolygon {
 	polys := make([]Polygon, m.NumPolygons())
 	for i := range polys {
-		transformed, err := m.PolygonN(i).TransformXY(fn, opts...)
-		if err != nil {
-			return MultiPolygon{}, wrapTransformed(err)
-		}
-		polys[i] = transformed
+		polys[i] = m.PolygonN(i).TransformXY(fn)
 	}
-	mp, err := NewMultiPolygon(polys, opts...)
-	return mp.ForceCoordinatesType(m.ctype), wrapTransformed(err)
+	mp, err := NewMultiPolygon(polys, DisableAllValidations)
+	if err != nil {
+		panic("non-validating ctor failed: " + err.Error())
+	}
+	return mp.ForceCoordinatesType(m.ctype)
 }
 
 // Area in the case of a MultiPolygon is the sum of the areas of its polygons.

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -200,13 +200,13 @@ func (p *Point) UnmarshalJSON(buf []byte) error {
 }
 
 // TransformXY transforms this Point into another Point according to fn.
-func (p Point) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Point, error) {
+func (p Point) TransformXY(fn func(XY) XY) Point {
 	if !p.full {
-		return p, nil
+		return p
 	}
 	newC := p.coords
 	newC.XY = fn(newC.XY)
-	return NewPoint(newC, opts...)
+	return newUncheckedPoint(newC)
 }
 
 // Centroid of a point is that point.

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -336,21 +336,24 @@ func (p Polygon) Coordinates() []Sequence {
 }
 
 // TransformXY transforms this Polygon into another Polygon according to fn.
-func (p Polygon) TransformXY(fn func(XY) XY, opts ...ConstructorOption) (Polygon, error) {
+func (p Polygon) TransformXY(fn func(XY) XY) Polygon {
 	n := len(p.rings)
 	transformed := make([]LineString, n)
 	for i, r := range p.rings {
 		var err error
 		transformed[i], err = NewLineString(
 			transformSequence(r.Coordinates(), fn),
-			opts...,
+			DisableAllValidations,
 		)
 		if err != nil {
-			return Polygon{}, wrapTransformed(err)
+			panic("non-validating ctor failed: " + err.Error())
 		}
 	}
-	poly, err := NewPolygon(transformed, opts...)
-	return poly.ForceCoordinatesType(p.ctype), wrapTransformed(err)
+	poly, err := NewPolygon(transformed)
+	if err != nil {
+		panic("non-validating ctor failed: " + err.Error())
+	}
+	return poly.ForceCoordinatesType(p.ctype)
 }
 
 // AreaOption allows the behaviour of area calculations to be modified.


### PR DESCRIPTION
## Description

The `TransformXY` methods transforms the coordinates of geometries in arbitrary ways via a user-supplied mapping. It should be obvious that this potentially could cause invalid results. For example, the mapping could trivially map every coordinate pair of a polygon to the same point. In practice, transformations are either affine (translation, rotation, scaling), or, at the very least, topologically preserving (e.g. WGS84 to a Mercator or Conic projection).

This change removes the choice to validate or not in `TransformXY` methods, always omitting a validation step. Users can still validate manually via the `Validate` method if they wish to.

## Check List

Have you:

- Added unit tests? No, however existing tests have been updated.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) No, release notes will be updated when all ctor option related changes have been made.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/504