### PR TITLE
Remove error and ctor options from direct ctors

### DIFF
--- a/geom/accessor_test.go
+++ b/geom/accessor_test.go
@@ -25,13 +25,11 @@ func TestLineStringAccessor(t *testing.T) {
 	pt56 := xyCoords(5, 6)
 
 	t.Run("start", func(t *testing.T) {
-		want, err := NewPoint(pt12)
-		expectNoErr(t, err)
+		want := NewPoint(pt12)
 		expectGeomEq(t, ls.StartPoint().AsGeometry(), want.AsGeometry())
 	})
 	t.Run("end", func(t *testing.T) {
-		want, err := NewPoint(pt56)
-		expectNoErr(t, err)
+		want := NewPoint(pt56)
 		expectGeomEq(t, ls.EndPoint().AsGeometry(), want.AsGeometry())
 	})
 	t.Run("num points", func(t *testing.T) {

--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -36,12 +36,9 @@ func convexHull(g Geometry) Geometry {
 		floats[2*i+1] = hull[i].Y
 	}
 	seq := NewSequence(floats, DimXY)
-	ring, err := NewLineString(seq)
-	if err != nil {
-		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid ring: %w", err))
-	}
-	poly, err := NewPolygon([]LineString{ring})
-	if err != nil {
+	ring := NewLineString(seq)
+	poly := NewPolygon([]LineString{ring})
+	if err := poly.Validate(); err != nil {
 		panic(fmt.Errorf("bug in monotoneChain routine - didn't produce a valid polygon: %w", err))
 	}
 	return poly.AsGeometry()

--- a/geom/alg_set_op.go
+++ b/geom/alg_set_op.go
@@ -81,6 +81,9 @@ func setOp(a Geometry, include func([2]bool) bool, b Geometry) (Geometry, error)
 	if err != nil {
 		return Geometry{}, wrap(err, "internal error extracting geometry")
 	}
+	if err := g.Validate(); err != nil {
+		return Geometry{}, wrap(err, "invalid geometry produced by overlay")
+	}
 	return g, nil
 }
 

--- a/geom/ctor_options.go
+++ b/geom/ctor_options.go
@@ -37,3 +37,11 @@ func newOptionSet(opts []ConstructorOption) ctorOptionSet {
 	}
 	return cos
 }
+
+func validate(opts []ConstructorOption, g interface{ Validate() error }) error {
+	os := newOptionSet(opts)
+	if os.skipValidations {
+		return nil
+	}
+	return g.Validate()
+}

--- a/geom/dcel_extract_geometry.go
+++ b/geom/dcel_extract_geometry.go
@@ -25,11 +25,7 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]bool) bool) (G
 		if len(areals) == 1 {
 			return areals[0].AsGeometry(), nil
 		}
-		mp, err := NewMultiPolygon(areals)
-		if err != nil {
-			return Geometry{}, wrap(err, "could not extract areal geometry from DCEL")
-		}
-		return mp.AsGeometry(), nil
+		return NewMultiPolygon(areals).AsGeometry(), nil
 	case len(areals) == 0 && len(linears) > 0 && len(points) == 0:
 		if len(linears) == 1 {
 			return linears[0].AsGeometry(), nil
@@ -100,11 +96,7 @@ func (d *doublyConnectedEdgeList) extractPolygons(include func([2]bool) bool) ([
 
 		// Construct the polygon.
 		orderPolygonRings(rings)
-		poly, err := NewPolygon(rings)
-		if err != nil {
-			return nil, err
-		}
-		polys = append(polys, poly)
+		polys = append(polys, NewPolygon(rings))
 	}
 
 	sort.Slice(polys, func(i, j int) bool {
@@ -146,11 +138,7 @@ func extractPolygonRing(faceSet map[*faceRecord]bool, start *halfEdgeRecord, see
 	}
 	rotateSeqs(seqs, len(seqs)-minI)
 
-	ring, err := NewLineString(buildRingSequence(seqs))
-	if err != nil {
-		panic(fmt.Sprintf("could not create LineString: %v", err))
-	}
-	return ring
+	return NewLineString(buildRingSequence(seqs))
 }
 
 func buildRingSequence(seqs []Sequence) Sequence {
@@ -260,11 +248,7 @@ func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]bool) bool)
 			e.origin.extracted = true
 			e.twin.origin.extracted = true
 
-			ls, err := NewLineString(e.seq)
-			if err != nil {
-				return nil, err
-			}
-			lss = append(lss, ls)
+			lss = append(lss, NewLineString(e.seq))
 		}
 	}
 	sort.Slice(lss, func(i, j int) bool {

--- a/geom/dcel_re_noding.go
+++ b/geom/dcel_re_noding.go
@@ -61,6 +61,9 @@ func ulpSizeForLine(ln line) float64 {
 // such that when the two geometries are overlaid the only interactions
 // (including self-interactions) between geometries are at nodes. Nodes that
 // are close to each other are also snapped together.
+//
+// TODO: should be able to remove the error returns from this function and its
+// descendants.
 func reNodeGeometries(g1, g2 Geometry, mls MultiLineString) (Geometry, Geometry, MultiLineString, error) {
 	// Calculate the maximum ULP size over all control points in the input
 	// geometries. This size is a good indication of the precision that we
@@ -245,11 +248,7 @@ func reNodeLineString(ls LineString, cut cutSet, nodes nodeSet) (LineString, err
 		newCoords = append(newCoords, last.X, last.Y)
 	}
 
-	newLS, err := NewLineString(NewSequence(newCoords, DimXY), DisableAllValidations)
-	if err != nil {
-		return LineString{}, err
-	}
-	return newLS, nil
+	return NewLineString(NewSequence(newCoords, DimXY)), nil
 }
 
 func reNodeMultiLineString(mls MultiLineString, cut cutSet, nodes nodeSet) (MultiLineString, error) {
@@ -262,7 +261,7 @@ func reNodeMultiLineString(mls MultiLineString, cut cutSet, nodes nodeSet) (Mult
 			return MultiLineString{}, err
 		}
 	}
-	return NewMultiLineString(lss, DisableAllValidations), nil
+	return NewMultiLineString(lss), nil
 }
 
 func reNodePolygon(poly Polygon, cut cutSet, nodes nodeSet) (Polygon, error) {
@@ -275,11 +274,7 @@ func reNodePolygon(poly Polygon, cut cutSet, nodes nodeSet) (Polygon, error) {
 	for i := 0; i < n; i++ {
 		rings[i] = reNodedBoundary.LineStringN(i)
 	}
-	reNodedPoly, err := NewPolygon(rings, DisableAllValidations)
-	if err != nil {
-		return Polygon{}, err
-	}
-	return reNodedPoly, nil
+	return NewPolygon(rings), nil
 }
 
 func reNodeMultiPolygonString(mp MultiPolygon, cut cutSet, nodes nodeSet) (MultiPolygon, error) {
@@ -292,11 +287,7 @@ func reNodeMultiPolygonString(mp MultiPolygon, cut cutSet, nodes nodeSet) (Multi
 			return MultiPolygon{}, err
 		}
 	}
-	reNodedMP, err := NewMultiPolygon(polys, DisableAllValidations)
-	if err != nil {
-		return MultiPolygon{}, err
-	}
-	return reNodedMP, nil
+	return NewMultiPolygon(polys), nil
 }
 
 func reNodeGeometryCollection(gc GeometryCollection, cut cutSet, nodes nodeSet) (GeometryCollection, error) {
@@ -309,5 +300,5 @@ func reNodeGeometryCollection(gc GeometryCollection, cut cutSet, nodes nodeSet) 
 			return GeometryCollection{}, err
 		}
 	}
-	return NewGeometryCollection(geoms, DisableAllValidations), nil
+	return NewGeometryCollection(geoms), nil
 }

--- a/geom/geojson_unmarshal.go
+++ b/geom/geojson_unmarshal.go
@@ -57,7 +57,14 @@ func UnmarshalGeoJSON(input []byte, opts ...ConstructorOption) (Geometry, error)
 		ctype = DimXYZ
 	}
 
-	return geojsonNodeToGeometry(rootObj, ctype, opts)
+	g, err := geojsonNodeToGeometry(rootObj, ctype, opts)
+	if err != nil {
+		return Geometry{}, err
+	}
+	if err := validate(opts, g); err != nil {
+		return Geometry{}, err
+	}
+	return g, nil
 }
 
 type geojsonNode struct {
@@ -234,19 +241,18 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
 	}
 }
 
+// TODO: remove error handling and opts from this function
 func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []ConstructorOption) (Geometry, error) {
 	switch node := node.(type) {
 	case geojsonPoint:
 		coords, ok := oneDimFloat64sToCoordinates(node.coords, ctype)
 		if ok {
-			pt, err := NewPoint(coords, opts...)
-			return pt.AsGeometry(), err
+			return NewPoint(coords).AsGeometry(), nil
 		}
 		return NewEmptyPoint(ctype).AsGeometry(), nil
 	case geojsonLineString:
 		seq := twoDimFloat64sToSequence(node.coords, ctype)
-		ls, err := NewLineString(seq, opts...)
-		return ls.AsGeometry(), err
+		return NewLineString(seq).AsGeometry(), nil
 	case geojsonPolygon:
 		if len(node.coords) == 0 {
 			return Polygon{}.ForceCoordinatesType(ctype).AsGeometry(), nil
@@ -254,14 +260,9 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 		rings := make([]LineString, len(node.coords))
 		for i, coords := range node.coords {
 			seq := twoDimFloat64sToSequence(coords, ctype)
-			var err error
-			rings[i], err = NewLineString(seq, opts...)
-			if err != nil {
-				return Geometry{}, err
-			}
+			rings[i] = NewLineString(seq)
 		}
-		poly, err := NewPolygon(rings, opts...)
-		return poly.AsGeometry(), err
+		return NewPolygon(rings).AsGeometry(), nil
 	case geojsonMultiPoint:
 		// GeoJSON MultiPoints cannot contain empty Points.
 		if len(node.coords) == 0 {
@@ -271,11 +272,7 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 		for i, coords := range node.coords {
 			coords, ok := oneDimFloat64sToCoordinates(coords, ctype)
 			if ok {
-				var err error
-				points[i], err = NewPoint(coords, opts...)
-				if err != nil {
-					return Geometry{}, err
-				}
+				points[i] = NewPoint(coords)
 			} else {
 				points[i] = NewEmptyPoint(ctype)
 			}
@@ -288,13 +285,9 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 		lss := make([]LineString, len(node.coords))
 		for i, coords := range node.coords {
 			seq := twoDimFloat64sToSequence(coords, ctype)
-			var err error
-			lss[i], err = NewLineString(seq, opts...)
-			if err != nil {
-				return Geometry{}, err
-			}
+			lss[i] = NewLineString(seq)
 		}
-		return NewMultiLineString(lss, opts...).AsGeometry(), nil
+		return NewMultiLineString(lss).AsGeometry(), nil
 	case geojsonMultiPolygon:
 		if len(node.coords) == 0 {
 			return MultiPolygon{}.ForceCoordinatesType(ctype).AsGeometry(), nil
@@ -304,21 +297,11 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 			rings := make([]LineString, len(coords))
 			for j, coords := range coords {
 				seq := twoDimFloat64sToSequence(coords, ctype)
-				var err error
-				rings[j], err = NewLineString(seq, opts...)
-				if err != nil {
-					return Geometry{}, err
-				}
+				rings[j] = NewLineString(seq)
 			}
-			var err error
-			polys[i], err = NewPolygon(rings, opts...)
-			if err != nil {
-				return Geometry{}, err
-			}
-			polys[i] = polys[i].ForceCoordinatesType(ctype)
+			polys[i] = NewPolygon(rings).ForceCoordinatesType(ctype)
 		}
-		mp, err := NewMultiPolygon(polys, opts...)
-		return mp.AsGeometry(), err
+		return NewMultiPolygon(polys).AsGeometry(), nil
 	case geojsonGeometryCollection:
 		if len(node.geoms) == 0 {
 			return GeometryCollection{}.ForceCoordinatesType(ctype).AsGeometry(), nil
@@ -331,7 +314,7 @@ func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType, opts []Const
 				return Geometry{}, err
 			}
 		}
-		return NewGeometryCollection(children, opts...).AsGeometry(), nil
+		return NewGeometryCollection(children).AsGeometry(), nil
 	default:
 		panic(fmt.Sprintf("unexpected node: %#v", node))
 	}

--- a/geom/line.go
+++ b/geom/line.go
@@ -1,7 +1,6 @@
 package geom
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/peterstace/simplefeatures/rtree"
@@ -49,15 +48,10 @@ func (ln line) centroid() XY {
 }
 
 func (ln line) asLineString() LineString {
-	ls, err := NewLineString(NewSequence([]float64{
+	return NewLineString(NewSequence([]float64{
 		ln.a.X, ln.a.Y,
 		ln.b.X, ln.b.Y,
 	}, DimXY))
-	if err != nil {
-		// Should not occur, because we know that a and b are distinct.
-		panic(fmt.Sprintf("could not create line string: %v", err))
-	}
-	return ls
 }
 
 func (ln line) intersectsXY(xy XY) bool {

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -25,15 +25,8 @@ func regularPolygon(center XY, radius float64, sides int) Polygon {
 	}
 	coords[2*sides+0] = coords[0]
 	coords[2*sides+1] = coords[1]
-	ring, err := NewLineString(NewSequence(coords, DimXY), geom.DisableAllValidations)
-	if err != nil {
-		panic(err)
-	}
-	poly, err := NewPolygon([]LineString{ring}, geom.DisableAllValidations)
-	if err != nil {
-		panic(err)
-	}
-	return poly
+	ring := NewLineString(NewSequence(coords, DimXY))
+	return NewPolygon([]LineString{ring})
 }
 
 func BenchmarkMarshalWKB(b *testing.B) {
@@ -78,20 +71,12 @@ func BenchmarkIntersectsLineStringWithLineString(b *testing.B) {
 			}
 			seq1 := geom.NewSequence(floats1, geom.DimXY)
 			seq2 := geom.NewSequence(floats2, geom.DimXY)
-			ls1, err := geom.NewLineString(seq1)
-			if err != nil {
-				b.Fatal(err)
-			}
-			ls2, err := geom.NewLineString(seq2)
-			if err != nil {
-				b.Fatal(err)
-			}
-			ls1g := ls1.AsGeometry()
-			ls2g := ls2.AsGeometry()
+			ls1 := geom.NewLineString(seq1).AsGeometry()
+			ls2 := geom.NewLineString(seq2).AsGeometry()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				if Intersects(ls1g, ls2g) {
+				if Intersects(ls1, ls2) {
 					b.Fatal("should not intersect")
 				}
 			}
@@ -135,15 +120,12 @@ func BenchmarkPolygonSingleRingValidation(b *testing.B) {
 			}
 			floats[2*sz+0] = floats[0]
 			floats[2*sz+1] = floats[1]
-			ring, err := NewLineString(NewSequence(floats, DimXY))
-			if err != nil {
-				b.Fatal(err)
-			}
-			rings := []LineString{ring}
+			ring := NewLineString(NewSequence(floats, DimXY))
+			poly := NewPolygon([]LineString{ring})
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewPolygon(rings); err != nil {
+				if err := poly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -156,11 +138,7 @@ func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
 		b.Run(fmt.Sprintf("n=%d", sz*sz), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
 			rings := make([]LineString, sz*sz+1)
-			var err error
-			rings[0], err = NewLineString(NewSequence([]float64{0, 0, 0, 1, 1, 1, 1, 0, 0, 0}, DimXY))
-			if err != nil {
-				b.Fatal(err)
-			}
+			rings[0] = NewLineString(NewSequence([]float64{0, 0, 0, 1, 1, 1, 1, 0, 0, 0}, DimXY))
 			for i := 0; i < sz*sz; i++ {
 				center := XY{
 					X: (0.5 + float64(i/sz)) / float64(sz),
@@ -168,21 +146,19 @@ func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
 				}
 				dx := rnd.Float64() * 0.5 / float64(sz)
 				dy := rnd.Float64() * 0.5 / float64(sz)
-				rings[1+i], err = NewLineString(NewSequence([]float64{
+				rings[1+i] = NewLineString(NewSequence([]float64{
 					center.X - dx, center.Y - dy,
 					center.X + dx, center.Y - dy,
 					center.X + dx, center.Y + dy,
 					center.X - dx, center.Y + dy,
 					center.X - dx, center.Y - dy,
 				}, DimXY))
-				if err != nil {
-					b.Fatal(err)
-				}
 			}
+			poly := NewPolygon(rings)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewPolygon(rings); err != nil {
+				if err := poly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -211,19 +187,13 @@ func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 				6, 1,
 				3, 1,
 			)
-			leftRing, err := NewLineString(NewSequence(leftFloats, DimXY))
-			if err != nil {
-				b.Fatal(err)
-			}
-			rightRing, err := NewLineString(NewSequence(rightFloats, DimXY))
-			if err != nil {
-				b.Fatal(err)
-			}
+			leftRing := NewLineString(NewSequence(leftFloats, DimXY))
+			rightRing := NewLineString(NewSequence(rightFloats, DimXY))
+			poly := NewPolygon([]LineString{outerRing, leftRing, rightRing})
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := NewPolygon([]LineString{outerRing, leftRing, rightRing})
-				if err != nil {
+				if err := poly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -237,9 +207,10 @@ func BenchmarkPolygonAnnulusValidation(b *testing.B) {
 			outer := regularPolygon(XY{}, 1.0, sz/2).ExteriorRing()
 			inner := regularPolygon(XY{}, 0.5, sz/2).ExteriorRing()
 			rings := []LineString{outer, inner}
+			poly := NewPolygon(rings)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewPolygon(rings); err != nil {
+				if err := poly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -257,25 +228,20 @@ func BenchmarkMultipolygonValidation(b *testing.B) {
 				cy := (0.5 + float64(i%sz)) / float64(sz)
 				dx := rnd.Float64() * 0.5 / float64(sz)
 				dy := rnd.Float64() * 0.5 / float64(sz)
-				ring, err := NewLineString(NewSequence([]float64{
+				ring := NewLineString(NewSequence([]float64{
 					cx - dx, cy - dy,
 					cx + dx, cy - dy,
 					cx + dx, cy + dy,
 					cx - dx, cy + dy,
 					cx - dx, cy - dy,
 				}, DimXY))
-				if err != nil {
-					b.Fatal(err)
-				}
-				polys[i], err = NewPolygon([]LineString{ring})
-				if err != nil {
-					b.Fatal(err)
-				}
+				polys[i] = NewPolygon([]LineString{ring})
 			}
+			multiPoly := NewMultiPolygon(polys)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewMultiPolygon(polys); err != nil {
+				if err := multiPoly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -291,9 +257,10 @@ func BenchmarkMultiPolygonTwoCircles(b *testing.B) {
 				regularPolygon(XY{X: -eps, Y: -eps}, 1.0, sz),
 				regularPolygon(XY{X: math.Sqrt2, Y: math.Sqrt2}, 1.0, sz),
 			}
+			multiPoly := NewMultiPolygon(polys)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, err := NewMultiPolygon(polys); err != nil {
+				if err := multiPoly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -313,28 +280,16 @@ func BenchmarkMultiPolygonMultipleTouchingPoints(b *testing.B) {
 			fs1 = append(fs1, 0, float64(2*sz), 0, 0)
 			fs2 = append(fs2, 4, float64(2*sz), 4, 0)
 
-			ls1, err := NewLineString(NewSequence(fs1, DimXY))
-			if err != nil {
-				b.Fatal(err)
-			}
-			ls2, err := NewLineString(NewSequence(fs2, DimXY))
-			if err != nil {
-				b.Fatal(err)
-			}
-			p1, err := NewPolygon([]LineString{ls1})
-			if err != nil {
-				b.Fatal(err)
-			}
-			p2, err := NewPolygon([]LineString{ls2})
-			if err != nil {
-				b.Fatal(err)
-			}
+			ls1 := NewLineString(NewSequence(fs1, DimXY))
+			ls2 := NewLineString(NewSequence(fs2, DimXY))
+			p1 := NewPolygon([]LineString{ls1})
+			p2 := NewPolygon([]LineString{ls2})
 			polys := []Polygon{p1, p2}
+			multiPoly := NewMultiPolygon(polys)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := NewMultiPolygon(polys)
-				if err != nil {
+				if err := multiPoly.Validate(); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -407,8 +362,8 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 					float64(2*i + 1),
 					float64(2*i + 1),
 				}, DimXY)
-				ls, err := NewLineString(seq)
-				if err != nil {
+				ls := NewLineString(seq)
+				if err := ls.Validate(); err != nil {
 					b.Fatal(err)
 				}
 				lss = append(lss, ls)

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -1,7 +1,6 @@
 package geom
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -125,14 +124,8 @@ func (e Envelope) AsGeometry() Geometry {
 		minX, e.minY,
 	}
 	seq := NewSequence(floats[:], DimXY)
-	ls, err := NewLineString(seq)
-	if err != nil {
-		panic(fmt.Sprintf("constructing geometry from envelope: %v", err))
-	}
-	poly, err := NewPolygon([]LineString{ls})
-	if err != nil {
-		panic(fmt.Sprintf("constructing geometry from envelope: %v", err))
-	}
+	ring := NewLineString(seq)
+	poly := NewPolygon([]LineString{ring})
 	return poly.AsGeometry()
 }
 
@@ -312,15 +305,9 @@ func (e Envelope) BoundingDiagonal() Geometry {
 		return e.min().asUncheckedPoint().AsGeometry()
 	}
 
-	// The Envelope has already been validated, so it's safe to skip validation
-	// when constructing the diagonal.
 	coords := []float64{e.minX(), e.minY, e.maxX, e.maxY}
 	seq := NewSequence(coords, DimXY)
-	ls, err := NewLineString(seq, DisableAllValidations)
-	if err != nil {
-		panic("non-validating ctor failed: " + err.Error())
-	}
-	return ls.AsGeometry()
+	return NewLineString(seq).AsGeometry()
 }
 
 // String implements the fmt.Stringer interface by printing the envelope in a

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -20,12 +20,9 @@ type GeometryCollection struct {
 // type of the GeometryCollection is the lowest common coordinates type of its
 // child geometries.
 //
-// Because GeometryCollections are unconstrained collections, this construction
-// function doesn't return an error.
-//
-// Note that this constructor doesn't check the validity of its Polygon
-// arguments.
-func NewGeometryCollection(geoms []Geometry, opts ...ConstructorOption) GeometryCollection {
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewGeometryCollection(geoms []Geometry) GeometryCollection {
 	if len(geoms) == 0 {
 		return GeometryCollection{}
 	}
@@ -552,5 +549,5 @@ func (c GeometryCollection) Simplify(threshold float64, opts ...ConstructorOptio
 			return GeometryCollection{}, wrapSimplified(err)
 		}
 	}
-	return NewGeometryCollection(geoms, opts...), nil
+	return NewGeometryCollection(geoms), nil
 }

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -15,19 +15,12 @@ type LineString struct {
 	seq Sequence
 }
 
-// NewLineString creates a new LineString from a Sequence of points. An error
-// is returned if the LineString would be invalid (see the Validate method for
-// details).
-func NewLineString(seq Sequence, opts ...ConstructorOption) (LineString, error) {
-	ls := LineString{seq}
-	co := newOptionSet(opts)
-	if co.skipValidations {
-		return ls, nil
-	}
-	if err := ls.Validate(); err != nil {
-		return LineString{}, err
-	}
-	return ls, nil
+// NewLineString creates a new LineString from a Sequence of points.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewLineString(seq Sequence) LineString {
+	return LineString{seq}
 }
 
 // Validate checks if the LineString is valid. For it to be valid, the
@@ -306,11 +299,7 @@ func (s LineString) Coordinates() Sequence {
 // TransformXY transforms this LineString into another LineString according to fn.
 func (s LineString) TransformXY(fn func(XY) XY) LineString {
 	transformed := transformSequence(s.seq, fn)
-	ls, err := NewLineString(transformed, DisableAllValidations)
-	if err != nil {
-		panic("non-validating ctor failed: " + err.Error())
-	}
-	return ls
+	return NewLineString(transformed)
 }
 
 // IsRing returns true iff this LineString is both simple and closed (i.e. is a
@@ -434,8 +423,8 @@ func (s LineString) Simplify(threshold float64) LineString {
 	seq := s.Coordinates()
 	floats := ramerDouglasPeucker(nil, seq, threshold)
 	seq = NewSequence(floats, seq.CoordinatesType())
-	ls, err := NewLineString(seq)
-	if err != nil {
+	ls := NewLineString(seq)
+	if ls.Validate() != nil {
 		return LineString{}.ForceCoordinatesType(s.CoordinatesType())
 	}
 	return ls

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -22,12 +22,9 @@ type MultiLineString struct {
 // LineStrings. The coordinates type of the MultiLineString is the lowest
 // common coordinates type of its LineStrings.
 //
-// Because MultiLineStrings are unconstrained collections, this constructor
-// function doesn't return an error.
-//
-// Note that this constructor doesn't check the validity of its LineString
-// arguments.
-func NewMultiLineString(lines []LineString, opts ...ConstructorOption) MultiLineString {
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiLineString(lines []LineString) MultiLineString {
 	if len(lines) == 0 {
 		return MultiLineString{}
 	}
@@ -339,14 +336,8 @@ func (m MultiLineString) TransformXY(fn func(XY) XY) MultiLineString {
 	}
 	transformed := make([]LineString, n)
 	for i := 0; i < n; i++ {
-		var err error
-		transformed[i], err = NewLineString(
-			transformSequence(m.LineStringN(i).Coordinates(), fn),
-			DisableAllValidations,
-		)
-		if err != nil {
-			panic("non-validating ctor failed: " + err.Error())
-		}
+		seq := transformSequence(m.LineStringN(i).Coordinates(), fn)
+		transformed[i] = NewLineString(seq)
 	}
 	return NewMultiLineString(transformed)
 }

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -18,12 +18,9 @@ type MultiPoint struct {
 // NewMultiPoint creates a MultiPoint from a list of Points. The coordinate
 // type of the MultiPoint is the lowest common coordinates type of its Points.
 //
-// Because MultiPoints are unconstrained collections, this constructor function
-// doesn't return an error.
-//
-// Note that this constructor doesn't check the validity of its Point
-// arguments.
-func NewMultiPoint(pts []Point, opts ...ConstructorOption) MultiPoint {
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPoint(pts []Point) MultiPoint {
 	if len(pts) == 0 {
 		return MultiPoint{}
 	}
@@ -228,11 +225,7 @@ func (m MultiPoint) TransformXY(fn func(XY) XY) MultiPoint {
 	for i, pt := range m.points {
 		if c, ok := pt.Coordinates(); ok {
 			c.XY = fn(c.XY)
-			var err error
-			txPoints[i], err = NewPoint(c, DisableAllValidations)
-			if err != nil {
-				panic("non-validating ctor failed: " + err.Error())
-			}
+			txPoints[i] = NewPoint(c)
 		} else {
 			txPoints[i] = pt
 		}

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -21,13 +21,9 @@ type MultiPolygon struct {
 // coordinates type of the MultiPolygon is the lowest common coordinates type
 // of its Polygons.
 //
-// The Polygons that make up a MultiPolygon are constrained by a set of
-// validation rules. If these are violated, then an error is returned (see the
-// Validate method for details).
-//
-// Note that this constructor doesn't check the validity of its Polygon
-// arguments.
-func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, error) {
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPolygon(polys []Polygon) MultiPolygon {
 	ctype := DimXY
 	if len(polys) > 0 {
 		ctype = DimXYZM
@@ -39,16 +35,7 @@ func NewMultiPolygon(polys []Polygon, opts ...ConstructorOption) (MultiPolygon, 
 	for i := range polys {
 		polys[i] = polys[i].ForceCoordinatesType(ctype)
 	}
-	mp := MultiPolygon{polys, ctype}
-
-	os := newOptionSet(opts)
-	if os.skipValidations {
-		return mp, nil
-	}
-	if err := mp.checkMultiPolygonConstraints(); err != nil {
-		return MultiPolygon{}, err
-	}
-	return mp, nil
+	return MultiPolygon{polys, ctype}
 }
 
 // Validate checks if the MultiPolygon is valid.
@@ -352,10 +339,7 @@ func (m MultiPolygon) TransformXY(fn func(XY) XY) MultiPolygon {
 	for i := range polys {
 		polys[i] = m.PolygonN(i).TransformXY(fn)
 	}
-	mp, err := NewMultiPolygon(polys, DisableAllValidations)
-	if err != nil {
-		panic("non-validating ctor failed: " + err.Error())
-	}
+	mp := NewMultiPolygon(polys)
 	return mp.ForceCoordinatesType(m.ctype)
 }
 
@@ -578,6 +562,9 @@ func (m MultiPolygon) Simplify(threshold float64, opts ...ConstructorOption) (Mu
 			polys = append(polys, poly)
 		}
 	}
-	simpl, err := NewMultiPolygon(polys, opts...)
-	return simpl, wrapSimplified(err)
+	simpl := NewMultiPolygon(polys)
+	if err := validate(opts, simpl); err != nil {
+		return MultiPolygon{}, wrapSimplified(err)
+	}
+	return simpl, nil
 }

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -18,18 +18,12 @@ type Point struct {
 	full   bool
 }
 
-// NewPoint creates a new point given its Coordinates. An error is returned for
-// invalid points (see the Validate method for details).
-func NewPoint(c Coordinates, opts ...ConstructorOption) (Point, error) {
-	pt := newUncheckedPoint(c)
-	os := newOptionSet(opts)
-	if os.skipValidations {
-		return pt, nil
-	}
-	if err := pt.Validate(); err != nil {
-		return Point{}, err
-	}
-	return pt, nil
+// NewPoint creates a new point given its Coordinates.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPoint(c Coordinates) Point {
+	return Point{c, true}
 }
 
 // Validate checks if the Point is valid. For it to be valid, it must be empty
@@ -57,6 +51,8 @@ func (p Point) Validate() error {
 // geometry that has been validated. Technically, these calculations could
 // overflow to +/- inf. However if control points are originally close to
 // infinity, many of the algorithms will be already broken in many other ways.
+//
+// TODO: this is the same as NewPoint, so it should be removed.
 func newUncheckedPoint(c Coordinates) Point {
 	return Point{c, true}
 }

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -23,9 +23,9 @@ type Polygon struct {
 // is the empty Polygon. The coordinate type of the polygon is the lowest
 // common coordinate type of its rings.
 //
-// An error is returned if any of the Polygon constraints are not met (see the
-// Validate method for details).
-func NewPolygon(rings []LineString, opts ...ConstructorOption) (Polygon, error) {
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPolygon(rings []LineString) Polygon {
 	ctype := DimXY
 	if len(rings) > 0 {
 		ctype = DimXYZM
@@ -37,16 +37,7 @@ func NewPolygon(rings []LineString, opts ...ConstructorOption) (Polygon, error) 
 	for i := range rings {
 		rings[i] = rings[i].ForceCoordinatesType(ctype)
 	}
-	poly := Polygon{rings, ctype}
-
-	os := newOptionSet(opts)
-	if os.skipValidations {
-		return poly, nil
-	}
-	if err := poly.Validate(); err != nil {
-		return Polygon{}, err
-	}
-	return poly, nil
+	return Polygon{rings, ctype}
 }
 
 // Validate checks if the Polygon is valid. For non-empty Polygons to be valid,
@@ -340,19 +331,10 @@ func (p Polygon) TransformXY(fn func(XY) XY) Polygon {
 	n := len(p.rings)
 	transformed := make([]LineString, n)
 	for i, r := range p.rings {
-		var err error
-		transformed[i], err = NewLineString(
-			transformSequence(r.Coordinates(), fn),
-			DisableAllValidations,
-		)
-		if err != nil {
-			panic("non-validating ctor failed: " + err.Error())
-		}
+		seq := transformSequence(r.Coordinates(), fn)
+		transformed[i] = NewLineString(seq)
 	}
-	poly, err := NewPolygon(transformed)
-	if err != nil {
-		panic("non-validating ctor failed: " + err.Error())
-	}
+	poly := NewPolygon(transformed)
 	return poly.ForceCoordinatesType(p.ctype)
 }
 
@@ -501,12 +483,7 @@ func (p Polygon) AsMultiPolygon() MultiPolygon {
 	if !p.IsEmpty() {
 		polys = []Polygon{p}
 	}
-	mp, err := NewMultiPolygon(polys)
-	if err != nil {
-		// Cannot occur due to construction. A valid polygon will always be a
-		// valid multipolygon.
-		panic(err)
-	}
+	mp := NewMultiPolygon(polys)
 	return mp.ForceCoordinatesType(p.ctype)
 }
 
@@ -695,6 +672,9 @@ func (p Polygon) Simplify(threshold float64, opts ...ConstructorOption) (Polygon
 			rings = append(rings, interior)
 		}
 	}
-	simpl, err := NewPolygon(rings, opts...)
-	return simpl, wrapSimplified(err)
+	simpl := NewPolygon(rings)
+	if err := validate(opts, simpl); err != nil {
+		return Polygon{}, wrapSimplified(err)
+	}
+	return simpl, nil
 }

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -32,19 +32,8 @@ func TestPointValidation(t *testing.T) {
 		{false, xy(-inf, -inf)},
 	} {
 		t.Run(fmt.Sprintf("point_%d", i), func(t *testing.T) {
-			t.Run("Constructor", func(t *testing.T) {
-				_, err := NewPoint(tc.input)
-				if tc.wantValid {
-					expectNoErr(t, err)
-				} else {
-					expectErr(t, err)
-				}
-			})
-			t.Run("Validate", func(t *testing.T) {
-				pt, err := NewPoint(tc.input, DisableAllValidations)
-				expectNoErr(t, err)
-				expectBoolEq(t, tc.wantValid, pt.Validate() == nil)
-			})
+			pt := NewPoint(tc.input)
+			expectBoolEq(t, tc.wantValid, pt.Validate() == nil)
 		})
 	}
 }
@@ -70,15 +59,8 @@ func TestLineStringValidation(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			seq := NewSequence(tc.inputs, DimXY)
-			t.Run("Constructor", func(t *testing.T) {
-				_, err := NewLineString(seq)
-				expectBoolEq(t, tc.wantValid, err == nil)
-			})
-			t.Run("Validate", func(t *testing.T) {
-				ls, err := NewLineString(seq, DisableAllValidations)
-				expectNoErr(t, err)
-				expectBoolEq(t, tc.wantValid, ls.Validate() == nil)
-			})
+			ls := NewLineString(seq)
+			expectBoolEq(t, tc.wantValid, ls.Validate() == nil)
 		})
 	}
 }
@@ -183,8 +165,7 @@ func TestMultiPointValidation(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var pts []Point
 			for _, c := range tc.coords {
-				pt, err := NewPoint(c, DisableAllValidations)
-				expectNoErr(t, err)
+				pt := NewPoint(c)
 				pts = append(pts, pt)
 			}
 			mp := NewMultiPoint(pts)
@@ -208,8 +189,7 @@ func TestMultiLineStringValidation(t *testing.T) {
 			var lss []LineString
 			for _, coords := range tc.coords {
 				seq := NewSequence(coords, DimXY)
-				ls, err := NewLineString(seq, DisableAllValidations)
-				expectNoErr(t, err)
+				ls := NewLineString(seq)
 				lss = append(lss, ls)
 			}
 			mls := NewMultiLineString(lss)
@@ -312,11 +292,7 @@ func TestMultiPolygonConstraintValidation(t *testing.T) {
 	expectNoErr(t, err)
 	expectErr(t, poly.Validate())
 
-	// The validity of the Polygon is not checked by the constructor and
-	// will only be caught by checking the validity of each input, or calling
-	// the Validate method.
-	mp, err := NewMultiPolygon([]Polygon{poly.MustAsPolygon()})
-	expectNoErr(t, err)
+	mp := NewMultiPolygon([]Polygon{poly.MustAsPolygon()})
 	expectErr(t, mp.Validate())
 }
 

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -14,15 +14,21 @@ func UnmarshalWKB(wkb []byte, opts ...ConstructorOption) (Geometry, error) {
 	// bytes. There is nothing in the OGC spec indicating that trailing bytes
 	// are illegal. Some Esri software will add (useless) trailing bytes to
 	// their WKBs.
-	p := wkbParser{body: wkb, opts: opts}
-	return p.run()
+	p := wkbParser{body: wkb}
+	g, err := p.run()
+	if err != nil {
+		return Geometry{}, err
+	}
+	if err := validate(opts, g); err != nil {
+		return Geometry{}, err
+	}
+	return g, nil
 }
 
 type wkbParser struct {
 	body []byte
 	bo   byte
 	no   bool
-	opts []ConstructorOption
 }
 
 func (p *wkbParser) run() (Geometry, error) {
@@ -37,7 +43,7 @@ func (p *wkbParser) run() (Geometry, error) {
 }
 
 func (p *wkbParser) inner() (Geometry, error) {
-	inner := wkbParser{body: p.body, opts: p.opts}
+	inner := wkbParser{body: p.body}
 	g, err := inner.run()
 	if err != nil {
 		return Geometry{}, err
@@ -207,7 +213,7 @@ func (p *wkbParser) parsePoint(ctype CoordinatesType) (Point, error) {
 	if math.IsNaN(c.X) || math.IsNaN(c.Y) {
 		return Point{}, wkbSyntaxError{"point contains mixed NaN values"}
 	}
-	return NewPoint(c, p.opts...)
+	return NewPoint(c), nil
 }
 
 func (p *wkbParser) parseLineString(ctype CoordinatesType) (LineString, error) {
@@ -233,7 +239,7 @@ func (p *wkbParser) parseLineString(ctype CoordinatesType) (LineString, error) {
 	copy(floats, bytesAsFloats(seqData))
 
 	seq := NewSequence(floats, ctype)
-	return NewLineString(seq, p.opts...)
+	return NewLineString(seq), nil
 }
 
 // bytesAsFloats reinterprets the bytes slice as a float64 slice in a similar
@@ -271,7 +277,7 @@ func (p *wkbParser) parsePolygon(ctype CoordinatesType) (Polygon, error) {
 			return Polygon{}, err
 		}
 	}
-	return NewPolygon(rings, p.opts...)
+	return NewPolygon(rings), nil
 }
 
 func (p *wkbParser) parseMultiPoint(ctype CoordinatesType) (MultiPoint, error) {
@@ -293,7 +299,7 @@ func (p *wkbParser) parseMultiPoint(ctype CoordinatesType) (MultiPoint, error) {
 		}
 		pts[i] = geom.MustAsPoint()
 	}
-	return NewMultiPoint(pts, p.opts...), nil
+	return NewMultiPoint(pts), nil
 }
 
 func (p *wkbParser) parseMultiLineString(ctype CoordinatesType) (MultiLineString, error) {
@@ -315,7 +321,7 @@ func (p *wkbParser) parseMultiLineString(ctype CoordinatesType) (MultiLineString
 		}
 		lss[i] = geom.MustAsLineString()
 	}
-	return NewMultiLineString(lss, p.opts...), nil
+	return NewMultiLineString(lss), nil
 }
 
 func (p *wkbParser) parseMultiPolygon(ctype CoordinatesType) (MultiPolygon, error) {
@@ -337,7 +343,7 @@ func (p *wkbParser) parseMultiPolygon(ctype CoordinatesType) (MultiPolygon, erro
 		}
 		polys[i] = geom.MustAsPolygon()
 	}
-	return NewMultiPolygon(polys, p.opts...)
+	return NewMultiPolygon(polys), nil
 }
 
 func (p *wkbParser) parseGeometryCollection(ctype CoordinatesType) (GeometryCollection, error) {
@@ -355,5 +361,5 @@ func (p *wkbParser) parseGeometryCollection(ctype CoordinatesType) (GeometryColl
 			return GeometryCollection{}, err
 		}
 	}
-	return NewGeometryCollection(geoms, p.opts...), nil
+	return NewGeometryCollection(geoms), nil
 }

--- a/geom/wkt_parser.go
+++ b/geom/wkt_parser.go
@@ -16,8 +16,8 @@ import (
 // UnmarshalWKT parses a Well Known Text (WKT), and returns the corresponding
 // Geometry.
 func UnmarshalWKT(wkt string, opts ...ConstructorOption) (Geometry, error) {
-	p := newParser(wkt, opts)
-	geom, err := p.nextGeometryTaggedText()
+	p := newParser(wkt)
+	g, err := p.nextGeometryTaggedText()
 	if err != nil {
 		return Geometry{}, err
 	}
@@ -27,7 +27,11 @@ func UnmarshalWKT(wkt string, opts ...ConstructorOption) (Geometry, error) {
 	} else if err != wktUnexpectedEOF {
 		return Geometry{}, err
 	}
-	return geom, nil
+
+	if err := validate(opts, g); err != nil {
+		return Geometry{}, err
+	}
+	return g, nil
 }
 
 func wantButGot(wantTok, gotTok string) error {
@@ -37,13 +41,12 @@ func wantButGot(wantTok, gotTok string) error {
 	)}
 }
 
-func newParser(wkt string, opts []ConstructorOption) *parser {
-	return &parser{lexer: newWKTLexer(wkt), opts: opts}
+func newParser(wkt string) *parser {
+	return &parser{lexer: newWKTLexer(wkt)}
 }
 
 type parser struct {
 	lexer wktLexer
-	opts  []ConstructorOption
 }
 
 func (p *parser) nextGeometryTaggedText() (Geometry, error) {
@@ -60,8 +63,7 @@ func (p *parser) nextGeometryTaggedText() (Geometry, error) {
 		if !ok {
 			return NewEmptyPoint(ctype).AsGeometry(), nil
 		}
-		pt, err := NewPoint(c, p.opts...)
-		return pt.AsGeometry(), err
+		return NewPoint(c).AsGeometry(), nil
 	case "LINESTRING":
 		ls, err := p.nextLineStringText(ctype)
 		return ls.AsGeometry(), err
@@ -257,7 +259,7 @@ func (p *parser) nextLineStringText(ctype CoordinatesType) (LineString, error) {
 		}
 	}
 	seq := NewSequence(floats, ctype)
-	return NewLineString(seq, p.opts...)
+	return NewLineString(seq), nil
 }
 
 func (p *parser) nextPolygonText(ctype CoordinatesType) (Polygon, error) {
@@ -268,7 +270,7 @@ func (p *parser) nextPolygonText(ctype CoordinatesType) (Polygon, error) {
 	if len(rings) == 0 {
 		return Polygon{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewPolygon(rings, p.opts...)
+	return NewPolygon(rings), nil
 }
 
 func (p *parser) nextMultiLineString(ctype CoordinatesType) (MultiLineString, error) {
@@ -279,7 +281,7 @@ func (p *parser) nextMultiLineString(ctype CoordinatesType) (MultiLineString, er
 	if len(lss) == 0 {
 		return MultiLineString{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewMultiLineString(lss, p.opts...), nil
+	return NewMultiLineString(lss), nil
 }
 
 func (p *parser) nextPolygonOrMultiLineStringText(ctype CoordinatesType) ([]LineString, error) {
@@ -326,11 +328,7 @@ func (p *parser) nextMultiPointText(ctype CoordinatesType) (MultiPoint, error) {
 				return MultiPoint{}, err
 			}
 			if ok {
-				pt, err := NewPoint(coords, p.opts...)
-				if err != nil {
-					return MultiPoint{}, err
-				}
-				points = append(points, pt)
+				points = append(points, NewPoint(coords))
 			} else {
 				points = append(points, NewEmptyPoint(ctype))
 			}
@@ -346,7 +344,7 @@ func (p *parser) nextMultiPointText(ctype CoordinatesType) (MultiPoint, error) {
 	if len(points) == 0 {
 		return MultiPoint{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewMultiPoint(points, p.opts...), nil
+	return NewMultiPoint(points), nil
 }
 
 func (p *parser) nextMultiPointStylePoint(ctype CoordinatesType) (Coordinates, bool, error) {
@@ -408,7 +406,7 @@ func (p *parser) nextMultiPolygonText(ctype CoordinatesType) (MultiPolygon, erro
 	if len(polys) == 0 {
 		return MultiPolygon{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewMultiPolygon(polys, p.opts...)
+	return NewMultiPolygon(polys), nil
 }
 
 func (p *parser) nextGeometryCollectionText(ctype CoordinatesType) (GeometryCollection, error) {
@@ -436,5 +434,5 @@ func (p *parser) nextGeometryCollectionText(ctype CoordinatesType) (GeometryColl
 	if len(geoms) == 0 {
 		return GeometryCollection{}.ForceCoordinatesType(ctype), nil
 	}
-	return NewGeometryCollection(geoms, p.opts...), nil
+	return NewGeometryCollection(geoms), nil
 }

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -25,15 +25,24 @@ func (w XY) validate() error {
 
 // AsPoint is a convenience function to convert this XY value into a Point
 // geometry.
+//
+// TODO: This method shouldn't return an error or accept ConstructorOptions.
 func (w XY) AsPoint(opts ...ConstructorOption) (Point, error) {
 	coords := Coordinates{XY: w, Type: DimXY}
-	return NewPoint(coords, opts...)
+	pt := NewPoint(coords)
+	if err := validate(opts, pt); err != nil {
+		return Point{}, err
+	}
+	return pt, nil
 }
 
 // asUncheckedPoint is a convenience function to convert this XY value into a
 // Point. The Point is constructed without checking any validations. It may be
 // used internally when the caller is sure that the XY value doesn't come
 // directly from outside of the library without first being validated.
+//
+// TODO: This method should be removed (caller can use AsPoint instead once its
+// ConstructorOptions and error are removed).
 func (w XY) asUncheckedPoint() Point {
 	coords := Coordinates{XY: w, Type: DimXY}
 	return newUncheckedPoint(coords)

--- a/geom/zero_value_test.go
+++ b/geom/zero_value_test.go
@@ -46,29 +46,32 @@ func TestZeroValueGeometries(t *testing.T) {
 
 func TestEmptySliceConstructors(t *testing.T) {
 	t.Run("Polygon", func(t *testing.T) {
-		p, err := NewPolygon(nil)
-		expectNoErr(t, err)
+		p := NewPolygon(nil)
+		expectNoErr(t, p.Validate())
 		expectBoolEq(t, p.IsEmpty(), true)
 		expectCoordinatesTypeEq(t, p.CoordinatesType(), DimXY)
 	})
 	t.Run("MultiPoint", func(t *testing.T) {
 		mp := NewMultiPoint(nil)
+		expectNoErr(t, mp.Validate())
 		expectIntEq(t, mp.NumPoints(), 0)
 		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
 	})
 	t.Run("MultiLineString", func(t *testing.T) {
 		mls := NewMultiLineString(nil)
+		expectNoErr(t, mls.Validate())
 		expectIntEq(t, mls.NumLineStrings(), 0)
 		expectCoordinatesTypeEq(t, mls.CoordinatesType(), DimXY)
 	})
 	t.Run("MultiPolygon", func(t *testing.T) {
-		mp, err := NewMultiPolygon(nil)
-		expectNoErr(t, err)
+		mp := NewMultiPolygon(nil)
+		expectNoErr(t, mp.Validate())
 		expectIntEq(t, mp.NumPolygons(), 0)
 		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
 	})
 	t.Run("GeometryCollection", func(t *testing.T) {
 		gc := NewGeometryCollection(nil)
+		expectNoErr(t, gc.Validate())
 		expectIntEq(t, gc.NumGeometries(), 0)
 		expectCoordinatesTypeEq(t, gc.CoordinatesType(), DimXY)
 	})

--- a/geos/benchmark_test.go
+++ b/geos/benchmark_test.go
@@ -22,15 +22,8 @@ func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	}
 	coords[2*sides+0] = coords[0]
 	coords[2*sides+1] = coords[1]
-	ring, err := geom.NewLineString(geom.NewSequence(coords, geom.DimXY), geom.DisableAllValidations)
-	if err != nil {
-		panic(err)
-	}
-	poly, err := geom.NewPolygon([]geom.LineString{ring}, geom.DisableAllValidations)
-	if err != nil {
-		panic(err)
-	}
-	return poly
+	ring := geom.NewLineString(geom.NewSequence(coords, geom.DimXY))
+	return geom.NewPolygon([]geom.LineString{ring})
 }
 
 func BenchmarkNoOp(b *testing.B) {

--- a/internal/cmprefimpl/cmpgeos/handle.go
+++ b/internal/cmprefimpl/cmpgeos/handle.go
@@ -315,8 +315,11 @@ func (h *Handle) decodeGeomHandle(gh *C.GEOSGeometry) (geom.Geometry, error) {
 			}
 			subPolys[i] = subPolyAsGeom.MustAsPolygon()
 		}
-		mp, err := geom.NewMultiPolygon(subPolys)
-		return mp.AsGeometry(), err
+		mp := geom.NewMultiPolygon(subPolys)
+		if err := mp.Validate(); err != nil {
+			return geom.Geometry{}, err
+		}
+		return mp.AsGeometry(), nil
 	case "GeometryCollection":
 		n := C.GEOSGetNumGeometries_r(h.context, gh)
 		if n == -1 {

--- a/internal/perf/linestring_issimple_test.go
+++ b/internal/perf/linestring_issimple_test.go
@@ -32,8 +32,8 @@ func BenchmarkLineStringIsSimpleZigZag(b *testing.B) {
 				floats[2*i+1] = float64(i) * 0.01
 			}
 			seq := geom.NewSequence(floats, geom.DimXY)
-			ls, err := geom.NewLineString(seq)
-			if err != nil {
+			ls := geom.NewLineString(seq)
+			if err := ls.Validate(); err != nil {
 				b.Fatal(err)
 			}
 

--- a/internal/perf/util.go
+++ b/internal/perf/util.go
@@ -20,13 +20,6 @@ func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	}
 	coords[2*sides+0] = coords[0]
 	coords[2*sides+1] = coords[1]
-	ring, err := geom.NewLineString(geom.NewSequence(coords, geom.DimXY), geom.DisableAllValidations)
-	if err != nil {
-		panic(err)
-	}
-	poly, err := geom.NewPolygon([]geom.LineString{ring}, geom.DisableAllValidations)
-	if err != nil {
-		panic(err)
-	}
-	return poly
+	ring := geom.NewLineString(geom.NewSequence(coords, geom.DimXY))
+	return geom.NewPolygon([]geom.LineString{ring})
 }


### PR DESCRIPTION
## Description

Modify direct constructors (`NewPoint` etc.) to no longer perform validation at all. The direct constructors are for more advanced use cases where geometries are being constructed from other geometries or raw sequences of floats. Things like custom geometric algorithms come to mind. Because these are for advanced use cases, making users validate manually is reasonable.

Modifying direct constructors removes error handling mismatch, with users no longer having to handle errors that can never occur (when validation is disabled). It also eliminates the situation where constructor options would sometimes be ignored, and simplifies the rules around what validation occurs during direct construction (i.e. now none is performed).

See https://github.com/peterstace/simplefeatures/discussions/525 for more context.


## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) No. This will be done when all constructor option changes are complete.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/504

## Benchmark Results

- Please paste benchmark results here. The benchmarks can be run using the
  `run_benchmarks.sh` script.

<details>

<summary>Click to expand</summary>

```
PASTE BENCHMARKS HERE
```

</details>