### PR TITLE
Remove unchecked point constructors

### DIFF
--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -17,7 +17,7 @@ func convexHull(g Geometry) Geometry {
 
 	// Check for point case:
 	if !hasAtLeast2DistinctPointsInXYs(pts) {
-		return pts[0].asPoint().AsGeometry()
+		return pts[0].AsPoint().AsGeometry()
 	}
 
 	hull := monotoneChain(pts)

--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -17,7 +17,7 @@ func convexHull(g Geometry) Geometry {
 
 	// Check for point case:
 	if !hasAtLeast2DistinctPointsInXYs(pts) {
-		return pts[0].asUncheckedPoint().AsGeometry()
+		return pts[0].asPoint().AsGeometry()
 	}
 
 	hull := monotoneChain(pts)

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -17,7 +17,7 @@ func intersectionOfIndexedLines(
 			}
 			if inter.ptA == inter.ptB {
 				if xy := inter.ptA; !seen[xy] {
-					pt := xy.asUncheckedPoint()
+					pt := xy.asPoint()
 					pts = append(pts, pt)
 					seen[xy] = true
 				}

--- a/geom/alg_intersection.go
+++ b/geom/alg_intersection.go
@@ -17,7 +17,7 @@ func intersectionOfIndexedLines(
 			}
 			if inter.ptA == inter.ptB {
 				if xy := inter.ptA; !seen[xy] {
-					pt := xy.asPoint()
+					pt := xy.AsPoint()
 					pts = append(pts, pt)
 					seen[xy] = true
 				}

--- a/geom/alg_linear_interpolation.go
+++ b/geom/alg_linear_interpolation.go
@@ -29,7 +29,7 @@ func (l linearInterpolator) interpolate(frac float64) Point {
 	frac = math.Max(0, math.Min(1, frac))
 	idx := sort.SearchFloat64s(l.cumulative, frac*l.total)
 	if idx == l.seq.Length() {
-		return l.seq.Get(idx - 1).asUncheckedPoint()
+		return l.seq.Get(idx - 1).asPoint()
 	}
 
 	p0 := l.seq.Get(idx)
@@ -49,7 +49,7 @@ func (l linearInterpolator) interpolate(frac float64) Point {
 		Z:    lerp(p0.Z, p1.Z, partial),
 		M:    lerp(p0.M, p1.M, partial),
 		Type: l.seq.CoordinatesType(),
-	}.asUncheckedPoint()
+	}.asPoint()
 }
 
 func lerp(a, b, ratio float64) float64 {

--- a/geom/alg_linear_interpolation.go
+++ b/geom/alg_linear_interpolation.go
@@ -29,7 +29,7 @@ func (l linearInterpolator) interpolate(frac float64) Point {
 	frac = math.Max(0, math.Min(1, frac))
 	idx := sort.SearchFloat64s(l.cumulative, frac*l.total)
 	if idx == l.seq.Length() {
-		return l.seq.Get(idx - 1).asPoint()
+		return l.seq.Get(idx - 1).AsPoint()
 	}
 
 	p0 := l.seq.Get(idx)
@@ -49,7 +49,7 @@ func (l linearInterpolator) interpolate(frac float64) Point {
 		Z:    lerp(p0.Z, p1.Z, partial),
 		M:    lerp(p0.M, p1.M, partial),
 		Type: l.seq.CoordinatesType(),
-	}.asPoint()
+	}.AsPoint()
 }
 
 func lerp(a, b, ratio float64) float64 {

--- a/geom/alg_point_on_surface.go
+++ b/geom/alg_point_on_surface.go
@@ -133,7 +133,7 @@ func pointOnAreaSurface(poly Polygon) (Point, float64) {
 	}
 	midX := (bestA + bestB) / 2
 
-	return XY{midX, midY}.asPoint(), bestB - bestA
+	return XY{midX, midY}.AsPoint(), bestB - bestA
 }
 
 func sortAndUniquifyFloats(fs []float64) []float64 {

--- a/geom/alg_point_on_surface.go
+++ b/geom/alg_point_on_surface.go
@@ -133,7 +133,7 @@ func pointOnAreaSurface(poly Polygon) (Point, float64) {
 	}
 	midX := (bestA + bestB) / 2
 
-	return XY{midX, midY}.asUncheckedPoint(), bestB - bestA
+	return XY{midX, midY}.asPoint(), bestB - bestA
 }
 
 func sortAndUniquifyFloats(fs []float64) []float64 {

--- a/geom/dcel_extract_geometry.go
+++ b/geom/dcel_extract_geometry.go
@@ -284,11 +284,7 @@ func (d *doublyConnectedEdgeList) extractPoints(include func([2]bool) bool) ([]P
 
 	pts := make([]Point, 0, len(xys))
 	for _, xy := range xys {
-		pt, err := xy.AsPoint()
-		if err != nil {
-			return nil, err
-		}
-		pts = append(pts, pt)
+		pts = append(pts, xy.AsPoint())
 	}
 	return pts, nil
 }

--- a/geom/dcel_interaction_points_test.go
+++ b/geom/dcel_interaction_points_test.go
@@ -153,7 +153,7 @@ func TestFindInteractionPoints(t *testing.T) {
 			gotXYs := findInteractionPoints(inputs)
 			var gotPoints []Point
 			for xy := range gotXYs {
-				gotPoints = append(gotPoints, xy.asUncheckedPoint())
+				gotPoints = append(gotPoints, xy.asPoint())
 			}
 			got := NewMultiPoint(gotPoints).AsGeometry()
 

--- a/geom/dcel_interaction_points_test.go
+++ b/geom/dcel_interaction_points_test.go
@@ -153,7 +153,7 @@ func TestFindInteractionPoints(t *testing.T) {
 			gotXYs := findInteractionPoints(inputs)
 			var gotPoints []Point
 			for xy := range gotXYs {
-				gotPoints = append(gotPoints, xy.asPoint())
+				gotPoints = append(gotPoints, xy.AsPoint())
 			}
 			got := NewMultiPoint(gotPoints).AsGeometry()
 

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -90,11 +90,9 @@ func BenchmarkIntersectsMultiPointWithMultiPoint(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
 			var pointsA, pointsB []Point
 			for i := 0; i < sz; i++ {
-				ptA, err := XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
-				expectNoErr(b, err)
+				ptA := XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
 				pointsA = append(pointsA, ptA)
-				ptB, err := XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
-				expectNoErr(b, err)
+				ptB := XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
 				pointsB = append(pointsB, ptB)
 			}
 			mpA := NewMultiPoint(pointsA).AsGeometry()

--- a/geom/twkb_parser.go
+++ b/geom/twkb_parser.go
@@ -343,8 +343,8 @@ func (p *twkbParser) parseBBoxHeader(twkb []byte) (bbox []Point, err error) {
 		maxZ := p.scalings[2] * float64(p.bbox[4]+p.bbox[5])
 		maxM := p.scalings[3] * float64(p.bbox[6]+p.bbox[7])
 
-		minPt := newUncheckedPoint(Coordinates{XY: XY{minX, minY}, Z: minZ, M: minM, Type: p.ctype})
-		maxPt := newUncheckedPoint(Coordinates{XY: XY{maxX, maxY}, Z: maxZ, M: maxM, Type: p.ctype})
+		minPt := NewPoint(Coordinates{XY: XY{minX, minY}, Z: minZ, M: minM, Type: p.ctype})
+		maxPt := NewPoint(Coordinates{XY: XY{maxX, maxY}, Z: maxZ, M: maxM, Type: p.ctype})
 		bbox = []Point{minPt, maxPt}
 
 	} else if p.hasZ {
@@ -356,8 +356,8 @@ func (p *twkbParser) parseBBoxHeader(twkb []byte) (bbox []Point, err error) {
 		maxY := p.scalings[1] * float64(p.bbox[2]+p.bbox[3])
 		maxZ := p.scalings[2] * float64(p.bbox[4]+p.bbox[5])
 
-		minPt := newUncheckedPoint(Coordinates{XY: XY{minX, minY}, Z: minZ, Type: p.ctype})
-		maxPt := newUncheckedPoint(Coordinates{XY: XY{maxX, maxY}, Z: maxZ, Type: p.ctype})
+		minPt := NewPoint(Coordinates{XY: XY{minX, minY}, Z: minZ, Type: p.ctype})
+		maxPt := NewPoint(Coordinates{XY: XY{maxX, maxY}, Z: maxZ, Type: p.ctype})
 		bbox = []Point{minPt, maxPt}
 
 	} else if p.hasM {
@@ -369,8 +369,8 @@ func (p *twkbParser) parseBBoxHeader(twkb []byte) (bbox []Point, err error) {
 		maxY := p.scalings[1] * float64(p.bbox[2]+p.bbox[3])
 		maxM := p.scalings[2] * float64(p.bbox[4]+p.bbox[5])
 
-		minPt := newUncheckedPoint(Coordinates{XY: XY{minX, minY}, M: minM, Type: p.ctype})
-		maxPt := newUncheckedPoint(Coordinates{XY: XY{maxX, maxY}, M: maxM, Type: p.ctype})
+		minPt := NewPoint(Coordinates{XY: XY{minX, minY}, M: minM, Type: p.ctype})
+		maxPt := NewPoint(Coordinates{XY: XY{maxX, maxY}, M: maxM, Type: p.ctype})
 		bbox = []Point{minPt, maxPt}
 
 	} else {
@@ -380,8 +380,8 @@ func (p *twkbParser) parseBBoxHeader(twkb []byte) (bbox []Point, err error) {
 		maxX := p.scalings[0] * float64(p.bbox[0]+p.bbox[1])
 		maxY := p.scalings[1] * float64(p.bbox[2]+p.bbox[3])
 
-		minPt := newUncheckedPoint(Coordinates{XY: XY{minX, minY}, Type: p.ctype})
-		maxPt := newUncheckedPoint(Coordinates{XY: XY{maxX, maxY}, Type: p.ctype})
+		minPt := NewPoint(Coordinates{XY: XY{minX, minY}, Type: p.ctype})
+		maxPt := NewPoint(Coordinates{XY: XY{maxX, maxY}, Type: p.ctype})
 		bbox = []Point{minPt, maxPt}
 	}
 	return bbox, nil

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -63,8 +63,8 @@ func (c Coordinates) appendFloat64s(dst []float64) []float64 {
 	}
 }
 
-// asUncheckedPoint shadows the asUncheckedPoint method on XY so that it's not
-// accidentally called.
-func (c Coordinates) asUncheckedPoint() Point {
-	return newUncheckedPoint(c)
+// asPoint shadows the asPoint method on XY so that it's not accidentally
+// called.
+func (c Coordinates) asPoint() Point {
+	return NewPoint(c)
 }

--- a/geom/type_coordinates.go
+++ b/geom/type_coordinates.go
@@ -63,8 +63,11 @@ func (c Coordinates) appendFloat64s(dst []float64) []float64 {
 	}
 }
 
-// asPoint shadows the asPoint method on XY so that it's not accidentally
-// called.
-func (c Coordinates) asPoint() Point {
+// AsPoint is a convenience function to convert this Coordinates value into a Point geometry.
+func (c Coordinates) AsPoint() Point {
+	// NOTE: this function is not very useful on its own. Its main purpose is
+	// to shadow the AsPoint method on XY. If it were not shadowed, a user
+	// could accidentally call AsPoint on a coordinates value (since XY is
+	// field embedded), which would result in a Point with just XY populated.
 	return NewPoint(c)
 }

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -109,7 +109,7 @@ func (e Envelope) AsGeometry() Geometry {
 	case e.IsEmpty():
 		return Geometry{}
 	case e.IsPoint():
-		return e.min().asUncheckedPoint().AsGeometry()
+		return e.min().asPoint().AsGeometry()
 	case e.IsLine():
 		ln := line{e.min(), e.max()}
 		return ln.asLineString().AsGeometry()
@@ -134,7 +134,7 @@ func (e Envelope) Min() Point {
 	if e.IsEmpty() {
 		return Point{}
 	}
-	return e.min().asUncheckedPoint()
+	return e.min().asPoint()
 }
 
 // Max returns the point in the envelope with the maximum X and Y values.
@@ -142,7 +142,7 @@ func (e Envelope) Max() Point {
 	if e.IsEmpty() {
 		return Point{}
 	}
-	return e.max().asUncheckedPoint()
+	return e.max().asPoint()
 }
 
 // MinMaxXYs returns the two XY values in the envelope that contain the minimum
@@ -220,7 +220,7 @@ func (e Envelope) Center() Point {
 	return e.min().
 		Add(e.max()).
 		Scale(0.5).
-		asUncheckedPoint()
+		asPoint()
 }
 
 // Covers returns true if and only if this envelope entirely covers another
@@ -302,7 +302,7 @@ func (e Envelope) BoundingDiagonal() Geometry {
 		return Geometry{}
 	}
 	if e.IsPoint() {
-		return e.min().asUncheckedPoint().AsGeometry()
+		return e.min().asPoint().AsGeometry()
 	}
 
 	coords := []float64{e.minX(), e.minY, e.maxX, e.maxY}

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -109,7 +109,7 @@ func (e Envelope) AsGeometry() Geometry {
 	case e.IsEmpty():
 		return Geometry{}
 	case e.IsPoint():
-		return e.min().asPoint().AsGeometry()
+		return e.min().AsPoint().AsGeometry()
 	case e.IsLine():
 		ln := line{e.min(), e.max()}
 		return ln.asLineString().AsGeometry()
@@ -134,7 +134,7 @@ func (e Envelope) Min() Point {
 	if e.IsEmpty() {
 		return Point{}
 	}
-	return e.min().asPoint()
+	return e.min().AsPoint()
 }
 
 // Max returns the point in the envelope with the maximum X and Y values.
@@ -142,7 +142,7 @@ func (e Envelope) Max() Point {
 	if e.IsEmpty() {
 		return Point{}
 	}
-	return e.max().asPoint()
+	return e.max().AsPoint()
 }
 
 // MinMaxXYs returns the two XY values in the envelope that contain the minimum
@@ -220,7 +220,7 @@ func (e Envelope) Center() Point {
 	return e.min().
 		Add(e.max()).
 		Scale(0.5).
-		asPoint()
+		AsPoint()
 }
 
 // Covers returns true if and only if this envelope entirely covers another
@@ -302,7 +302,7 @@ func (e Envelope) BoundingDiagonal() Geometry {
 		return Geometry{}
 	}
 	if e.IsPoint() {
-		return e.min().asPoint().AsGeometry()
+		return e.min().AsPoint().AsGeometry()
 	}
 
 	coords := []float64{e.minX(), e.minY, e.maxX, e.maxY}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -336,7 +336,7 @@ func (c GeometryCollection) pointCentroid() Point {
 			}
 		}
 	})
-	return sumPoints.Scale(1 / float64(numPoints)).asPoint()
+	return sumPoints.Scale(1 / float64(numPoints)).AsPoint()
 }
 
 func (c GeometryCollection) linearCentroid() Point {
@@ -367,7 +367,7 @@ func (c GeometryCollection) linearCentroid() Point {
 			}
 		}
 	})
-	return weightedCentroid.Scale(1 / lengthSum).asPoint()
+	return weightedCentroid.Scale(1 / lengthSum).AsPoint()
 }
 
 func (c GeometryCollection) arealCentroid() Point {
@@ -390,7 +390,7 @@ func (c GeometryCollection) arealCentroid() Point {
 				centroid.Scale(area / areaSum))
 		}
 	})
-	return weightedCentroid.asPoint()
+	return weightedCentroid.AsPoint()
 }
 
 // CoordinatesType returns the CoordinatesType used to represent points making

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -336,7 +336,7 @@ func (c GeometryCollection) pointCentroid() Point {
 			}
 		}
 	})
-	return sumPoints.Scale(1 / float64(numPoints)).asUncheckedPoint()
+	return sumPoints.Scale(1 / float64(numPoints)).asPoint()
 }
 
 func (c GeometryCollection) linearCentroid() Point {
@@ -367,7 +367,7 @@ func (c GeometryCollection) linearCentroid() Point {
 			}
 		}
 	})
-	return weightedCentroid.Scale(1 / lengthSum).asUncheckedPoint()
+	return weightedCentroid.Scale(1 / lengthSum).asPoint()
 }
 
 func (c GeometryCollection) arealCentroid() Point {
@@ -390,7 +390,7 @@ func (c GeometryCollection) arealCentroid() Point {
 				centroid.Scale(area / areaSum))
 		}
 	})
-	return weightedCentroid.asUncheckedPoint()
+	return weightedCentroid.asPoint()
 }
 
 // CoordinatesType returns the CoordinatesType used to represent points making

--- a/geom/type_geometry_test.go
+++ b/geom/type_geometry_test.go
@@ -24,8 +24,7 @@ func TestZeroGeometry(t *testing.T) {
 	expectNoErr(t, err)
 	expectStringEq(t, strings.TrimSpace(buf.String()), `{"type":"GeometryCollection","geometries":[]}`)
 
-	pt, err := XY{1, 2}.AsPoint()
-	expectNoErr(t, err)
+	pt := XY{1, 2}.AsPoint()
 	z = pt.AsGeometry() // Set away from zero value
 	expectBoolEq(t, z.IsPoint(), true)
 	err = json.NewDecoder(&buf).Decode(&z)

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -73,7 +73,7 @@ func (s LineString) StartPoint() Point {
 		return NewEmptyPoint(s.CoordinatesType())
 	}
 	c := s.seq.Get(0)
-	return newUncheckedPoint(c)
+	return NewPoint(c)
 }
 
 // EndPoint gives the last point of the LineString. If the LineString is empty
@@ -84,7 +84,7 @@ func (s LineString) EndPoint() Point {
 	}
 	end := s.seq.Length() - 1
 	c := s.seq.Get(end)
-	return newUncheckedPoint(c)
+	return NewPoint(c)
 }
 
 // AsText returns the WKT (Well Known Text) representation of this geometry.
@@ -327,7 +327,7 @@ func (s LineString) Centroid() Point {
 	if sumLength == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return sumXY.Scale(1.0 / sumLength).asUncheckedPoint()
+	return sumXY.Scale(1.0 / sumLength).asPoint()
 }
 
 func sumCentroidAndLengthOfLineString(s LineString) (sumXY XY, sumLength float64) {
@@ -392,7 +392,7 @@ func (s LineString) PointOnSurface() Point {
 	n := s.seq.Length()
 	nearest := newNearestPointAccumulator(s.Centroid())
 	for i := 1; i < n-1; i++ {
-		candidate := s.seq.GetXY(i).asUncheckedPoint()
+		candidate := s.seq.GetXY(i).asPoint()
 		nearest.consider(candidate)
 	}
 	if !nearest.point.IsEmpty() {

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -327,7 +327,7 @@ func (s LineString) Centroid() Point {
 	if sumLength == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return sumXY.Scale(1.0 / sumLength).asPoint()
+	return sumXY.Scale(1.0 / sumLength).AsPoint()
 }
 
 func sumCentroidAndLengthOfLineString(s LineString) (sumXY XY, sumLength float64) {
@@ -392,7 +392,7 @@ func (s LineString) PointOnSurface() Point {
 	n := s.seq.Length()
 	nearest := newNearestPointAccumulator(s.Centroid())
 	for i := 1; i < n-1; i++ {
-		candidate := s.seq.GetXY(i).asPoint()
+		candidate := s.seq.GetXY(i).AsPoint()
 		nearest.consider(candidate)
 	}
 	if !nearest.point.IsEmpty() {

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -181,7 +181,7 @@ func (m MultiLineString) IsSimple() bool {
 					return rtree.Stop
 				}
 				boundary := intersectionOfMultiPointAndMultiPoint(ls.Boundary(), otherLS.Boundary())
-				if !hasIntersectionPointWithMultiPoint(inter.ptA.asUncheckedPoint(), boundary) {
+				if !hasIntersectionPointWithMultiPoint(inter.ptA.asPoint(), boundary) {
 					isSimple = false
 					return rtree.Stop
 				}
@@ -364,7 +364,7 @@ func (m MultiLineString) Centroid() Point {
 	if sumLength == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return sumXY.Scale(1.0 / sumLength).asUncheckedPoint()
+	return sumXY.Scale(1.0 / sumLength).asPoint()
 }
 
 // Reverse in the case of MultiLineString outputs each component line string in their
@@ -428,7 +428,7 @@ func (m MultiLineString) PointOnSurface() Point {
 		seq := m.LineStringN(i).Coordinates()
 		n := seq.Length()
 		for j := 1; j < n-1; j++ {
-			candidate := seq.GetXY(j).asUncheckedPoint()
+			candidate := seq.GetXY(j).asPoint()
 			nearest.consider(candidate)
 		}
 	}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -181,7 +181,7 @@ func (m MultiLineString) IsSimple() bool {
 					return rtree.Stop
 				}
 				boundary := intersectionOfMultiPointAndMultiPoint(ls.Boundary(), otherLS.Boundary())
-				if !hasIntersectionPointWithMultiPoint(inter.ptA.asPoint(), boundary) {
+				if !hasIntersectionPointWithMultiPoint(inter.ptA.AsPoint(), boundary) {
 					isSimple = false
 					return rtree.Stop
 				}
@@ -364,7 +364,7 @@ func (m MultiLineString) Centroid() Point {
 	if sumLength == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return sumXY.Scale(1.0 / sumLength).asPoint()
+	return sumXY.Scale(1.0 / sumLength).AsPoint()
 }
 
 // Reverse in the case of MultiLineString outputs each component line string in their
@@ -428,7 +428,7 @@ func (m MultiLineString) PointOnSurface() Point {
 		seq := m.LineStringN(i).Coordinates()
 		n := seq.Length()
 		for j := 1; j < n-1; j++ {
-			candidate := seq.GetXY(j).asPoint()
+			candidate := seq.GetXY(j).AsPoint()
 			nearest.consider(candidate)
 		}
 	}

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -246,7 +246,7 @@ func (m MultiPoint) Centroid() Point {
 	if n == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return sum.Scale(1 / float64(n)).asPoint()
+	return sum.Scale(1 / float64(n)).AsPoint()
 }
 
 // Reverse in the case of MultiPoint outputs each component point in their

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -246,7 +246,7 @@ func (m MultiPoint) Centroid() Point {
 	if n == 0 {
 		return NewEmptyPoint(DimXY)
 	}
-	return sum.Scale(1 / float64(n)).asUncheckedPoint()
+	return sum.Scale(1 / float64(n)).asPoint()
 }
 
 // Reverse in the case of MultiPoint outputs each component point in their

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -373,7 +373,7 @@ func (m MultiPolygon) Centroid() Point {
 			weightedCentroid = weightedCentroid.Add(centroid.Scale(areas[i] / totalArea))
 		}
 	}
-	return weightedCentroid.asPoint()
+	return weightedCentroid.AsPoint()
 }
 
 // Reverse in the case of MultiPolygon outputs the component polygons in their original order,

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -373,7 +373,7 @@ func (m MultiPolygon) Centroid() Point {
 			weightedCentroid = weightedCentroid.Add(centroid.Scale(areas[i] / totalArea))
 		}
 	}
-	return weightedCentroid.asUncheckedPoint()
+	return weightedCentroid.asPoint()
 }
 
 // Reverse in the case of MultiPolygon outputs the component polygons in their original order,

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -35,28 +35,6 @@ func (p Point) Validate() error {
 	return p.coords.XY.validate()
 }
 
-// newUncheckedPoint constructs a point without checking any validations. It
-// may be used internally when the caller is sure that the coordinates don't
-// come directly from outside the library, or have already otherwise been
-// validated.
-//
-// An examples of valid use:
-//
-// - The coordinates have just been validated.
-//
-// - The coordinates are taken directly from the control points of a geometry
-// that has been validated.
-//
-// - The coordinates are derived from calculations based on control points of a
-// geometry that has been validated. Technically, these calculations could
-// overflow to +/- inf. However if control points are originally close to
-// infinity, many of the algorithms will be already broken in many other ways.
-//
-// TODO: this is the same as NewPoint, so it should be removed.
-func newUncheckedPoint(c Coordinates) Point {
-	return Point{c, true}
-}
-
 // NewEmptyPoint creates a Point that is empty.
 func NewEmptyPoint(ctype CoordinatesType) Point {
 	return Point{Coordinates{Type: ctype}, false}
@@ -202,7 +180,7 @@ func (p Point) TransformXY(fn func(XY) XY) Point {
 	}
 	newC := p.coords
 	newC.XY = fn(newC.XY)
-	return newUncheckedPoint(newC)
+	return NewPoint(newC)
 }
 
 // Centroid of a point is that point.

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -442,7 +442,7 @@ func (p Polygon) Centroid() Point {
 		centroid = centroid.Add(
 			weightedCentroid(p.InteriorRingN(i), areas[i+1], sumAreas))
 	}
-	return centroid.asPoint()
+	return centroid.AsPoint()
 }
 
 func weightedCentroid(ring LineString, ringArea, totalArea float64) XY {

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -442,7 +442,7 @@ func (p Polygon) Centroid() Point {
 		centroid = centroid.Add(
 			weightedCentroid(p.InteriorRingN(i), areas[i+1], sumAreas))
 	}
-	return centroid.asUncheckedPoint()
+	return centroid.asPoint()
 }
 
 func weightedCentroid(ring LineString, ringArea, totalArea float64) XY {

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -36,16 +36,10 @@ func (w XY) AsPoint(opts ...ConstructorOption) (Point, error) {
 	return pt, nil
 }
 
-// asUncheckedPoint is a convenience function to convert this XY value into a
-// Point. The Point is constructed without checking any validations. It may be
-// used internally when the caller is sure that the XY value doesn't come
-// directly from outside of the library without first being validated.
-//
-// TODO: This method should be removed (caller can use AsPoint instead once its
-// ConstructorOptions and error are removed).
-func (w XY) asUncheckedPoint() Point {
+// asPoint is a convenience function to convert this XY value into a Point.
+func (w XY) asPoint() Point {
 	coords := Coordinates{XY: w, Type: DimXY}
-	return newUncheckedPoint(coords)
+	return NewPoint(coords)
 }
 
 // uncheckedEnvelope is a convenience function to convert this XY value into

--- a/geom/xy.go
+++ b/geom/xy.go
@@ -25,19 +25,7 @@ func (w XY) validate() error {
 
 // AsPoint is a convenience function to convert this XY value into a Point
 // geometry.
-//
-// TODO: This method shouldn't return an error or accept ConstructorOptions.
-func (w XY) AsPoint(opts ...ConstructorOption) (Point, error) {
-	coords := Coordinates{XY: w, Type: DimXY}
-	pt := NewPoint(coords)
-	if err := validate(opts, pt); err != nil {
-		return Point{}, err
-	}
-	return pt, nil
-}
-
-// asPoint is a convenience function to convert this XY value into a Point.
-func (w XY) asPoint() Point {
+func (w XY) AsPoint() Point {
 	coords := Coordinates{XY: w, Type: DimXY}
 	return NewPoint(coords)
 }

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -232,8 +232,8 @@ func checkAsBinary(h *Handle, g geom.Geometry, log *log.Logger) error {
 	if err == nil {
 		wantDefined = true
 	}
-	hasPointEmpty := hasEmptyPoint(g)
-	if !wantDefined && !hasPointEmpty {
+	hAsPointEmpty := hasEmptyPoint(g)
+	if !wantDefined && !hAsPointEmpty {
 		return errors.New("AsBinary wasn't defined by libgeos and the test is " +
 			"NOT for a geometry containing a POINT EMPTY, which is unexpected",
 		)

--- a/internal/cmprefimpl/cmpgeos/util_test.go
+++ b/internal/cmprefimpl/cmpgeos/util_test.go
@@ -25,10 +25,7 @@ func TestMantissaTerminatesQuickly(t *testing.T) {
 		{math.Pi, false},
 	} {
 		t.Run(fmt.Sprintf("%v", tt.f), func(t *testing.T) {
-			pt, err := geom.XY{X: tt.f, Y: tt.f}.AsPoint()
-			if err != nil {
-				t.Fatal(err)
-			}
+			pt := geom.XY{X: tt.f, Y: tt.f}.AsPoint()
 			got := mantissaTerminatesQuickly(pt.AsGeometry())
 			if got != tt.want {
 				t.Errorf("got=%v want=%v", got, tt.want)


### PR DESCRIPTION
## Description

- Remove the constructor options and error returns from the `AsPoint` constructor method on `XY`.

- Adds an `AsPoint` constructor method to `Coordinates` (to shadow the method on `XY`).

- Removes the `asUncheckedPoint` constructor helper methods.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- Part of https://github.com/peterstace/simplefeatures/issues/504