### PR TITLE
Fix bug in Envelope's TransformXY method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: cmpgeos
       run: make cmpgeos
     - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.6
+      uses: jandelgado/gcov2lcov-action@v1.0.9
       with:
         infile: coverage.out
         outfile: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: cmpgeos
       run: make cmpgeos
     - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.2
+      uses: jandelgado/gcov2lcov-action@v1.0.6
       with:
         infile: coverage.out
         outfile: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ jobs:
       run: make lint
     - name: unit
       run: make unit
-    - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.9
-      with:
-        infile: coverage.out
-        outfile: coverage.lcov
     - name: geos
       run: make geos
     - name: pgscan
@@ -23,6 +18,11 @@ jobs:
       run: make cmppg
     - name: cmpgeos
       run: make cmpgeos
+    - name: Convert coverage to lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.9
+      with:
+        infile: coverage.out
+        outfile: coverage.lcov
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
       run: make lint
     - name: unit
       run: make unit
+    - name: Convert coverage to lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.9
+      with:
+        infile: coverage.out
+        outfile: coverage.lcov
     - name: geos
       run: make geos
     - name: pgscan
@@ -18,11 +23,6 @@ jobs:
       run: make cmppg
     - name: cmpgeos
       run: make cmpgeos
-    - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.9
-      with:
-        infile: coverage.out
-        outfile: coverage.lcov
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.45.1
+
+2023-09-29
+
+- Fixes a bug in `Envelope`'s `TransformXY` method, where (depending on the
+  transform) invariants in the newly created `Envelope` value would be
+  violated.
+
 ## v0.45.0
 
 2023-09-29

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -279,7 +279,12 @@ func (e Envelope) TransformXY(fn func(XY) XY) Envelope {
 	if !ok {
 		return Envelope{}
 	}
-	return newUncheckedEnvelope(fn(min), fn(max))
+	u := fn(min)
+	v := fn(max)
+	return newUncheckedEnvelope(
+		XY{fastMin(u.X, v.X), fastMin(u.Y, v.Y)},
+		XY{fastMax(u.X, v.X), fastMax(u.Y, v.Y)},
+	)
 }
 
 // AsBox converts this Envelope to an rtree.Box.

--- a/geom/type_envelope_test.go
+++ b/geom/type_envelope_test.go
@@ -572,6 +572,16 @@ func TestEnvelopeTransformXY(t *testing.T) {
 	}
 }
 
+func TestEnvelopeTransformBugFix(t *testing.T) {
+	// Reproduces a bug where a transform that alters which coordinates are min
+	// and max causes a malformed envelope.
+	env := twoPtEnv(1, 2, 3, 4)
+	got := env.TransformXY(func(in XY) XY {
+		return XY{-in.X, -in.Y}
+	})
+	expectEnvEq(t, got, twoPtEnv(-3, -4, -1, -2))
+}
+
 func BenchmarkEnvelopeTransformXY(b *testing.B) {
 	input := twoPtEnv(1, 2, 3, 4)
 	b.ResetTimer()

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -209,11 +209,7 @@ func expectEnvEq(t testing.TB, got, want Envelope) {
 		ExactEquals(got.Max().AsGeometry(), want.Max().AsGeometry()) {
 		return
 	}
-	t.Errorf(
-		"\ngot:  %v\nwant: %v\n",
-		got.AsGeometry().AsText(),
-		want.AsGeometry().AsText(),
-	)
+	t.Errorf("\ngot:  %v\nwant: %v", got, want)
 }
 
 func expectSequenceEq(t testing.TB, got, want Sequence) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/peterstace/simplefeatures
 
 go 1.17
 
+retract v0.45.0 // Due to bug: https://github.com/peterstace/simplefeatures/pull/554
+
 require github.com/lib/pq v1.1.1


### PR DESCRIPTION
## Description

The bug occurs when the transform function doesn't preserve the property that the envelopes min and max points remain the min and max points after the transformation. There is no expectation that this transform will preserve this property (e.g. WGS84 to WebMercator doesn't preserve the ordering due to the inverted Y-axis of WebMercator pixel space).

The fix is to reorder the min/max before constructing the new envelope.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A