### PR TITLE
Add `Envelope` method to `Sequence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 YYYY-MM-DD
 
-- Adds an method with signature `Envelope() Envelope` to type `Sequence`.
+- Adds a method with signature `Envelope() Envelope` to type `Sequence`.
 
 ## v0.45.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+YYYY-MM-DD
+
+- Adds an method with signature `Envelope() Envelope` to type `Sequence`.
+
 ## v0.45.1
 
 2023-09-29

--- a/geom/type_sequence.go
+++ b/geom/type_sequence.go
@@ -186,6 +186,29 @@ func (s Sequence) less(o Sequence) bool {
 	return false
 }
 
+// Envelope returns the axis aligned bounding box that most tightly surrounds
+// the XY values in the sequence.
+func (s Sequence) Envelope() Envelope {
+	n := s.Length()
+	if n == 0 {
+		return Envelope{}
+	}
+
+	xy0 := s.GetXY(0)
+	min, max := xy0, xy0
+
+	stride := s.ctype.Dimension()
+	for i := stride; i < len(s.floats); i += stride {
+		x := s.floats[i]
+		y := s.floats[i+1]
+		min.X = fastMin(min.X, x)
+		min.Y = fastMin(min.Y, y)
+		max.X = fastMax(max.X, x)
+		max.Y = fastMax(max.Y, y)
+	}
+	return newUncheckedEnvelope(min, max)
+}
+
 // getLine extracts a 2D line segment from a sequence by joining together
 // adjacent locations in the sequence. It is designed to be called with i equal
 // to each index in the sequence (from 0 to n-1, both inclusive). The flag


### PR DESCRIPTION
## Description

The motivation behind this change is to allow Envelopes for linear and areal types to be calculated more efficiently. Rather than expanding an envelope XY by XY, an Envelope can be calculated directly from a sequence. This change will be made in a separate PR.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?)

## Related Issue

- N/A