### PR TITLE
Optimise `LineString` `Envelope` method

### DIFF
--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -213,12 +213,7 @@ func (s LineString) IsEmpty() bool {
 
 // Envelope returns the Envelope that most tightly surrounds the geometry.
 func (s LineString) Envelope() Envelope {
-	var env Envelope
-	n := s.seq.Length()
-	for i := 0; i < n; i++ {
-		env = env.uncheckedExtend(s.seq.GetXY(i))
-	}
-	return env
+	return s.seq.Envelope()
 }
 
 // Boundary returns the spatial boundary of this LineString. For closed


### PR DESCRIPTION
## Description

Optimises `LineString`'s `Envelope` method by using the `Sequence`'s `Envelope`
method instead of iterating over the sequence and extending the envelope point
by point.

## Check List

Have you:

- Added unit tests? Uses existing.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A, not really a user-facing change.

## Related Issue

- N/A

## Benchmark Results

NOTE: results are measured between this branch and the commit of master before https://github.com/peterstace/simplefeatures/pull/556 was merged.

Results show small improvements for operations involving envelopes (which is great, since all I was after was to eliminate the regressions caused by #556).

[results_0.1s.txt](https://github.com/peterstace/simplefeatures/files/12807400/results_0.1s.txt)
