### PR TITLE
Separate `Envelope` validation from construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ YYYY-MM-DD
 
 - Simplifies the internal representation of the `Envelope` type.
 
+- **Breaking change**: Renames `Envelope`'s `ExtendToIncludeXY` method to
+  `ExpandToIncludeXY`. This makes the names of the `ExpandToIncludeXY` and
+  `ExpandToIncludeEnvelope` methods have consistent naming.
+
+- **Breaking change**: Alters the signature (and behaviour) of the
+  `NewEnvelope` function. It previously returned an `Envelope` and an `error`,
+  and new just returns an `Envelope`. It no longer validates that its inputs
+  don't contain NaN or +/- infinity (this can be checked via the `Validate`
+  method if desired). It also now accepts a variadic list of `XY` values,
+  rather than a slice of `XY` values.
+
 ## v0.45.1
 
 2023-09-29

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -226,19 +226,19 @@ func hasIntersectionBetweenLines(
 
 			if !populateExtension {
 				env = inter.ptA.uncheckedEnvelope()
-				env = env.uncheckedExtend(inter.ptB)
+				env = env.ExpandToIncludeXY(inter.ptB)
 				return rtree.Stop
 			}
 
 			if inter.ptA != inter.ptB {
 				env = inter.ptA.uncheckedEnvelope()
-				env = env.uncheckedExtend(inter.ptB)
+				env = env.ExpandToIncludeXY(inter.ptB)
 				return rtree.Stop
 			}
 
 			// Single point intersection case from here onwards:
 
-			env = env.uncheckedExtend(inter.ptA)
+			env = env.ExpandToIncludeXY(inter.ptA)
 			if !env.IsPoint() {
 				return rtree.Stop
 			}

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -167,8 +167,7 @@ func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
 func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
-			outerRingEnv, err := NewEnvelope([]XY{{}, {7, float64(sz + 1)}})
-			expectNoErr(b, err)
+			outerRingEnv := NewEnvelope(XY{}, XY{7, float64(sz + 1)})
 			outerRing := outerRingEnv.AsGeometry().MustAsPolygon().ExteriorRing()
 			var leftFloats, rightFloats []float64
 			for i := 0; i < sz; i++ {

--- a/geom/twkb_parser.go
+++ b/geom/twkb_parser.go
@@ -95,16 +95,16 @@ func UnmarshalTWKBEnvelope(twkb []byte) (Envelope, error) {
 	if !p.hasBBox {
 		return Envelope{}, nil
 	}
-	return NewEnvelope([]XY{
-		{
+	return NewEnvelope(
+		XY{
 			p.scalings[0] * float64(p.bbox[0]),
 			p.scalings[1] * float64(p.bbox[2]),
 		},
-		{
+		XY{
 			p.scalings[0] * float64(p.bbox[0]+p.bbox[1]),
 			p.scalings[1] * float64(p.bbox[2]+p.bbox[3]),
 		},
-	})
+	), nil
 }
 
 // twkbParser holds all state information for interpreting TWKB buffers

--- a/geom/type_envelope.go
+++ b/geom/type_envelope.go
@@ -136,7 +136,7 @@ func (e Envelope) MinMaxXYs() (XY, XY, bool) {
 }
 
 // ExpandToIncludeXY returns the smallest envelope that contains all of the
-// points in this envelope along with the provided point. If will produce an
+// points in this envelope along with the provided point. It will produce an
 // invalid envelope if any of the coordinates in the existing envelope or new
 // XY contain NaN or +/- infinity.
 func (e Envelope) ExpandToIncludeXY(xy XY) Envelope {

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -97,7 +97,7 @@ func (p Point) IsSimple() bool {
 // envelope, or an envelope covering a single point).
 func (p Point) Envelope() Envelope {
 	if xy, ok := p.XY(); ok {
-		return Envelope{}.uncheckedExtend(xy)
+		return Envelope{}.ExpandToIncludeXY(xy)
 	}
 	return Envelope{}
 }

--- a/internal/cmprefimpl/cmpgeos/handle.go
+++ b/internal/cmprefimpl/cmpgeos/handle.go
@@ -509,7 +509,11 @@ func (h *Handle) envelope(g geom.Geometry) (geom.Envelope, error) {
 		if C.GEOSGeomGetY_r(h.context, env, &y) == 0 {
 			return geom.Envelope{}, h.err()
 		}
-		return geom.NewEnvelope([]geom.XY{{X: float64(x), Y: float64(y)}})
+		env := geom.NewEnvelope(geom.XY{X: float64(x), Y: float64(y)})
+		if err := env.Validate(); err != nil {
+			return geom.Envelope{}, err
+		}
+		return env, nil
 	case "Polygon":
 		// Continues below
 	default:
@@ -549,12 +553,12 @@ func (h *Handle) envelope(g geom.Geometry) (geom.Envelope, error) {
 			return geom.Envelope{}, h.err()
 		}
 		xy := geom.XY{X: float64(x), Y: float64(y)}
-		sfEnv, err = sfEnv.ExtendToIncludeXY(xy)
-		if err != nil {
-			return geom.Envelope{}, err
-		}
+		sfEnv = sfEnv.ExpandToIncludeXY(xy)
 	}
 
+	if err := sfEnv.Validate(); err != nil {
+		return geom.Envelope{}, err
+	}
 	return sfEnv, nil
 }
 


### PR DESCRIPTION
## Description

This change moves Envelope validation out of constructors, and into a separate `Validate` method. This is similar to the recent changes for regular geometries.

It includes two further small breaking changes, so that all breaking changes are bundled together:

- The `ExtendToIncludeXY` method is renamed to `ExpandToIncludeXY` (to be consistent with `ExpandToIncludeEnvelope`).

- The `NewEnvelope` now accepts a variadic list of `XY` rather than a slice of `XY`. This is just a small ergonomic improvement.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A