### PR TITLE
Enable `unparam` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,6 +96,7 @@ linters:
     - thelper
     - tparallel
     - unconvert
+    - unparam
     - unused
     - usestdlibvars
     - wastedassign
@@ -151,4 +152,3 @@ linters:
     - errorlint
     - revive
     - stylecheck
-    - unparam

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -62,11 +62,10 @@ func Intersects(g1, g2 Geometry) bool {
 				g1.MustAsLineString().AsMultiLineString(),
 			)
 		case g2.IsMultiLineString():
-			has, _ := hasIntersectionMultiLineStringWithMultiLineString(
+			return hasIntersectionMultiLineStringWithMultiLineString(
 				g1.MustAsLineString().AsMultiLineString(),
 				g2.MustAsMultiLineString(),
 			)
-			return has
 		case g2.IsMultiPolygon():
 			return hasIntersectionMultiLineStringWithMultiPolygon(
 				g1.MustAsLineString().AsMultiLineString(),
@@ -117,11 +116,10 @@ func Intersects(g1, g2 Geometry) bool {
 	case g1.IsMultiLineString():
 		switch {
 		case g2.IsMultiLineString():
-			has, _ := hasIntersectionMultiLineStringWithMultiLineString(
+			return hasIntersectionMultiLineStringWithMultiLineString(
 				g1.MustAsMultiLineString(),
 				g2.MustAsMultiLineString(),
 			)
-			return has
 		case g2.IsMultiPolygon():
 			return hasIntersectionMultiLineStringWithMultiPolygon(
 				g1.MustAsMultiLineString(),
@@ -180,14 +178,11 @@ func hasIntersectionLineStringWithLineString(
 	return hasIntersectionBetweenLines(lines1, lines2, populateExtension)
 }
 
-func hasIntersectionMultiLineStringWithMultiLineString(
-	mls1, mls2 MultiLineString,
-) (
-	bool, mlsWithMLSIntersectsExtension,
-) {
+func hasIntersectionMultiLineStringWithMultiLineString(mls1, mls2 MultiLineString) bool {
 	lines1 := mls1.asLines()
 	lines2 := mls2.asLines()
-	return hasIntersectionBetweenLines(lines1, lines2, true)
+	has, _ := hasIntersectionBetweenLines(lines1, lines2, false)
+	return has
 }
 
 func hasIntersectionBetweenLines(
@@ -258,7 +253,7 @@ func hasIntersectionBetweenLines(
 }
 
 func hasIntersectionMultiLineStringWithMultiPolygon(mls MultiLineString, mp MultiPolygon) bool {
-	if has, _ := hasIntersectionMultiLineStringWithMultiLineString(mls, mp.Boundary()); has {
+	if hasIntersectionMultiLineStringWithMultiLineString(mls, mp.Boundary()) {
 		return true
 	}
 
@@ -389,7 +384,7 @@ func hasIntersectionPolygonWithPolygon(p1, p2 Polygon) bool {
 	// intersect.
 	b1 := p1.Boundary()
 	b2 := p2.Boundary()
-	if has, _ := hasIntersectionMultiLineStringWithMultiLineString(b1, b2); has {
+	if hasIntersectionMultiLineStringWithMultiLineString(b1, b2) {
 		return true
 	}
 

--- a/geom/alg_intersects.go
+++ b/geom/alg_intersects.go
@@ -65,7 +65,6 @@ func Intersects(g1, g2 Geometry) bool {
 			has, _ := hasIntersectionMultiLineStringWithMultiLineString(
 				g1.MustAsLineString().AsMultiLineString(),
 				g2.MustAsMultiLineString(),
-				false,
 			)
 			return has
 		case g2.IsMultiPolygon():
@@ -121,7 +120,6 @@ func Intersects(g1, g2 Geometry) bool {
 			has, _ := hasIntersectionMultiLineStringWithMultiLineString(
 				g1.MustAsMultiLineString(),
 				g2.MustAsMultiLineString(),
-				false,
 			)
 			return has
 		case g2.IsMultiPolygon():
@@ -183,13 +181,13 @@ func hasIntersectionLineStringWithLineString(
 }
 
 func hasIntersectionMultiLineStringWithMultiLineString(
-	mls1, mls2 MultiLineString, populateExtension bool,
+	mls1, mls2 MultiLineString,
 ) (
 	bool, mlsWithMLSIntersectsExtension,
 ) {
 	lines1 := mls1.asLines()
 	lines2 := mls2.asLines()
-	return hasIntersectionBetweenLines(lines1, lines2, populateExtension)
+	return hasIntersectionBetweenLines(lines1, lines2, true)
 }
 
 func hasIntersectionBetweenLines(
@@ -260,7 +258,7 @@ func hasIntersectionBetweenLines(
 }
 
 func hasIntersectionMultiLineStringWithMultiPolygon(mls MultiLineString, mp MultiPolygon) bool {
-	if has, _ := hasIntersectionMultiLineStringWithMultiLineString(mls, mp.Boundary(), false); has {
+	if has, _ := hasIntersectionMultiLineStringWithMultiLineString(mls, mp.Boundary()); has {
 		return true
 	}
 
@@ -391,7 +389,7 @@ func hasIntersectionPolygonWithPolygon(p1, p2 Polygon) bool {
 	// intersect.
 	b1 := p1.Boundary()
 	b2 := p2.Boundary()
-	if has, _ := hasIntersectionMultiLineStringWithMultiLineString(b1, b2, false); has {
+	if has, _ := hasIntersectionMultiLineStringWithMultiLineString(b1, b2); has {
 		return true
 	}
 

--- a/geom/alg_relate.go
+++ b/geom/alg_relate.go
@@ -21,6 +21,7 @@ package geom
 // The matrix is represented by a 9 character string, with entries in row-major
 // order (i.e. entries are ordered II, IB, IE, BI, BB, BE, EI, EB, EE).
 func Relate(a, b Geometry) (string, error) {
+	// TODO: don't need to return an error from this function
 	if a.IsEmpty() || b.IsEmpty() {
 		im := newMatrix()
 		im.set(imExterior, imExterior, '2')

--- a/geom/alg_relate.go
+++ b/geom/alg_relate.go
@@ -53,10 +53,7 @@ func Relate(a, b Geometry) (string, error) {
 		return im.code(), nil
 	}
 
-	overlay, err := newDCELFromGeometries(a, b)
-	if err != nil {
-		return "", wrap(err, "internal error creating overlay")
-	}
+	overlay := newDCELFromGeometries(a, b)
 	im := overlay.extractIntersectionMatrix()
 	return im.code(), nil
 }

--- a/geom/alg_set_op.go
+++ b/geom/alg_set_op.go
@@ -72,11 +72,7 @@ func UnionMany(gs []Geometry) (Geometry, error) {
 }
 
 func setOp(a Geometry, include func([2]bool) bool, b Geometry) (Geometry, error) {
-	overlay, err := newDCELFromGeometries(a, b)
-	if err != nil {
-		return Geometry{}, wrap(err, "internal error creating overlay")
-	}
-
+	overlay := newDCELFromGeometries(a, b)
 	g, err := overlay.extractGeometry(include)
 	if err != nil {
 		return Geometry{}, wrap(err, "internal error extracting geometry")

--- a/geom/dcel.go
+++ b/geom/dcel.go
@@ -1,6 +1,6 @@
 package geom
 
-func newDCELFromGeometries(a, b Geometry) (*doublyConnectedEdgeList, error) {
+func newDCELFromGeometries(a, b Geometry) *doublyConnectedEdgeList {
 	ghosts := createGhosts(a, b)
 	a, b, ghosts = reNodeGeometries(a, b, ghosts)
 
@@ -16,7 +16,7 @@ func newDCELFromGeometries(a, b Geometry) (*doublyConnectedEdgeList, error) {
 	dcel.assignFaces()
 	dcel.populateInSetLabels()
 
-	return dcel, nil
+	return dcel
 }
 
 func newDCEL() *doublyConnectedEdgeList {

--- a/geom/dcel_extract_geometry.go
+++ b/geom/dcel_extract_geometry.go
@@ -11,14 +11,8 @@ func (d *doublyConnectedEdgeList) extractGeometry(include func([2]bool) bool) (G
 	if err != nil {
 		return Geometry{}, err
 	}
-	linears, err := d.extractLineStrings(include)
-	if err != nil {
-		return Geometry{}, err
-	}
-	points, err := d.extractPoints(include)
-	if err != nil {
-		return Geometry{}, err
-	}
+	linears := d.extractLineStrings(include)
+	points := d.extractPoints(include)
 
 	switch {
 	case len(areals) > 0 && len(linears) == 0 && len(points) == 0:
@@ -236,7 +230,7 @@ func orderPolygonRings(rings []LineString) {
 	})
 }
 
-func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]bool) bool) ([]LineString, error) {
+func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]bool) bool) []LineString {
 	var lss []LineString
 	for _, e := range d.halfEdges {
 		if shouldExtractLine(e, include) {
@@ -256,7 +250,7 @@ func (d *doublyConnectedEdgeList) extractLineStrings(include func([2]bool) bool)
 		seqJ := lss[j].Coordinates()
 		return seqI.less(seqJ)
 	})
-	return lss, nil
+	return lss
 }
 
 func shouldExtractLine(e *halfEdgeRecord, include func([2]bool) bool) bool {
@@ -269,7 +263,7 @@ func shouldExtractLine(e *halfEdgeRecord, include func([2]bool) bool) bool {
 // extractPoints extracts any vertices in the DCEL that should be part of the
 // output geometry, but aren't yet represented as part of any previously
 // extracted geometries.
-func (d *doublyConnectedEdgeList) extractPoints(include func([2]bool) bool) ([]Point, error) {
+func (d *doublyConnectedEdgeList) extractPoints(include func([2]bool) bool) []Point {
 	xys := make([]XY, 0, len(d.vertices))
 	for _, vert := range d.vertices {
 		if include(vert.inSet) && !vert.extracted {
@@ -286,5 +280,5 @@ func (d *doublyConnectedEdgeList) extractPoints(include func([2]bool) bool) ([]P
 	for _, xy := range xys {
 		pts = append(pts, xy.AsPoint())
 	}
-	return pts, nil
+	return pts
 }

--- a/geom/dcel_internal_test.go
+++ b/geom/dcel_internal_test.go
@@ -309,11 +309,7 @@ func newDCELFromWKTs(t *testing.T, wktA, wktB string) *doublyConnectedEdgeList {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dcel, err := newDCELFromGeometries(gA, gB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dcel
+	return newDCELFromGeometries(gA, gB)
 }
 
 func newDCELFromWKT(t *testing.T, wkt string) *doublyConnectedEdgeList {

--- a/geom/twkb_parser.go
+++ b/geom/twkb_parser.go
@@ -72,7 +72,7 @@ func UnmarshalTWKBWithHeaders(twkb []byte, nv ...NoValidate) (g Geometry, bbox [
 // Any remaining geometry is not parsed by this function.
 func UnmarshalTWKBBoundingBoxHeader(twkb []byte) (bbox []Point, err error) {
 	p := newTWKBParser(twkb)
-	bbox, err = p.parseBBoxHeader(twkb)
+	bbox, err = p.parseBBoxHeader()
 	return bbox, p.annotateError(err)
 }
 
@@ -334,7 +334,7 @@ func (p *twkbParser) parseBBox() error {
 	return nil
 }
 
-func (p *twkbParser) parseBBoxHeader(twkb []byte) (bbox []Point, err error) {
+func (p *twkbParser) parseBBoxHeader() (bbox []Point, err error) {
 	if err = p.parseHeaders(); err != nil {
 		return nil, err
 	}

--- a/geom/twkb_write.go
+++ b/geom/twkb_write.go
@@ -261,13 +261,13 @@ func (w *twkbWriter) writePoint(pt Point) error {
 func (w *twkbWriter) writePointCoords(pt Point) {
 	switch pt.CoordinatesType() {
 	case DimXY:
-		w.writePoints(1, pt.coords.XY.X, pt.coords.XY.Y)
+		w.writeSinglePointArray(pt.coords.XY.X, pt.coords.XY.Y)
 	case DimXYZ:
-		w.writePoints(1, pt.coords.XY.X, pt.coords.XY.Y, pt.coords.Z)
+		w.writeSinglePointArray(pt.coords.XY.X, pt.coords.XY.Y, pt.coords.Z)
 	case DimXYM:
-		w.writePoints(1, pt.coords.XY.X, pt.coords.XY.Y, pt.coords.M)
+		w.writeSinglePointArray(pt.coords.XY.X, pt.coords.XY.Y, pt.coords.M)
 	case DimXYZM:
-		w.writePoints(1, pt.coords.XY.X, pt.coords.XY.Y, pt.coords.Z, pt.coords.M)
+		w.writeSinglePointArray(pt.coords.XY.X, pt.coords.XY.Y, pt.coords.Z, pt.coords.M)
 	default:
 		panic(fmt.Errorf("point has unknown type %s", pt.CoordinatesType()))
 	}
@@ -508,8 +508,8 @@ func (w *twkbWriter) writeExtendedPrecision() {
 	w.writeHeaderByte(ext)
 }
 
-func (w *twkbWriter) writePoints(numPoints int, coords ...float64) {
-	w.writePointArray(numPoints, coords)
+func (w *twkbWriter) writeSinglePointArray(coords ...float64) {
+	w.writePointArray(1, coords)
 }
 
 // Convert a given number of points from floating point to integer coordinates.
@@ -592,18 +592,16 @@ func (w *twkbWriter) writeIDList(num int) error {
 	return nil
 }
 
-func (w *twkbWriter) writeSignedVarint(val int64) int {
+func (w *twkbWriter) writeSignedVarint(val int64) {
 	var buf [binary.MaxVarintLen64]byte
 	n := binary.PutVarint(buf[:], val)
 	w.twkbContents = append(w.twkbContents, buf[:n]...)
-	return n
 }
 
-func (w *twkbWriter) writeUnsignedVarint(val uint64) int {
+func (w *twkbWriter) writeUnsignedVarint(val uint64) {
 	var buf [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(buf[:], val)
 	w.twkbContents = append(w.twkbContents, buf[:n]...)
-	return n
 }
 
 func (w *twkbWriter) writeHeaderByte(b byte) {

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/peterstace/simplefeatures/geom"
 )
 
+//nolint:unparam
 func geomFromWKT(tb testing.TB, wkt string, nv ...NoValidate) Geometry {
 	tb.Helper()
 	geom, err := UnmarshalWKT(wkt, nv...)
@@ -17,6 +18,7 @@ func geomFromWKT(tb testing.TB, wkt string, nv ...NoValidate) Geometry {
 	return geom
 }
 
+//nolint:unparam
 func geomsFromWKTs(tb testing.TB, wkts []string, nv ...NoValidate) []Geometry {
 	tb.Helper()
 	var gs []Geometry
@@ -117,6 +119,7 @@ func expectGeomEqWKT(tb testing.TB, got Geometry, wantWKT string, opts ...ExactE
 	expectGeomEq(tb, got, want, opts...)
 }
 
+//nolint:unparam
 func expectGeomsEq(tb testing.TB, got, want []Geometry, opts ...ExactEqualsOption) {
 	tb.Helper()
 	if len(got) != len(want) {

--- a/internal/cmprefimpl/cmppg/checks.go
+++ b/internal/cmprefimpl/cmppg/checks.go
@@ -62,7 +62,7 @@ func checkWKBParse(t *testing.T, pg PostGIS, candidates []string) {
 			}
 
 			_, sfErr := geom.UnmarshalWKB(buf)
-			isValid, reason := pg.WKBIsValidWithReason(t, wkb)
+			isValid, reason := pg.WKBIsValidWithReason(wkb)
 			if (sfErr == nil) != isValid {
 				t.Logf("WKB: %v", wkb)
 				t.Logf("SimpleFeatures err: %v", sfErr)
@@ -124,7 +124,7 @@ func checkGeoJSONParse(t *testing.T, pg PostGIS, candidates []string) {
 		found = true
 		t.Run(fmt.Sprintf("CheckGeoJSONParse_%d", i), func(t *testing.T) {
 			_, sfErr := geom.UnmarshalGeoJSON([]byte(geojson))
-			isValid, reason := pg.GeoJSONIsValidWithReason(t, geojson)
+			isValid, reason := pg.GeoJSONIsValidWithReason(geojson)
 			if (sfErr == nil) != isValid {
 				t.Logf("GeoJSON: %v", geojson)
 				t.Logf("SimpleFeatures err: %v", sfErr)

--- a/rtree/golden_internal_test.go
+++ b/rtree/golden_internal_test.go
@@ -126,7 +126,7 @@ func TestBulkLoadGolden(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("n=%d", tt.pop), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
-			rt, _ := testBulkLoad(rnd, tt.pop, 0.9, 0.1)
+			rt, _ := testBulkLoad(rnd, tt.pop)
 			got := checksum(rt.root)
 			if got != tt.want {
 				t.Errorf("got=%d want=%d", got, tt.want)

--- a/rtree/nearest_internal_test.go
+++ b/rtree/nearest_internal_test.go
@@ -13,7 +13,7 @@ func TestNearest(t *testing.T) {
 	for _, population := range testPopulations(66, 1000, 1.1) {
 		t.Run(fmt.Sprintf("n=%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
-			rt, boxes := testBulkLoad(rnd, population, 0.9, 0.1)
+			rt, boxes := testBulkLoad(rnd, population)
 			checkInvariants(t, rt, boxes)
 			checkPrioritySearch(t, rt, boxes, rnd)
 			checkNearest(t, rt, boxes, rnd)

--- a/rtree/perf_internal_test.go
+++ b/rtree/perf_internal_test.go
@@ -30,7 +30,7 @@ func BenchmarkRangeSearch(b *testing.B) {
 	for _, pop := range [...]int{10, 100, 1000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("n=%d", pop), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
-			tree, _ := testBulkLoad(rnd, pop, 0.9, 0.1)
+			tree, _ := testBulkLoad(rnd, pop)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				tree.RangeSearch(Box{0.5, 0.5, 0.5, 0.5}, func(int) error { return nil })

--- a/rtree/rtree_internal_test.go
+++ b/rtree/rtree_internal_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 )
 
-func testBulkLoad(rnd *rand.Rand, pop int, maxStart, maxWidth float64) (*RTree, []Box) {
+func testBulkLoad(rnd *rand.Rand, pop int) (*RTree, []Box) {
 	boxes := make([]Box, pop)
 	seenX := make(map[float64]bool)
 	seenY := make(map[float64]bool)
 	for i := range boxes {
 		var box Box
 		for {
-			box = randomBox(rnd, maxStart, maxWidth)
+			box = randomBox(rnd, 0.9, 0.1)
 			x := box.MinX + box.MaxX
 			y := box.MinY + box.MaxY
 			if !seenX[x] && !seenY[y] {
@@ -50,7 +50,7 @@ func TestRandom(t *testing.T) {
 	for _, population := range testPopulations(66, 1000, 1.2) {
 		t.Run(fmt.Sprintf("bulk_%d", population), func(t *testing.T) {
 			rnd := rand.New(rand.NewSource(0))
-			rt, boxes := testBulkLoad(rnd, population, 0.9, 0.1)
+			rt, boxes := testBulkLoad(rnd, population)
 			checkInvariants(t, rt, boxes)
 			checkSearch(t, rt, boxes, rnd)
 		})


### PR DESCRIPTION
## Description

The [`unparam`](https://github.com/mvdan/unparam) linter finds unused function and method parameters.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/522