### PR TITLE
Enable `stylecheck` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,6 +88,7 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
+    - stylecheck
     - tagalign
     - tagliatelle
     - tenv
@@ -151,4 +152,3 @@ linters:
     # They will be enabled later.
     - errorlint
     - revive
-    - stylecheck

--- a/geom/geojson_unmarshal_test.go
+++ b/geom/geojson_unmarshal_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
-	. "github.com/peterstace/simplefeatures/geom"
 )
 
 func TestGeoJSONUnmarshalValid(t *testing.T) {
@@ -172,7 +171,7 @@ func TestGeoJSONUnmarshalValid(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got, err := UnmarshalGeoJSON([]byte(tt.geojson))
+			got, err := geom.UnmarshalGeoJSON([]byte(tt.geojson))
 			expectNoErr(t, err)
 			want := geomFromWKT(t, tt.wkt)
 			expectGeomEq(t, got, want)
@@ -219,7 +218,7 @@ func TestGeoJSONUnmarshalValidAllowAdditionalCoordDimensions(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got, err := UnmarshalGeoJSON([]byte(tt.geojson))
+			got, err := geom.UnmarshalGeoJSON([]byte(tt.geojson))
 			expectNoErr(t, err)
 			want := geomFromWKT(t, tt.wkt)
 			expectGeomEq(t, got, want)
@@ -322,7 +321,7 @@ func TestGeoJSONSyntaxError(t *testing.T) {
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			_, err := UnmarshalGeoJSON([]byte(tc.geojson))
+			_, err := geom.UnmarshalGeoJSON([]byte(tc.geojson))
 			if err == nil {
 				t.Fatal("expected an error but got nil")
 			}
@@ -368,10 +367,10 @@ func TestGeoJSONUnmarshalNoValidate(t *testing.T) {
 		`{"type":"MultiPolygon","coordinates":[[[[0,0],[0,0]]]]}`,
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			if _, err := UnmarshalGeoJSON([]byte(geojson)); err == nil {
+			if _, err := geom.UnmarshalGeoJSON([]byte(geojson)); err == nil {
 				t.Fatal("invalid test case -- geometry should be invalid")
 			}
-			if _, err := UnmarshalGeoJSON([]byte(geojson), NoValidate{}); err != nil {
+			if _, err := geom.UnmarshalGeoJSON([]byte(geojson), geom.NoValidate{}); err != nil {
 				t.Errorf("got error but didn't expect one because validations are disabled")
 			}
 		})
@@ -383,43 +382,43 @@ func TestGeoJSONUnmarshalIntoConcreteGeometryValid(t *testing.T) {
 		target interface {
 			json.Unmarshaler
 			AsGeometry() geom.Geometry
-			Type() GeometryType
+			Type() geom.GeometryType
 		}
 		geojson string
 		wantWKT string
 	}{
 		{
-			target:  new(GeometryCollection),
+			target:  new(geom.GeometryCollection),
 			geojson: `{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1,2]}]}`,
 			wantWKT: "GEOMETRYCOLLECTION(POINT(1 2))",
 		},
 		{
-			target:  new(Point),
+			target:  new(geom.Point),
 			geojson: `{"type":"Point","coordinates":[1,2]}`,
 			wantWKT: "POINT(1 2)",
 		},
 		{
-			target:  new(LineString),
+			target:  new(geom.LineString),
 			geojson: `{"type":"LineString","coordinates":[[1,2],[3,4]]}`,
 			wantWKT: "LINESTRING(1 2,3 4)",
 		},
 		{
-			target:  new(Polygon),
+			target:  new(geom.Polygon),
 			geojson: `{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,0],[0,0]]]}`,
 			wantWKT: "POLYGON((0 0,0 1,1 0,0 0))",
 		},
 		{
-			target:  new(MultiPoint),
+			target:  new(geom.MultiPoint),
 			geojson: `{"type":"MultiPoint","coordinates":[[1,2]]}`,
 			wantWKT: "MULTIPOINT((1 2))",
 		},
 		{
-			target:  new(MultiLineString),
+			target:  new(geom.MultiLineString),
 			geojson: `{"type":"MultiLineString","coordinates":[[[1,2],[3,4]]]}`,
 			wantWKT: "MULTILINESTRING((1 2,3 4))",
 		},
 		{
-			target:  new(MultiPolygon),
+			target:  new(geom.MultiPolygon),
 			geojson: `{"type":"MultiPolygon","coordinates":[[[[0,0],[0,1],[1,0],[0,0]]]]}`,
 			wantWKT: "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))",
 		},
@@ -436,16 +435,16 @@ func TestGeoJSONUnmarshalIntoConcreteGeometryWrongType(t *testing.T) {
 	for _, tc := range []struct {
 		dest interface {
 			json.Unmarshaler
-			Type() GeometryType
+			Type() geom.GeometryType
 		}
 	}{
-		{new(GeometryCollection)},
-		{new(Point)},
-		{new(LineString)},
-		{new(Polygon)},
-		{new(MultiPoint)},
-		{new(MultiLineString)},
-		{new(MultiPolygon)},
+		{new(geom.GeometryCollection)},
+		{new(geom.Point)},
+		{new(geom.LineString)},
+		{new(geom.Polygon)},
+		{new(geom.MultiPoint)},
+		{new(geom.MultiLineString)},
+		{new(geom.MultiPolygon)},
 	} {
 		t.Run("dest_"+tc.dest.Type().String(), func(t *testing.T) {
 			for _, geojson := range []string{

--- a/geom/perf_test.go
+++ b/geom/perf_test.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
-	. "github.com/peterstace/simplefeatures/geom"
 )
 
 // regularPolygon computes a regular polygon circumscribed by a circle with the
 // given center and radius. Sides must be at least 3 or it will panic.
-func regularPolygon(center XY, radius float64, sides int) Polygon {
+func regularPolygon(center geom.XY, radius float64, sides int) geom.Polygon {
 	if sides <= 2 {
 		panic(sides)
 	}
@@ -25,15 +24,15 @@ func regularPolygon(center XY, radius float64, sides int) Polygon {
 	}
 	coords[2*sides+0] = coords[0]
 	coords[2*sides+1] = coords[1]
-	ring := NewLineString(NewSequence(coords, DimXY))
-	return NewPolygon([]LineString{ring})
+	ring := geom.NewLineString(geom.NewSequence(coords, geom.DimXY))
+	return geom.NewPolygon([]geom.LineString{ring})
 }
 
 func BenchmarkMarshalWKB(b *testing.B) {
 	b.Run("polygon", func(b *testing.B) {
 		for _, sz := range []int{10, 100, 1000, 10000} {
 			b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
-				poly := regularPolygon(XY{}, 1.0, sz)
+				poly := regularPolygon(geom.XY{}, 1.0, sz)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					poly.AsBinary()
@@ -47,10 +46,10 @@ func BenchmarkUnmarshalWKB(b *testing.B) {
 	b.Run("polygon", func(b *testing.B) {
 		for _, sz := range []int{10, 100, 1000, 10000} {
 			b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
-				wkb := regularPolygon(XY{}, 1.0, sz).AsBinary()
+				wkb := regularPolygon(geom.XY{}, 1.0, sz).AsBinary()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					_, err := UnmarshalWKB(wkb, NoValidate{})
+					_, err := geom.UnmarshalWKB(wkb, geom.NoValidate{})
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -76,7 +75,7 @@ func BenchmarkIntersectsLineStringWithLineString(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				if Intersects(ls1, ls2) {
+				if geom.Intersects(ls1, ls2) {
 					b.Fatal("should not intersect")
 				}
 			}
@@ -88,18 +87,18 @@ func BenchmarkIntersectsMultiPointWithMultiPoint(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("n=%d", 2*sz), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
-			var pointsA, pointsB []Point
+			var pointsA, pointsB []geom.Point
 			for i := 0; i < sz; i++ {
-				ptA := XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
+				ptA := geom.XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
 				pointsA = append(pointsA, ptA)
-				ptB := XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
+				ptB := geom.XY{X: rnd.Float64(), Y: rnd.Float64()}.AsPoint()
 				pointsB = append(pointsB, ptB)
 			}
-			mpA := NewMultiPoint(pointsA).AsGeometry()
-			mpB := NewMultiPoint(pointsB).AsGeometry()
+			mpA := geom.NewMultiPoint(pointsA).AsGeometry()
+			mpB := geom.NewMultiPoint(pointsB).AsGeometry()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if Intersects(mpA, mpB) {
+				if geom.Intersects(mpA, mpB) {
 					b.Fatal("shouldn't have intersected")
 				}
 			}
@@ -118,8 +117,8 @@ func BenchmarkPolygonSingleRingValidation(b *testing.B) {
 			}
 			floats[2*sz+0] = floats[0]
 			floats[2*sz+1] = floats[1]
-			ring := NewLineString(NewSequence(floats, DimXY))
-			poly := NewPolygon([]LineString{ring})
+			ring := geom.NewLineString(geom.NewSequence(floats, geom.DimXY))
+			poly := geom.NewPolygon([]geom.LineString{ring})
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -135,24 +134,24 @@ func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
 	for _, sz := range []int{2, 6, 20, 64} {
 		b.Run(fmt.Sprintf("n=%d", sz*sz), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
-			rings := make([]LineString, sz*sz+1)
-			rings[0] = NewLineString(NewSequence([]float64{0, 0, 0, 1, 1, 1, 1, 0, 0, 0}, DimXY))
+			rings := make([]geom.LineString, sz*sz+1)
+			rings[0] = geom.NewLineString(geom.NewSequence([]float64{0, 0, 0, 1, 1, 1, 1, 0, 0, 0}, geom.DimXY))
 			for i := 0; i < sz*sz; i++ {
-				center := XY{
+				center := geom.XY{
 					X: (0.5 + float64(i/sz)) / float64(sz),
 					Y: (0.5 + float64(i%sz)) / float64(sz),
 				}
 				dx := rnd.Float64() * 0.5 / float64(sz)
 				dy := rnd.Float64() * 0.5 / float64(sz)
-				rings[1+i] = NewLineString(NewSequence([]float64{
+				rings[1+i] = geom.NewLineString(geom.NewSequence([]float64{
 					center.X - dx, center.Y - dy,
 					center.X + dx, center.Y - dy,
 					center.X + dx, center.Y + dy,
 					center.X - dx, center.Y + dy,
 					center.X - dx, center.Y - dy,
-				}, DimXY))
+				}, geom.DimXY))
 			}
-			poly := NewPolygon(rings)
+			poly := geom.NewPolygon(rings)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -167,7 +166,7 @@ func BenchmarkPolygonMultipleRingsValidation(b *testing.B) {
 func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
-			outerRingEnv := NewEnvelope(XY{}, XY{7, float64(sz + 1)})
+			outerRingEnv := geom.NewEnvelope(geom.XY{}, geom.XY{7, float64(sz + 1)})
 			outerRing := outerRingEnv.AsGeometry().MustAsPolygon().ExteriorRing()
 			var leftFloats, rightFloats []float64
 			for i := 0; i < sz; i++ {
@@ -184,9 +183,9 @@ func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 				6, 1,
 				3, 1,
 			)
-			leftRing := NewLineString(NewSequence(leftFloats, DimXY))
-			rightRing := NewLineString(NewSequence(rightFloats, DimXY))
-			poly := NewPolygon([]LineString{outerRing, leftRing, rightRing})
+			leftRing := geom.NewLineString(geom.NewSequence(leftFloats, geom.DimXY))
+			rightRing := geom.NewLineString(geom.NewSequence(rightFloats, geom.DimXY))
+			poly := geom.NewPolygon([]geom.LineString{outerRing, leftRing, rightRing})
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -201,10 +200,10 @@ func BenchmarkPolygonZigZagRingsValidation(b *testing.B) {
 func BenchmarkPolygonAnnulusValidation(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
-			outer := regularPolygon(XY{}, 1.0, sz/2).ExteriorRing()
-			inner := regularPolygon(XY{}, 0.5, sz/2).ExteriorRing()
-			rings := []LineString{outer, inner}
-			poly := NewPolygon(rings)
+			outer := regularPolygon(geom.XY{}, 1.0, sz/2).ExteriorRing()
+			inner := regularPolygon(geom.XY{}, 0.5, sz/2).ExteriorRing()
+			rings := []geom.LineString{outer, inner}
+			poly := geom.NewPolygon(rings)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if err := poly.Validate(); err != nil {
@@ -219,22 +218,22 @@ func BenchmarkMultipolygonValidation(b *testing.B) {
 	for _, sz := range []int{1, 2, 4, 8, 16, 32} {
 		b.Run(fmt.Sprintf("n=%d", sz*sz), func(b *testing.B) {
 			rnd := rand.New(rand.NewSource(0))
-			polys := make([]Polygon, sz*sz)
+			polys := make([]geom.Polygon, sz*sz)
 			for i := 0; i < sz*sz; i++ {
 				cx := (0.5 + float64(i/sz)) / float64(sz)
 				cy := (0.5 + float64(i%sz)) / float64(sz)
 				dx := rnd.Float64() * 0.5 / float64(sz)
 				dy := rnd.Float64() * 0.5 / float64(sz)
-				ring := NewLineString(NewSequence([]float64{
+				ring := geom.NewLineString(geom.NewSequence([]float64{
 					cx - dx, cy - dy,
 					cx + dx, cy - dy,
 					cx + dx, cy + dy,
 					cx - dx, cy + dy,
 					cx - dx, cy - dy,
-				}, DimXY))
-				polys[i] = NewPolygon([]LineString{ring})
+				}, geom.DimXY))
+				polys[i] = geom.NewPolygon([]geom.LineString{ring})
 			}
-			multiPoly := NewMultiPolygon(polys)
+			multiPoly := geom.NewMultiPolygon(polys)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -250,11 +249,11 @@ func BenchmarkMultiPolygonTwoCircles(b *testing.B) {
 	for _, sz := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
 			const eps = 0.1
-			polys := []Polygon{
-				regularPolygon(XY{X: -eps, Y: -eps}, 1.0, sz),
-				regularPolygon(XY{X: math.Sqrt2, Y: math.Sqrt2}, 1.0, sz),
+			polys := []geom.Polygon{
+				regularPolygon(geom.XY{X: -eps, Y: -eps}, 1.0, sz),
+				regularPolygon(geom.XY{X: math.Sqrt2, Y: math.Sqrt2}, 1.0, sz),
 			}
-			multiPoly := NewMultiPolygon(polys)
+			multiPoly := geom.NewMultiPolygon(polys)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if err := multiPoly.Validate(); err != nil {
@@ -277,12 +276,12 @@ func BenchmarkMultiPolygonMultipleTouchingPoints(b *testing.B) {
 			fs1 = append(fs1, 0, float64(2*sz), 0, 0)
 			fs2 = append(fs2, 4, float64(2*sz), 4, 0)
 
-			ls1 := NewLineString(NewSequence(fs1, DimXY))
-			ls2 := NewLineString(NewSequence(fs2, DimXY))
-			p1 := NewPolygon([]LineString{ls1})
-			p2 := NewPolygon([]LineString{ls2})
-			polys := []Polygon{p1, p2}
-			multiPoly := NewMultiPolygon(polys)
+			ls1 := geom.NewLineString(geom.NewSequence(fs1, geom.DimXY))
+			ls2 := geom.NewLineString(geom.NewSequence(fs2, geom.DimXY))
+			p1 := geom.NewPolygon([]geom.LineString{ls1})
+			p2 := geom.NewPolygon([]geom.LineString{ls2})
+			polys := []geom.Polygon{p1, p2}
+			multiPoly := geom.NewMultiPolygon(polys)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -306,7 +305,7 @@ func BenchmarkWKTParsing(b *testing.B) {
 	} {
 		b.Run(tc.desc, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := UnmarshalWKT(tc.wkt); err != nil {
+				if _, err := geom.UnmarshalWKT(tc.wkt); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -324,7 +323,7 @@ func BenchmarkDistancePolygonToPolygonOrdering(b *testing.B) {
 					p1, p2 = p2, p1
 				}
 				for i := 0; i < b.N; i++ {
-					Distance(p1, p2)
+					geom.Distance(p1, p2)
 				}
 			})
 		}
@@ -341,7 +340,7 @@ func BenchmarkIntersectionPolygonWithPolygonOrdering(b *testing.B) {
 					p1, p2 = p2, p1
 				}
 				for i := 0; i < b.N; i++ {
-					Distance(p1, p2)
+					geom.Distance(p1, p2)
 				}
 			})
 		}
@@ -351,21 +350,21 @@ func BenchmarkIntersectionPolygonWithPolygonOrdering(b *testing.B) {
 func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 	for _, sz := range []int{100, 1000} {
 		b.Run(fmt.Sprintf("n=%d", sz), func(b *testing.B) {
-			var lss []LineString
+			var lss []geom.LineString
 			for i := 0; i < sz; i++ {
-				seq := NewSequence([]float64{
+				seq := geom.NewSequence([]float64{
 					float64(2*i + 0),
 					float64(2*i + 0),
 					float64(2*i + 1),
 					float64(2*i + 1),
-				}, DimXY)
-				ls := NewLineString(seq)
+				}, geom.DimXY)
+				ls := geom.NewLineString(seq)
 				if err := ls.Validate(); err != nil {
 					b.Fatal(err)
 				}
 				lss = append(lss, ls)
 			}
-			mls := NewMultiLineString(lss)
+			mls := geom.NewMultiLineString(lss)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -378,18 +377,18 @@ func BenchmarkMultiLineStringIsSimpleManyLineStrings(b *testing.B) {
 func BenchmarkForceCWandForceCCW(b *testing.B) {
 	for i, tc := range []struct {
 		wkt     string
-		geoType GeometryType
+		geoType geom.GeometryType
 		isCW    bool
 		isCCW   bool
 		note    string
 	}{
-		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", TypePolygon, true, false, "CW"},
-		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", TypePolygon, false, true, "CCW"},
-		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", TypePolygon, true, false, "outer CW inner CCW"},
-		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", TypePolygon, false, true, "outer CCW inner CW"},
-		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", TypeMultiPolygon, true, false, "all CW"},
-		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, true, "all CCW"},
-		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", geom.TypePolygon, true, false, "CW"},
+		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", geom.TypePolygon, false, true, "CCW"},
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", geom.TypePolygon, true, false, "outer CW inner CCW"},
+		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", geom.TypePolygon, false, true, "outer CCW inner CW"},
+		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", geom.TypeMultiPolygon, true, false, "all CW"},
+		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", geom.TypeMultiPolygon, false, true, "all CCW"},
+		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", geom.TypeGeometryCollection, true, false, "all CW"},
 	} {
 		g := geomFromWKT(b, tc.wkt)
 		for _, correct := range map[string]bool{

--- a/geom/sql_test.go
+++ b/geom/sql_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
-	. "github.com/peterstace/simplefeatures/geom"
 )
 
 func TestSQLValueGeometry(t *testing.T) {
@@ -14,7 +13,7 @@ func TestSQLValueGeometry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	geom, err := UnmarshalWKB(val.([]byte))
+	geom, err := geom.UnmarshalWKB(val.([]byte))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +23,7 @@ func TestSQLValueGeometry(t *testing.T) {
 func TestSQLScanGeometry(t *testing.T) {
 	const wkt = "POINT(2 3)"
 	wkb := geomFromWKT(t, wkt).AsBinary()
-	var g Geometry
+	var g geom.Geometry
 	check := func(t *testing.T, err error) {
 		t.Helper()
 		if err != nil {
@@ -33,11 +32,11 @@ func TestSQLScanGeometry(t *testing.T) {
 		expectGeomEq(t, g, geomFromWKT(t, wkt))
 	}
 	t.Run("string", func(t *testing.T) {
-		g = Geometry{}
+		g = geom.Geometry{}
 		check(t, g.Scan(string(wkb)))
 	})
 	t.Run("byte", func(t *testing.T) {
-		g = Geometry{}
+		g = geom.Geometry{}
 		check(t, g.Scan(wkb))
 	})
 }
@@ -57,12 +56,12 @@ func TestSQLValueConcrete(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log(wkt)
-			geom := geomFromWKT(t, wkt)
-			val, err := geom.Value()
+			in := geomFromWKT(t, wkt)
+			val, err := in.Value()
 			expectNoErr(t, err)
-			g, err := UnmarshalWKB(val.([]byte))
+			out, err := geom.UnmarshalWKB(val.([]byte))
 			expectNoErr(t, err)
-			expectGeomEq(t, g, geom)
+			expectGeomEq(t, out, in)
 		})
 	}
 }

--- a/internal/benchmarkreport/main.go
+++ b/internal/benchmarkreport/main.go
@@ -117,7 +117,7 @@ func showTable(benches map[benchmark]time.Duration) {
 }
 
 func roundDuration(d time.Duration) time.Duration {
-	var round time.Duration = time.Nanosecond
+	round := time.Nanosecond
 	for round < d {
 		round *= 10
 	}

--- a/rtree/rtree.go
+++ b/rtree/rtree.go
@@ -37,7 +37,7 @@ type RTree struct {
 
 // Stop is a special sentinel error that can be used to stop a search operation
 // without any error.
-var Stop = errors.New("stop")
+var Stop = errors.New("stop") //nolint:stylecheck // ST1012
 
 // RangeSearch looks for any items in the tree that overlap with the given
 // bounding box. The callback is called with the record ID for each found item.


### PR DESCRIPTION
## Description

The `stylecheck` checks for rules that are "generally agreed upon by the Go community" (I tend to agree!).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/522