### PR TITLE
Enable `errorlint` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,7 @@ linters:
     - durationcheck
     - errcheck
     - errchkjson
+    - errorlint
     - execinquery
     - exportloopref
     - ginkgolinter
@@ -150,5 +151,4 @@ linters:
 
     # These are a good idea to enable, but would involve noisey changes.
     # They will be enabled later.
-    - errorlint
     - revive

--- a/geom/wkt_lexer_internal_test.go
+++ b/geom/wkt_lexer_internal_test.go
@@ -1,6 +1,7 @@
 package geom
 
 import (
+	"errors"
 	"reflect"
 	"strconv"
 	"testing"
@@ -42,7 +43,7 @@ func TestWKTLexer(t *testing.T) {
 			for {
 				tok, err := lexer.next()
 				if err != nil {
-					if err == wktUnexpectedEOF {
+					if errors.Is(err, wktUnexpectedEOF) {
 						break
 					}
 					t.Fatal(err)

--- a/geom/wkt_parser.go
+++ b/geom/wkt_parser.go
@@ -1,6 +1,7 @@
 package geom
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -26,7 +27,7 @@ func UnmarshalWKT(wkt string, nv ...NoValidate) (Geometry, error) {
 
 	if tok, err := p.lexer.next(); err == nil {
 		return Geometry{}, wantButGot("EOF", tok)
-	} else if err != wktUnexpectedEOF {
+	} else if !errors.Is(err, wktUnexpectedEOF) {
 		return Geometry{}, err
 	}
 

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -319,7 +319,7 @@ func checkEnvelope(h *Handle, g geom.Geometry, log *log.Logger) error {
 func checkIsSimple(h *Handle, g geom.Geometry, log *log.Logger) error {
 	want, wantDefined, err := h.isSimple(g)
 	if err != nil {
-		if err == errLibgeosCrash {
+		if errors.Is(err, errLibgeosCrash) {
 			// Skip any tests that would cause libgeos to crash.
 			return nil
 		}
@@ -606,7 +606,7 @@ func checkIntersects(h *Handle, g1, g2 geom.Geometry, log *log.Logger) error {
 
 	want, err := h.intersects(g1, g2)
 	if err != nil {
-		if err == errLibgeosCrash {
+		if errors.Is(err, errLibgeosCrash) {
 			return nil
 		}
 		return err
@@ -639,7 +639,7 @@ func checkExactEquals(h *Handle, g1, g2 geom.Geometry, log *log.Logger) error {
 func checkDistance(h *Handle, g1, g2 geom.Geometry, log *log.Logger) error {
 	want, err := h.distance(g1, g2)
 	if err != nil {
-		if err == errLibgeosCrash {
+		if errors.Is(err, errLibgeosCrash) {
 			// Skip any tests that would cause libgeos to crash.
 			return nil
 		}
@@ -832,7 +832,7 @@ func checkDCELOp(
 
 	want, err := refImpl(g1, g2)
 	if err != nil {
-		if err == errInvalidAccordingToGEOS {
+		if errors.Is(err, errInvalidAccordingToGEOS) {
 			// Because GEOS has given us back an invalid geometry (even according
 			// to its own validation routines) we can't trust it for this test
 			// case.
@@ -898,7 +898,7 @@ func checkRelate(h *Handle, g1, g2 geom.Geometry, log *log.Logger) error {
 	}
 	want, err := h.relate(g1, g2)
 	if err != nil {
-		if err == errLibgeosCrash {
+		if errors.Is(err, errLibgeosCrash) {
 			// Skip any tests that would cause libgeos to crash.
 			return nil
 		}

--- a/internal/cmprefimpl/cmpgeos/handle.go
+++ b/internal/cmprefimpl/cmpgeos/handle.go
@@ -366,7 +366,7 @@ func (h *Handle) decodeGeomHandleUsingWKB(gh *C.GEOSGeometry) (geom.Geometry, er
 	var size C.size_t
 	wkb := C.GEOSWKBWriter_write_r(h.context, h.wkbWriter, gh, &size)
 	if wkb == nil {
-		return geom.Geometry{}, fmt.Errorf("writing wkb: %v", h.err())
+		return geom.Geometry{}, fmt.Errorf("writing wkb: %w", h.err())
 	}
 	defer C.GEOSFree_r(h.context, unsafe.Pointer(wkb))
 	byts := C.GoBytes(unsafe.Pointer(wkb), C.int(size))
@@ -399,7 +399,7 @@ func (h *Handle) asText(g geom.Geometry) (string, error) {
 func (h *Handle) fromText(wkt string) (geom.Geometry, error) {
 	reader := C.GEOSWKTReader_create_r(h.context)
 	if reader == nil {
-		return geom.Geometry{}, fmt.Errorf("creating wkt reader: %v", h.err())
+		return geom.Geometry{}, fmt.Errorf("creating wkt reader: %w", h.err())
 	}
 	defer C.GEOSWKTReader_destroy_r(h.context, reader)
 

--- a/rtree/nearest.go
+++ b/rtree/nearest.go
@@ -1,6 +1,9 @@
 package rtree
 
-import "container/heap"
+import (
+	"container/heap"
+	"errors"
+)
 
 // Nearest finds the record in the RTree that is the closest to the input box
 // as measured by the Euclidean metric. Note that there may be multiple records
@@ -21,7 +24,7 @@ func (t *RTree) Nearest(box Box) (recordID int, found bool) {
 // error is returned from the callback, then iteration stops immediately. Any
 // error returned from the callback is returned by PrioritySearch, except for
 // the case where the special Stop sentinel error is returned (in which case
-// nil will be returned from PrioritySearch).
+// nil will be returned from PrioritySearch). Stop may be wrapped.
 func (t *RTree) PrioritySearch(box Box, callback func(recordID int) error) error {
 	if t.root == nil {
 		return nil
@@ -39,7 +42,7 @@ func (t *RTree) PrioritySearch(box Box, callback func(recordID int) error) error
 		nearest := heap.Pop(&queue).(*entry)
 		if nearest.child == nil {
 			if err := callback(nearest.recordID); err != nil {
-				if err == Stop {
+				if errors.Is(err, Stop) {
 					return nil
 				}
 				return err

--- a/rtree/nearest_internal_test.go
+++ b/rtree/nearest_internal_test.go
@@ -114,7 +114,7 @@ func TestPrioritySearchEarlyStop(t *testing.T) {
 			}
 			return nil
 		})
-		if err != userErr {
+		if !errors.Is(err, userErr) {
 			t.Fatalf("expected to get userErr but got: %v", userErr)
 		}
 		if count != 3 {

--- a/rtree/rtree.go
+++ b/rtree/rtree.go
@@ -44,7 +44,7 @@ var Stop = errors.New("stop") //nolint:stylecheck // ST1012
 // If an error is returned from the callback then the search is terminated
 // early.  Any error returned from the callback is returned by RangeSearch,
 // except for the case where the special Stop sentinel error is returned (in
-// which case nil will be returned from RangeSearch).
+// which case nil will be returned from RangeSearch). Stop may be wrapped.
 func (t *RTree) RangeSearch(box Box, callback func(recordID int) error) error {
 	if t.root == nil {
 		return nil
@@ -57,7 +57,7 @@ func (t *RTree) RangeSearch(box Box, callback func(recordID int) error) error {
 				continue
 			}
 			if entry.child == nil {
-				if err := callback(entry.recordID); err == Stop {
+				if err := callback(entry.recordID); errors.Is(err, Stop) {
 					return nil
 				} else if err != nil {
 					return err


### PR DESCRIPTION
## Description

The `errorlint` linter finds problems in code relating to Go's error wrapping scheme.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/522