### PR TITLE
Upgrade golangci-lint to v1.55.2

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.54.2
+FROM golangci/golangci-lint:v1.55.2
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,6 +83,7 @@ linters:
     - noctx
     - nolintlint
     - nosprintfhostport
+    - perfsprint
     - predeclared
     - promlinter
     - reassign
@@ -133,12 +134,14 @@ linters:
     - gci
     - gochecknoglobals
     - gochecknoinits
+    - gochecksumtype
     - gocognit
     - goconst
     - gocyclo
     - godox
     - goerr113
     - gomnd
+    - inamedparam
     - lll
     - maintidx
     - nestif
@@ -146,6 +149,9 @@ linters:
     - nonamedreturns
     - paralleltest
     - prealloc
+    - protogetter
+    - sloglint
+    - testifylint
     - varnamelen
     - wrapcheck
     - wsl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ YYYY-MM-DD
 
 - Simplifies the internal representation of the `Envelope` type.
 
+- Upgrades `golangci-lint` to `v1.55.2`.
+
 - **Breaking change**: Renames `Envelope`'s `ExtendToIncludeXY` method to
   `ExpandToIncludeXY`. This makes the names of the `ExpandToIncludeXY` and
   `ExpandToIncludeEnvelope` methods have consistent naming.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ DC_RUN = \
 	--project-name sf-$$task \
 	--file .ci/docker-compose-$$task.yml \
 	up \
-	--abort-on-container-exit
+	--abort-on-container-exit \
+	--build
 
 .PHONY: lint
 lint:

--- a/geom/accessor_test.go
+++ b/geom/accessor_test.go
@@ -3,13 +3,13 @@ package geom_test
 import (
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestPointAccessorNonEmpty(t *testing.T) {
 	xy, ok := geomFromWKT(t, "POINT(1 2)").MustAsPoint().XY()
 	expectBoolEq(t, ok, true)
-	expectXYEq(t, xy, XY{1, 2})
+	expectXYEq(t, xy, geom.XY{1, 2})
 }
 
 func TestPointAccessorEmpty(t *testing.T) {
@@ -25,11 +25,11 @@ func TestLineStringAccessor(t *testing.T) {
 	pt56 := xyCoords(5, 6)
 
 	t.Run("start", func(t *testing.T) {
-		want := NewPoint(pt12)
+		want := geom.NewPoint(pt12)
 		expectGeomEq(t, ls.StartPoint().AsGeometry(), want.AsGeometry())
 	})
 	t.Run("end", func(t *testing.T) {
-		want := NewPoint(pt56)
+		want := geom.NewPoint(pt56)
 		expectGeomEq(t, ls.EndPoint().AsGeometry(), want.AsGeometry())
 	})
 	t.Run("num points", func(t *testing.T) {

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestIsEmptyDimension(t *testing.T) {
@@ -46,7 +46,7 @@ func TestIsEmptyDimension(t *testing.T) {
 		{"GEOMETRYCOLLECTION(POLYGON((0 0,1 1,1 0,0 0)),POINT(1 1),LINESTRING(0 0,1 1))", false, 2},
 	} {
 		t.Run(tt.wkt, func(t *testing.T) {
-			geom, err := UnmarshalWKT(tt.wkt)
+			geom, err := geom.UnmarshalWKT(tt.wkt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -67,13 +67,13 @@ func TestIsEmptyDimension(t *testing.T) {
 }
 
 func TestEnvelope(t *testing.T) {
-	xy := func(x, y float64) XY {
-		return XY{x, y}
+	xy := func(x, y float64) geom.XY {
+		return geom.XY{x, y}
 	}
 	for i, tt := range []struct {
 		wkt string
-		min XY
-		max XY
+		min geom.XY
+		max geom.XY
 	}{
 		{"POINT(1 1)", xy(1, 1), xy(1, 1)},
 		{"LINESTRING(1 2,3 4)", xy(1, 2), xy(3, 4)},
@@ -319,7 +319,7 @@ func TestCoordinatesSequence(t *testing.T) {
 		t.Run("populated", func(t *testing.T) {
 			c, ok := geomFromWKT(t, "POINT(1 2)").MustAsPoint().Coordinates()
 			expectBoolEq(t, ok, true)
-			expectXYEq(t, c.XY, XY{1, 2})
+			expectXYEq(t, c.XY, geom.XY{1, 2})
 		})
 		t.Run("empty", func(t *testing.T) {
 			_, ok := geomFromWKT(t, "POINT EMPTY").MustAsPoint().Coordinates()
@@ -329,52 +329,52 @@ func TestCoordinatesSequence(t *testing.T) {
 	t.Run("linestring", func(t *testing.T) {
 		seq := geomFromWKT(t, "LINESTRING(0 1,2 3,4 5)").MustAsLineString().Coordinates()
 		expectIntEq(t, seq.Length(), 3)
-		expectXYEq(t, seq.GetXY(0), XY{0, 1})
-		expectXYEq(t, seq.GetXY(1), XY{2, 3})
-		expectXYEq(t, seq.GetXY(2), XY{4, 5})
+		expectXYEq(t, seq.GetXY(0), geom.XY{0, 1})
+		expectXYEq(t, seq.GetXY(1), geom.XY{2, 3})
+		expectXYEq(t, seq.GetXY(2), geom.XY{4, 5})
 	})
 	t.Run("linestring with dupe", func(t *testing.T) {
 		seq := geomFromWKT(t, "LINESTRING(1 5,5 2,5 2,4 9)").MustAsLineString().Coordinates()
 		expectIntEq(t, seq.Length(), 4)
-		expectXYEq(t, seq.GetXY(0), XY{1, 5})
-		expectXYEq(t, seq.GetXY(1), XY{5, 2})
-		expectXYEq(t, seq.GetXY(2), XY{5, 2})
-		expectXYEq(t, seq.GetXY(3), XY{4, 9})
+		expectXYEq(t, seq.GetXY(0), geom.XY{1, 5})
+		expectXYEq(t, seq.GetXY(1), geom.XY{5, 2})
+		expectXYEq(t, seq.GetXY(2), geom.XY{5, 2})
+		expectXYEq(t, seq.GetXY(3), geom.XY{4, 9})
 	})
 	t.Run("polygon", func(t *testing.T) {
 		seq := geomFromWKT(t, "POLYGON((0 0,0 10,10 0,0 0),(2 2,2 7,7 2,2 2))").MustAsPolygon().Coordinates()
 		expectIntEq(t, len(seq), 2)
 		expectIntEq(t, seq[0].Length(), 4)
-		expectXYEq(t, seq[0].GetXY(0), XY{0, 0})
-		expectXYEq(t, seq[0].GetXY(1), XY{0, 10})
-		expectXYEq(t, seq[0].GetXY(2), XY{10, 0})
-		expectXYEq(t, seq[0].GetXY(3), XY{0, 0})
+		expectXYEq(t, seq[0].GetXY(0), geom.XY{0, 0})
+		expectXYEq(t, seq[0].GetXY(1), geom.XY{0, 10})
+		expectXYEq(t, seq[0].GetXY(2), geom.XY{10, 0})
+		expectXYEq(t, seq[0].GetXY(3), geom.XY{0, 0})
 		expectIntEq(t, seq[1].Length(), 4)
-		expectXYEq(t, seq[1].GetXY(0), XY{2, 2})
-		expectXYEq(t, seq[1].GetXY(1), XY{2, 7})
-		expectXYEq(t, seq[1].GetXY(2), XY{7, 2})
-		expectXYEq(t, seq[1].GetXY(3), XY{2, 2})
+		expectXYEq(t, seq[1].GetXY(0), geom.XY{2, 2})
+		expectXYEq(t, seq[1].GetXY(1), geom.XY{2, 7})
+		expectXYEq(t, seq[1].GetXY(2), geom.XY{7, 2})
+		expectXYEq(t, seq[1].GetXY(3), geom.XY{2, 2})
 	})
 	t.Run("multipoint", func(t *testing.T) {
 		seq := geomFromWKT(t, "MULTIPOINT(0 1,2 3,EMPTY,4 5)").MustAsMultiPoint().Coordinates()
 		expectIntEq(t, seq.Length(), 3)
-		expectXYEq(t, seq.GetXY(0), XY{0, 1})
-		expectXYEq(t, seq.GetXY(1), XY{2, 3})
-		expectXYEq(t, seq.GetXY(2), XY{4, 5})
+		expectXYEq(t, seq.GetXY(0), geom.XY{0, 1})
+		expectXYEq(t, seq.GetXY(1), geom.XY{2, 3})
+		expectXYEq(t, seq.GetXY(2), geom.XY{4, 5})
 	})
 	t.Run("multilinestring", func(t *testing.T) {
 		seq := geomFromWKT(t, "MULTILINESTRING((0 0,0 10,10 0,0 0),(2 2,2 8,8 2,2 2))").MustAsMultiLineString().Coordinates()
 		expectIntEq(t, len(seq), 2)
 		expectIntEq(t, seq[0].Length(), 4)
-		expectXYEq(t, seq[0].GetXY(0), XY{0, 0})
-		expectXYEq(t, seq[0].GetXY(1), XY{0, 10})
-		expectXYEq(t, seq[0].GetXY(2), XY{10, 0})
-		expectXYEq(t, seq[0].GetXY(3), XY{0, 0})
+		expectXYEq(t, seq[0].GetXY(0), geom.XY{0, 0})
+		expectXYEq(t, seq[0].GetXY(1), geom.XY{0, 10})
+		expectXYEq(t, seq[0].GetXY(2), geom.XY{10, 0})
+		expectXYEq(t, seq[0].GetXY(3), geom.XY{0, 0})
 		expectIntEq(t, seq[1].Length(), 4)
-		expectXYEq(t, seq[1].GetXY(0), XY{2, 2})
-		expectXYEq(t, seq[1].GetXY(1), XY{2, 8})
-		expectXYEq(t, seq[1].GetXY(2), XY{8, 2})
-		expectXYEq(t, seq[1].GetXY(3), XY{2, 2})
+		expectXYEq(t, seq[1].GetXY(0), geom.XY{2, 2})
+		expectXYEq(t, seq[1].GetXY(1), geom.XY{2, 8})
+		expectXYEq(t, seq[1].GetXY(2), geom.XY{8, 2})
+		expectXYEq(t, seq[1].GetXY(3), geom.XY{2, 2})
 	})
 	t.Run("multipolygon", func(t *testing.T) {
 		seq := geomFromWKT(t, `
@@ -393,33 +393,33 @@ func TestCoordinatesSequence(t *testing.T) {
 
 		expectIntEq(t, len(seq[0]), 2)
 		expectIntEq(t, seq[0][0].Length(), 4)
-		expectXYEq(t, seq[0][0].GetXY(0), XY{0, 0})
-		expectXYEq(t, seq[0][0].GetXY(1), XY{0, 10})
-		expectXYEq(t, seq[0][0].GetXY(2), XY{10, 0})
-		expectXYEq(t, seq[0][0].GetXY(3), XY{0, 0})
+		expectXYEq(t, seq[0][0].GetXY(0), geom.XY{0, 0})
+		expectXYEq(t, seq[0][0].GetXY(1), geom.XY{0, 10})
+		expectXYEq(t, seq[0][0].GetXY(2), geom.XY{10, 0})
+		expectXYEq(t, seq[0][0].GetXY(3), geom.XY{0, 0})
 		expectIntEq(t, seq[0][1].Length(), 4)
-		expectXYEq(t, seq[0][1].GetXY(0), XY{2, 2})
-		expectXYEq(t, seq[0][1].GetXY(1), XY{2, 7})
-		expectXYEq(t, seq[0][1].GetXY(2), XY{7, 2})
-		expectXYEq(t, seq[0][1].GetXY(3), XY{2, 2})
+		expectXYEq(t, seq[0][1].GetXY(0), geom.XY{2, 2})
+		expectXYEq(t, seq[0][1].GetXY(1), geom.XY{2, 7})
+		expectXYEq(t, seq[0][1].GetXY(2), geom.XY{7, 2})
+		expectXYEq(t, seq[0][1].GetXY(3), geom.XY{2, 2})
 
 		expectIntEq(t, len(seq[1]), 2)
 		expectIntEq(t, seq[1][0].Length(), 4)
-		expectXYEq(t, seq[1][0].GetXY(0), XY{100, 100})
-		expectXYEq(t, seq[1][0].GetXY(1), XY{100, 110})
-		expectXYEq(t, seq[1][0].GetXY(2), XY{110, 100})
-		expectXYEq(t, seq[1][0].GetXY(3), XY{100, 100})
+		expectXYEq(t, seq[1][0].GetXY(0), geom.XY{100, 100})
+		expectXYEq(t, seq[1][0].GetXY(1), geom.XY{100, 110})
+		expectXYEq(t, seq[1][0].GetXY(2), geom.XY{110, 100})
+		expectXYEq(t, seq[1][0].GetXY(3), geom.XY{100, 100})
 		expectIntEq(t, seq[1][1].Length(), 4)
-		expectXYEq(t, seq[1][1].GetXY(0), XY{102, 102})
-		expectXYEq(t, seq[1][1].GetXY(1), XY{102, 107})
-		expectXYEq(t, seq[1][1].GetXY(2), XY{107, 102})
-		expectXYEq(t, seq[1][1].GetXY(3), XY{102, 102})
+		expectXYEq(t, seq[1][1].GetXY(0), geom.XY{102, 102})
+		expectXYEq(t, seq[1][1].GetXY(1), geom.XY{102, 107})
+		expectXYEq(t, seq[1][1].GetXY(2), geom.XY{107, 102})
+		expectXYEq(t, seq[1][1].GetXY(3), geom.XY{102, 102})
 	})
 }
 
 func TestTransformXY(t *testing.T) {
-	transform := func(in XY) XY {
-		return XY{in.X * 1.5, in.Y}
+	transform := func(in geom.XY) geom.XY {
+		return geom.XY{in.X * 1.5, in.Y}
 	}
 	for i, tt := range []struct {
 		wktIn, wktOut string
@@ -616,8 +616,8 @@ func TestSignedArea(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("input: %s", tc.input)
-			geom := geomFromWKT(t, tc.input)
-			got := geom.Area(SignedArea)
+			g := geomFromWKT(t, tc.input)
+			got := g.Area(geom.SignedArea)
 			if got != tc.expected {
 				t.Errorf("expected: %f, got: %f", tc.expected, got)
 			}
@@ -636,7 +636,7 @@ func TestTransformedArea(t *testing.T) {
 		{"MULTIPOLYGON(((0 0,1 0,0 1,0 0)),((2 2,3 2,2 3,2 2)))", 0.125},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := geomFromWKT(t, tt.wkt).Area(WithTransform(func(xy XY) XY {
+			got := geomFromWKT(t, tt.wkt).Area(geom.WithTransform(func(xy geom.XY) geom.XY {
 				xy.X *= 0.5
 				xy.Y *= 0.25
 				return xy
@@ -651,7 +651,7 @@ func TestTransformedArea(t *testing.T) {
 func TestTransformedAreaInvocationCount(t *testing.T) {
 	g := geomFromWKT(t, "POLYGON((0 0,0 1,1 0,0 0))")
 	var count int
-	g.Area(WithTransform(func(xy XY) XY {
+	g.Area(geom.WithTransform(func(xy geom.XY) geom.XY {
 		count++
 		return xy
 	}))
@@ -719,7 +719,7 @@ func TestCentroid(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := geomFromWKT(t, tt.input).Centroid()
 			want := geomFromWKT(t, tt.output)
-			if !ExactEquals(want, got.AsGeometry(), ToleranceXY(0.00000001)) {
+			if !geom.ExactEquals(want, got.AsGeometry(), geom.ToleranceXY(0.00000001)) {
 				t.Log(tt.input)
 				t.Errorf("got=%v want=%v", got.AsText(), tt.output)
 			}
@@ -731,7 +731,7 @@ func TestLineStringToMultiLineString(t *testing.T) {
 	ls := geomFromWKT(t, "LINESTRING(1 2,3 4,5 6)").MustAsLineString()
 	got := ls.AsMultiLineString()
 	want := geomFromWKT(t, "MULTILINESTRING((1 2,3 4,5 6))")
-	if !ExactEquals(got.AsGeometry(), want) {
+	if !geom.ExactEquals(got.AsGeometry(), want) {
 		t.Errorf("want=%v got=%v", want, got)
 	}
 }
@@ -885,161 +885,161 @@ func TestReverse(t *testing.T) {
 func TestForceCoordinatesType(t *testing.T) {
 	for i, tt := range []struct {
 		input  string
-		ct     CoordinatesType
+		ct     geom.CoordinatesType
 		output string
 	}{
-		{"POINT EMPTY", DimXY, "POINT EMPTY"},
-		{"POINT EMPTY", DimXYZ, "POINT Z EMPTY"},
-		{"POINT EMPTY", DimXYM, "POINT M EMPTY"},
-		{"POINT EMPTY", DimXYZM, "POINT ZM EMPTY"},
-		{"POINT Z EMPTY", DimXY, "POINT EMPTY"},
-		{"POINT Z EMPTY", DimXYZ, "POINT Z EMPTY"},
-		{"POINT Z EMPTY", DimXYM, "POINT M EMPTY"},
-		{"POINT Z EMPTY", DimXYZM, "POINT ZM EMPTY"},
-		{"POINT M EMPTY", DimXY, "POINT EMPTY"},
-		{"POINT M EMPTY", DimXYZ, "POINT Z EMPTY"},
-		{"POINT M EMPTY", DimXYM, "POINT M EMPTY"},
-		{"POINT M EMPTY", DimXYZM, "POINT ZM EMPTY"},
-		{"POINT ZM EMPTY", DimXY, "POINT EMPTY"},
-		{"POINT ZM EMPTY", DimXYZ, "POINT Z EMPTY"},
-		{"POINT ZM EMPTY", DimXYM, "POINT M EMPTY"},
-		{"POINT ZM EMPTY", DimXYZM, "POINT ZM EMPTY"},
+		{"POINT EMPTY", geom.DimXY, "POINT EMPTY"},
+		{"POINT EMPTY", geom.DimXYZ, "POINT Z EMPTY"},
+		{"POINT EMPTY", geom.DimXYM, "POINT M EMPTY"},
+		{"POINT EMPTY", geom.DimXYZM, "POINT ZM EMPTY"},
+		{"POINT Z EMPTY", geom.DimXY, "POINT EMPTY"},
+		{"POINT Z EMPTY", geom.DimXYZ, "POINT Z EMPTY"},
+		{"POINT Z EMPTY", geom.DimXYM, "POINT M EMPTY"},
+		{"POINT Z EMPTY", geom.DimXYZM, "POINT ZM EMPTY"},
+		{"POINT M EMPTY", geom.DimXY, "POINT EMPTY"},
+		{"POINT M EMPTY", geom.DimXYZ, "POINT Z EMPTY"},
+		{"POINT M EMPTY", geom.DimXYM, "POINT M EMPTY"},
+		{"POINT M EMPTY", geom.DimXYZM, "POINT ZM EMPTY"},
+		{"POINT ZM EMPTY", geom.DimXY, "POINT EMPTY"},
+		{"POINT ZM EMPTY", geom.DimXYZ, "POINT Z EMPTY"},
+		{"POINT ZM EMPTY", geom.DimXYM, "POINT M EMPTY"},
+		{"POINT ZM EMPTY", geom.DimXYZM, "POINT ZM EMPTY"},
 
-		{"POINT(1 2)", DimXY, "POINT(1 2)"},
-		{"POINT(1 2)", DimXYZ, "POINT Z (1 2 0)"},
-		{"POINT(1 2)", DimXYM, "POINT M (1 2 0)"},
-		{"POINT(1 2)", DimXYZM, "POINT ZM (1 2 0 0)"},
-		{"POINT Z (1 2 3)", DimXY, "POINT(1 2)"},
-		{"POINT Z (1 2 3)", DimXYZ, "POINT Z (1 2 3)"},
-		{"POINT Z (1 2 3)", DimXYM, "POINT M (1 2 0)"},
-		{"POINT Z (1 2 3)", DimXYZM, "POINT ZM (1 2 3 0)"},
-		{"POINT M (1 2 4)", DimXY, "POINT(1 2)"},
-		{"POINT M (1 2 4)", DimXYZ, "POINT Z (1 2 0)"},
-		{"POINT M (1 2 4)", DimXYM, "POINT M (1 2 4)"},
-		{"POINT M (1 2 4)", DimXYZM, "POINT ZM (1 2 0 4)"},
-		{"POINT ZM (1 2 3 4)", DimXY, "POINT(1 2)"},
-		{"POINT ZM (1 2 3 4)", DimXYZ, "POINT Z (1 2 3)"},
-		{"POINT ZM (1 2 3 4)", DimXYM, "POINT M (1 2 4)"},
-		{"POINT ZM (1 2 3 4)", DimXYZM, "POINT ZM (1 2 3 4)"},
+		{"POINT(1 2)", geom.DimXY, "POINT(1 2)"},
+		{"POINT(1 2)", geom.DimXYZ, "POINT Z (1 2 0)"},
+		{"POINT(1 2)", geom.DimXYM, "POINT M (1 2 0)"},
+		{"POINT(1 2)", geom.DimXYZM, "POINT ZM (1 2 0 0)"},
+		{"POINT Z (1 2 3)", geom.DimXY, "POINT(1 2)"},
+		{"POINT Z (1 2 3)", geom.DimXYZ, "POINT Z (1 2 3)"},
+		{"POINT Z (1 2 3)", geom.DimXYM, "POINT M (1 2 0)"},
+		{"POINT Z (1 2 3)", geom.DimXYZM, "POINT ZM (1 2 3 0)"},
+		{"POINT M (1 2 4)", geom.DimXY, "POINT(1 2)"},
+		{"POINT M (1 2 4)", geom.DimXYZ, "POINT Z (1 2 0)"},
+		{"POINT M (1 2 4)", geom.DimXYM, "POINT M (1 2 4)"},
+		{"POINT M (1 2 4)", geom.DimXYZM, "POINT ZM (1 2 0 4)"},
+		{"POINT ZM (1 2 3 4)", geom.DimXY, "POINT(1 2)"},
+		{"POINT ZM (1 2 3 4)", geom.DimXYZ, "POINT Z (1 2 3)"},
+		{"POINT ZM (1 2 3 4)", geom.DimXYM, "POINT M (1 2 4)"},
+		{"POINT ZM (1 2 3 4)", geom.DimXYZM, "POINT ZM (1 2 3 4)"},
 
-		{"LINESTRING(1 2,3 4)", DimXY, "LINESTRING(1 2,3 4)"},
-		{"LINESTRING(1 2,3 4)", DimXYZ, "LINESTRING Z (1 2 0,3 4 0)"},
-		{"LINESTRING(1 2,3 4)", DimXYM, "LINESTRING M (1 2 0,3 4 0)"},
-		{"LINESTRING(1 2,3 4)", DimXYZM, "LINESTRING ZM (1 2 0 0,3 4 0 0)"},
-		{"LINESTRING Z (1 2 3,4 5 6)", DimXY, "LINESTRING(1 2,4 5)"},
-		{"LINESTRING Z (1 2 3,4 5 6)", DimXYZ, "LINESTRING Z (1 2 3,4 5 6)"},
-		{"LINESTRING Z (1 2 3,4 5 6)", DimXYM, "LINESTRING M (1 2 0,4 5 0)"},
-		{"LINESTRING Z (1 2 3,4 5 6)", DimXYZM, "LINESTRING ZM (1 2 3 0,4 5 6 0)"},
-		{"LINESTRING M (1 2 3,4 5 6)", DimXY, "LINESTRING(1 2,4 5)"},
-		{"LINESTRING M (1 2 3,4 5 6)", DimXYZ, "LINESTRING Z (1 2 0,4 5 0)"},
-		{"LINESTRING M (1 2 3,4 5 6)", DimXYM, "LINESTRING M (1 2 3,4 5 6)"},
-		{"LINESTRING M (1 2 3,4 5 6)", DimXYZM, "LINESTRING ZM (1 2 0 3,4 5 0 6)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", DimXY, "LINESTRING(1 2,5 6)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", DimXYZ, "LINESTRING Z (1 2 3,5 6 7)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", DimXYM, "LINESTRING M (1 2 4,5 6 8)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", DimXYZM, "LINESTRING ZM (1 2 3 4,5 6 7 8)"},
+		{"LINESTRING(1 2,3 4)", geom.DimXY, "LINESTRING(1 2,3 4)"},
+		{"LINESTRING(1 2,3 4)", geom.DimXYZ, "LINESTRING Z (1 2 0,3 4 0)"},
+		{"LINESTRING(1 2,3 4)", geom.DimXYM, "LINESTRING M (1 2 0,3 4 0)"},
+		{"LINESTRING(1 2,3 4)", geom.DimXYZM, "LINESTRING ZM (1 2 0 0,3 4 0 0)"},
+		{"LINESTRING Z (1 2 3,4 5 6)", geom.DimXY, "LINESTRING(1 2,4 5)"},
+		{"LINESTRING Z (1 2 3,4 5 6)", geom.DimXYZ, "LINESTRING Z (1 2 3,4 5 6)"},
+		{"LINESTRING Z (1 2 3,4 5 6)", geom.DimXYM, "LINESTRING M (1 2 0,4 5 0)"},
+		{"LINESTRING Z (1 2 3,4 5 6)", geom.DimXYZM, "LINESTRING ZM (1 2 3 0,4 5 6 0)"},
+		{"LINESTRING M (1 2 3,4 5 6)", geom.DimXY, "LINESTRING(1 2,4 5)"},
+		{"LINESTRING M (1 2 3,4 5 6)", geom.DimXYZ, "LINESTRING Z (1 2 0,4 5 0)"},
+		{"LINESTRING M (1 2 3,4 5 6)", geom.DimXYM, "LINESTRING M (1 2 3,4 5 6)"},
+		{"LINESTRING M (1 2 3,4 5 6)", geom.DimXYZM, "LINESTRING ZM (1 2 0 3,4 5 0 6)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", geom.DimXY, "LINESTRING(1 2,5 6)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", geom.DimXYZ, "LINESTRING Z (1 2 3,5 6 7)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", geom.DimXYM, "LINESTRING M (1 2 4,5 6 8)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8)", geom.DimXYZM, "LINESTRING ZM (1 2 3 4,5 6 7 8)"},
 
-		{"LINESTRING(1 2,3 4,5 6)", DimXY, "LINESTRING(1 2,3 4,5 6)"},
-		{"LINESTRING(1 2,3 4,5 6)", DimXYZ, "LINESTRING Z (1 2 0,3 4 0,5 6 0)"},
-		{"LINESTRING(1 2,3 4,5 6)", DimXYM, "LINESTRING M (1 2 0,3 4 0,5 6 0)"},
-		{"LINESTRING(1 2,3 4,5 6)", DimXYZM, "LINESTRING ZM (1 2 0 0,3 4 0 0,5 6 0 0)"},
-		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", DimXY, "LINESTRING(1 2,4 5,7 8)"},
-		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", DimXYZ, "LINESTRING Z (1 2 3,4 5 6,7 8 9)"},
-		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", DimXYM, "LINESTRING M (1 2 0,4 5 0,7 8 0)"},
-		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", DimXYZM, "LINESTRING ZM (1 2 3 0,4 5 6 0,7 8 9 0)"},
-		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", DimXY, "LINESTRING(1 2,4 5,7 8)"},
-		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", DimXYZ, "LINESTRING Z (1 2 0,4 5 0,7 8 0)"},
-		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", DimXYM, "LINESTRING M (1 2 3,4 5 6,7 8 9)"},
-		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", DimXYZM, "LINESTRING ZM (1 2 0 3,4 5 0 6,7 8 0 9)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXY, "LINESTRING(1 2,5 6,9 10)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXYZ, "LINESTRING Z (1 2 3,5 6 7,9 10 11)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXYM, "LINESTRING M (1 2 4,5 6 8,9 10 12)"},
-		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXYZM, "LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)"},
+		{"LINESTRING(1 2,3 4,5 6)", geom.DimXY, "LINESTRING(1 2,3 4,5 6)"},
+		{"LINESTRING(1 2,3 4,5 6)", geom.DimXYZ, "LINESTRING Z (1 2 0,3 4 0,5 6 0)"},
+		{"LINESTRING(1 2,3 4,5 6)", geom.DimXYM, "LINESTRING M (1 2 0,3 4 0,5 6 0)"},
+		{"LINESTRING(1 2,3 4,5 6)", geom.DimXYZM, "LINESTRING ZM (1 2 0 0,3 4 0 0,5 6 0 0)"},
+		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", geom.DimXY, "LINESTRING(1 2,4 5,7 8)"},
+		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", geom.DimXYZ, "LINESTRING Z (1 2 3,4 5 6,7 8 9)"},
+		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", geom.DimXYM, "LINESTRING M (1 2 0,4 5 0,7 8 0)"},
+		{"LINESTRING Z (1 2 3,4 5 6,7 8 9)", geom.DimXYZM, "LINESTRING ZM (1 2 3 0,4 5 6 0,7 8 9 0)"},
+		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", geom.DimXY, "LINESTRING(1 2,4 5,7 8)"},
+		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", geom.DimXYZ, "LINESTRING Z (1 2 0,4 5 0,7 8 0)"},
+		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", geom.DimXYM, "LINESTRING M (1 2 3,4 5 6,7 8 9)"},
+		{"LINESTRING M (1 2 3,4 5 6,7 8 9)", geom.DimXYZM, "LINESTRING ZM (1 2 0 3,4 5 0 6,7 8 0 9)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXY, "LINESTRING(1 2,5 6,9 10)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXYZ, "LINESTRING Z (1 2 3,5 6 7,9 10 11)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXYM, "LINESTRING M (1 2 4,5 6 8,9 10 12)"},
+		{"LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXYZM, "LINESTRING ZM (1 2 3 4,5 6 7 8,9 10 11 12)"},
 
-		{"POLYGON((0 0,0 1,1 0,0 0))", DimXY, "POLYGON((0 0,0 1,1 0,0 0))"},
-		{"POLYGON((0 0,0 1,1 0,0 0))", DimXYZ, "POLYGON Z ((0 0 0,0 1 0,1 0 0,0 0 0))"},
-		{"POLYGON((0 0,0 1,1 0,0 0))", DimXYM, "POLYGON M ((0 0 0,0 1 0,1 0 0,0 0 0))"},
-		{"POLYGON((0 0,0 1,1 0,0 0))", DimXYZM, "POLYGON ZM ((0 0 0 0,0 1 0 0,1 0 0 0,0 0 0 0))"},
-		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXY, "POLYGON((0 0,1 0,0 1,0 0))"},
-		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXYZ, "POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))"},
-		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXYM, "POLYGON M ((0 0 0,1 0 0,0 1 0,0 0 0))"},
-		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXYZM, "POLYGON ZM ((0 0 3 0,1 0 6 0,0 1 9 0,0 0 3 0))"},
-		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXY, "POLYGON((0 0,1 0,0 1,0 0))"},
-		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXYZ, "POLYGON Z ((0 0 0,1 0 0,0 1 0,0 0 0))"},
-		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXYM, "POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))"},
-		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", DimXYZM, "POLYGON ZM ((0 0 0 3,1 0 0 6,0 1 0 9,0 0 0 3))"},
-		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", DimXY, "POLYGON((0 0,1 0,0 1,0 0))"},
-		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", DimXYZ, "POLYGON Z ((0 0 3,1 0 7,0 1 11,0 0 3))"},
-		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", DimXYM, "POLYGON M ((0 0 4,1 0 8,0 1 12,0 0 4))"},
-		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", DimXYZM, "POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))"},
+		{"POLYGON((0 0,0 1,1 0,0 0))", geom.DimXY, "POLYGON((0 0,0 1,1 0,0 0))"},
+		{"POLYGON((0 0,0 1,1 0,0 0))", geom.DimXYZ, "POLYGON Z ((0 0 0,0 1 0,1 0 0,0 0 0))"},
+		{"POLYGON((0 0,0 1,1 0,0 0))", geom.DimXYM, "POLYGON M ((0 0 0,0 1 0,1 0 0,0 0 0))"},
+		{"POLYGON((0 0,0 1,1 0,0 0))", geom.DimXYZM, "POLYGON ZM ((0 0 0 0,0 1 0 0,1 0 0 0,0 0 0 0))"},
+		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXY, "POLYGON((0 0,1 0,0 1,0 0))"},
+		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXYZ, "POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))"},
+		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXYM, "POLYGON M ((0 0 0,1 0 0,0 1 0,0 0 0))"},
+		{"POLYGON Z ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXYZM, "POLYGON ZM ((0 0 3 0,1 0 6 0,0 1 9 0,0 0 3 0))"},
+		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXY, "POLYGON((0 0,1 0,0 1,0 0))"},
+		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXYZ, "POLYGON Z ((0 0 0,1 0 0,0 1 0,0 0 0))"},
+		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXYM, "POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))"},
+		{"POLYGON M ((0 0 3,1 0 6,0 1 9,0 0 3))", geom.DimXYZM, "POLYGON ZM ((0 0 0 3,1 0 0 6,0 1 0 9,0 0 0 3))"},
+		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", geom.DimXY, "POLYGON((0 0,1 0,0 1,0 0))"},
+		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", geom.DimXYZ, "POLYGON Z ((0 0 3,1 0 7,0 1 11,0 0 3))"},
+		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", geom.DimXYM, "POLYGON M ((0 0 4,1 0 8,0 1 12,0 0 4))"},
+		{"POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))", geom.DimXYZM, "POLYGON ZM ((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4))"},
 
-		{"MULTIPOINT(1 2,3 4,5 6)", DimXY, "MULTIPOINT(1 2,3 4,5 6)"},
-		{"MULTIPOINT(1 2,3 4,5 6)", DimXYZ, "MULTIPOINT Z (1 2 0,3 4 0,5 6 0)"},
-		{"MULTIPOINT(1 2,3 4,5 6)", DimXYM, "MULTIPOINT M (1 2 0,3 4 0,5 6 0)"},
-		{"MULTIPOINT(1 2,3 4,5 6)", DimXYZM, "MULTIPOINT ZM (1 2 0 0,3 4 0 0,5 6 0 0)"},
-		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", DimXY, "MULTIPOINT(1 2,4 5,7 8)"},
-		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", DimXYZ, "MULTIPOINT Z (1 2 3,4 5 6,7 8 9)"},
-		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", DimXYM, "MULTIPOINT M (1 2 0,4 5 0,7 8 0)"},
-		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", DimXYZM, "MULTIPOINT ZM (1 2 3 0,4 5 6 0,7 8 9 0)"},
-		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", DimXY, "MULTIPOINT(1 2,4 5,7 8)"},
-		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", DimXYZ, "MULTIPOINT Z (1 2 0,4 5 0,7 8 0)"},
-		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", DimXYM, "MULTIPOINT M (1 2 3,4 5 6,7 8 9)"},
-		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", DimXYZM, "MULTIPOINT ZM (1 2 0 3,4 5 0 6,7 8 0 9)"},
-		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXY, "MULTIPOINT(1 2,5 6,9 10)"},
-		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXYZ, "MULTIPOINT Z (1 2 3,5 6 7,9 10 11)"},
-		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXYM, "MULTIPOINT M (1 2 4,5 6 8,9 10 12)"},
-		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", DimXYZM, "MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)"},
+		{"MULTIPOINT(1 2,3 4,5 6)", geom.DimXY, "MULTIPOINT(1 2,3 4,5 6)"},
+		{"MULTIPOINT(1 2,3 4,5 6)", geom.DimXYZ, "MULTIPOINT Z (1 2 0,3 4 0,5 6 0)"},
+		{"MULTIPOINT(1 2,3 4,5 6)", geom.DimXYM, "MULTIPOINT M (1 2 0,3 4 0,5 6 0)"},
+		{"MULTIPOINT(1 2,3 4,5 6)", geom.DimXYZM, "MULTIPOINT ZM (1 2 0 0,3 4 0 0,5 6 0 0)"},
+		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", geom.DimXY, "MULTIPOINT(1 2,4 5,7 8)"},
+		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", geom.DimXYZ, "MULTIPOINT Z (1 2 3,4 5 6,7 8 9)"},
+		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", geom.DimXYM, "MULTIPOINT M (1 2 0,4 5 0,7 8 0)"},
+		{"MULTIPOINT Z (1 2 3,4 5 6,7 8 9)", geom.DimXYZM, "MULTIPOINT ZM (1 2 3 0,4 5 6 0,7 8 9 0)"},
+		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", geom.DimXY, "MULTIPOINT(1 2,4 5,7 8)"},
+		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", geom.DimXYZ, "MULTIPOINT Z (1 2 0,4 5 0,7 8 0)"},
+		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", geom.DimXYM, "MULTIPOINT M (1 2 3,4 5 6,7 8 9)"},
+		{"MULTIPOINT M (1 2 3,4 5 6,7 8 9)", geom.DimXYZM, "MULTIPOINT ZM (1 2 0 3,4 5 0 6,7 8 0 9)"},
+		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXY, "MULTIPOINT(1 2,5 6,9 10)"},
+		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXYZ, "MULTIPOINT Z (1 2 3,5 6 7,9 10 11)"},
+		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXYM, "MULTIPOINT M (1 2 4,5 6 8,9 10 12)"},
+		{"MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)", geom.DimXYZM, "MULTIPOINT ZM (1 2 3 4,5 6 7 8,9 10 11 12)"},
 
-		{"MULTILINESTRING((1 2,3 4,5 6))", DimXY, "MULTILINESTRING((1 2,3 4,5 6))"},
-		{"MULTILINESTRING((1 2,3 4,5 6))", DimXYZ, "MULTILINESTRING Z ((1 2 0,3 4 0,5 6 0))"},
-		{"MULTILINESTRING((1 2,3 4,5 6))", DimXYM, "MULTILINESTRING M ((1 2 0,3 4 0,5 6 0))"},
-		{"MULTILINESTRING((1 2,3 4,5 6))", DimXYZM, "MULTILINESTRING ZM ((1 2 0 0,3 4 0 0,5 6 0 0))"},
-		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", DimXY, "MULTILINESTRING((1 2,4 5,7 8))"},
-		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", DimXYZ, "MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))"},
-		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", DimXYM, "MULTILINESTRING M ((1 2 0,4 5 0,7 8 0))"},
-		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", DimXYZM, "MULTILINESTRING ZM ((1 2 3 0,4 5 6 0,7 8 9 0))"},
-		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", DimXY, "MULTILINESTRING((1 2,4 5,7 8))"},
-		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", DimXYZ, "MULTILINESTRING Z ((1 2 0,4 5 0,7 8 0))"},
-		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", DimXYM, "MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))"},
-		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", DimXYZM, "MULTILINESTRING ZM ((1 2 0 3,4 5 0 6,7 8 0 9))"},
-		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", DimXY, "MULTILINESTRING((1 2,5 6,9 10))"},
-		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", DimXYZ, "MULTILINESTRING Z ((1 2 3,5 6 7,9 10 11))"},
-		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", DimXYM, "MULTILINESTRING M ((1 2 4,5 6 8,9 10 12))"},
-		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", DimXYZM, "MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))"},
+		{"MULTILINESTRING((1 2,3 4,5 6))", geom.DimXY, "MULTILINESTRING((1 2,3 4,5 6))"},
+		{"MULTILINESTRING((1 2,3 4,5 6))", geom.DimXYZ, "MULTILINESTRING Z ((1 2 0,3 4 0,5 6 0))"},
+		{"MULTILINESTRING((1 2,3 4,5 6))", geom.DimXYM, "MULTILINESTRING M ((1 2 0,3 4 0,5 6 0))"},
+		{"MULTILINESTRING((1 2,3 4,5 6))", geom.DimXYZM, "MULTILINESTRING ZM ((1 2 0 0,3 4 0 0,5 6 0 0))"},
+		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", geom.DimXY, "MULTILINESTRING((1 2,4 5,7 8))"},
+		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", geom.DimXYZ, "MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))"},
+		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", geom.DimXYM, "MULTILINESTRING M ((1 2 0,4 5 0,7 8 0))"},
+		{"MULTILINESTRING Z ((1 2 3,4 5 6,7 8 9))", geom.DimXYZM, "MULTILINESTRING ZM ((1 2 3 0,4 5 6 0,7 8 9 0))"},
+		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", geom.DimXY, "MULTILINESTRING((1 2,4 5,7 8))"},
+		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", geom.DimXYZ, "MULTILINESTRING Z ((1 2 0,4 5 0,7 8 0))"},
+		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", geom.DimXYM, "MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))"},
+		{"MULTILINESTRING M ((1 2 3,4 5 6,7 8 9))", geom.DimXYZM, "MULTILINESTRING ZM ((1 2 0 3,4 5 0 6,7 8 0 9))"},
+		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", geom.DimXY, "MULTILINESTRING((1 2,5 6,9 10))"},
+		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", geom.DimXYZ, "MULTILINESTRING Z ((1 2 3,5 6 7,9 10 11))"},
+		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", geom.DimXYM, "MULTILINESTRING M ((1 2 4,5 6 8,9 10 12))"},
+		{"MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))", geom.DimXYZM, "MULTILINESTRING ZM ((1 2 3 4,5 6 7 8,9 10 11 12))"},
 
-		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", DimXY, "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))"},
-		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", DimXYZ, "MULTIPOLYGON Z (((0 0 0,0 1 0,1 0 0,0 0 0)))"},
-		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", DimXYM, "MULTIPOLYGON M (((0 0 0,0 1 0,1 0 0,0 0 0)))"},
-		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", DimXYZM, "MULTIPOLYGON ZM (((0 0 0 0,0 1 0 0,1 0 0 0,0 0 0 0)))"},
-		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXY, "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))"},
-		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXYZ, "MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))"},
-		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXYM, "MULTIPOLYGON M (((0 0 0,1 0 0,0 1 0,0 0 0)))"},
-		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXYZM, "MULTIPOLYGON ZM (((0 0 3 0,1 0 6 0,0 1 9 0,0 0 3 0)))"},
-		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXY, "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))"},
-		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXYZ, "MULTIPOLYGON Z (((0 0 0,1 0 0,0 1 0,0 0 0)))"},
-		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXYM, "MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))"},
-		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", DimXYZM, "MULTIPOLYGON ZM (((0 0 0 3,1 0 0 6,0 1 0 9,0 0 0 3)))"},
-		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", DimXY, "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))"},
-		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", DimXYZ, "MULTIPOLYGON Z (((0 0 3,1 0 7,0 1 11,0 0 3)))"},
-		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", DimXYM, "MULTIPOLYGON M (((0 0 4,1 0 8,0 1 12,0 0 4)))"},
-		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", DimXYZM, "MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))"},
+		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", geom.DimXY, "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))"},
+		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", geom.DimXYZ, "MULTIPOLYGON Z (((0 0 0,0 1 0,1 0 0,0 0 0)))"},
+		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", geom.DimXYM, "MULTIPOLYGON M (((0 0 0,0 1 0,1 0 0,0 0 0)))"},
+		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", geom.DimXYZM, "MULTIPOLYGON ZM (((0 0 0 0,0 1 0 0,1 0 0 0,0 0 0 0)))"},
+		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXY, "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))"},
+		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXYZ, "MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))"},
+		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXYM, "MULTIPOLYGON M (((0 0 0,1 0 0,0 1 0,0 0 0)))"},
+		{"MULTIPOLYGON Z (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXYZM, "MULTIPOLYGON ZM (((0 0 3 0,1 0 6 0,0 1 9 0,0 0 3 0)))"},
+		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXY, "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))"},
+		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXYZ, "MULTIPOLYGON Z (((0 0 0,1 0 0,0 1 0,0 0 0)))"},
+		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXYM, "MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))"},
+		{"MULTIPOLYGON M (((0 0 3,1 0 6,0 1 9,0 0 3)))", geom.DimXYZM, "MULTIPOLYGON ZM (((0 0 0 3,1 0 0 6,0 1 0 9,0 0 0 3)))"},
+		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", geom.DimXY, "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))"},
+		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", geom.DimXYZ, "MULTIPOLYGON Z (((0 0 3,1 0 7,0 1 11,0 0 3)))"},
+		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", geom.DimXYM, "MULTIPOLYGON M (((0 0 4,1 0 8,0 1 12,0 0 4)))"},
+		{"MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))", geom.DimXYZM, "MULTIPOLYGON ZM (((0 0 3 4,1 0 7 8,0 1 11 12,0 0 3 4)))"},
 
-		{"GEOMETRYCOLLECTION(POINT(1 2))", DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
-		{"GEOMETRYCOLLECTION(POINT(1 2))", DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 0))"},
-		{"GEOMETRYCOLLECTION(POINT(1 2))", DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 0))"},
-		{"GEOMETRYCOLLECTION(POINT(1 2))", DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 0 0))"},
-		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
-		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 3))"},
-		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 0))"},
-		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 0))"},
-		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
-		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 0))"},
-		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 4))"},
-		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 0 4))"},
-		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
-		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 3))"},
-		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 4))"},
-		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))"},
+		{"GEOMETRYCOLLECTION(POINT(1 2))", geom.DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
+		{"GEOMETRYCOLLECTION(POINT(1 2))", geom.DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 0))"},
+		{"GEOMETRYCOLLECTION(POINT(1 2))", geom.DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 0))"},
+		{"GEOMETRYCOLLECTION(POINT(1 2))", geom.DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 0 0))"},
+		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", geom.DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
+		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", geom.DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 3))"},
+		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", geom.DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 0))"},
+		{"GEOMETRYCOLLECTION Z (POINT Z (1 2 3))", geom.DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 0))"},
+		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", geom.DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
+		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", geom.DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 0))"},
+		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", geom.DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 4))"},
+		{"GEOMETRYCOLLECTION M (POINT M (1 2 4))", geom.DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 0 4))"},
+		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", geom.DimXY, "GEOMETRYCOLLECTION(POINT(1 2))"},
+		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", geom.DimXYZ, "GEOMETRYCOLLECTION Z (POINT Z (1 2 3))"},
+		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", geom.DimXYM, "GEOMETRYCOLLECTION M (POINT M (1 2 4))"},
+		{"GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))", geom.DimXYZM, "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4))"},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log("input", tt.input)
@@ -1616,7 +1616,7 @@ func TestPolygonDumpRings(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			input := geomFromWKT(t, tc.inputWKT).MustAsPolygon()
-			wantRings := make([]LineString, len(tc.wantRingWKTs))
+			wantRings := make([]geom.LineString, len(tc.wantRingWKTs))
 			for j, wantRingWKT := range tc.wantRingWKTs {
 				wantRings[j] = geomFromWKT(t, wantRingWKT).MustAsLineString()
 			}

--- a/geom/dump_coordinates_test.go
+++ b/geom/dump_coordinates_test.go
@@ -3,54 +3,54 @@ package geom_test
 import (
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestDumpCoordinatesPoint(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        Sequence
+		want        geom.Sequence
 	}{
 		{
 			description: "empty",
 			inputWKT:    "POINT EMPTY",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "empty z",
 			inputWKT:    "POINT Z EMPTY",
-			want:        NewSequence(nil, DimXYZ),
+			want:        geom.NewSequence(nil, geom.DimXYZ),
 		},
 		{
 			description: "empty m",
 			inputWKT:    "POINT M EMPTY",
-			want:        NewSequence(nil, DimXYM),
+			want:        geom.NewSequence(nil, geom.DimXYM),
 		},
 		{
 			description: "empty zm",
 			inputWKT:    "POINT ZM EMPTY",
-			want:        NewSequence(nil, DimXYZM),
+			want:        geom.NewSequence(nil, geom.DimXYZM),
 		},
 		{
 			description: "non-empty",
 			inputWKT:    "POINT(1 2)",
-			want:        NewSequence([]float64{1, 2}, DimXY),
+			want:        geom.NewSequence([]float64{1, 2}, geom.DimXY),
 		},
 		{
 			description: "non-empty z",
 			inputWKT:    "POINT Z(1 2 3)",
-			want:        NewSequence([]float64{1, 2, 3}, DimXYZ),
+			want:        geom.NewSequence([]float64{1, 2, 3}, geom.DimXYZ),
 		},
 		{
 			description: "non-empty m",
 			inputWKT:    "POINT M(1 2 3)",
-			want:        NewSequence([]float64{1, 2, 3}, DimXYM),
+			want:        geom.NewSequence([]float64{1, 2, 3}, geom.DimXYM),
 		},
 		{
 			description: "non-empty zm",
 			inputWKT:    "POINT ZM(1 2 3 4)",
-			want:        NewSequence([]float64{1, 2, 3, 4}, DimXYZM),
+			want:        geom.NewSequence([]float64{1, 2, 3, 4}, geom.DimXYZM),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -64,47 +64,47 @@ func TestDumpCoordinatesMultiLineString(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        Sequence
+		want        geom.Sequence
 	}{
 		{
 			description: "empty",
 			inputWKT:    "MULTILINESTRING EMPTY",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "contains empty LineString",
 			inputWKT:    "MULTILINESTRING(EMPTY)",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "single non-empty LineString",
 			inputWKT:    "MULTILINESTRING((1 2,3 4))",
-			want:        NewSequence([]float64{1, 2, 3, 4}, DimXY),
+			want:        geom.NewSequence([]float64{1, 2, 3, 4}, geom.DimXY),
 		},
 		{
 			description: "multiple non-empty LineStrings",
 			inputWKT:    "MULTILINESTRING((1 2,3 4),(5 6,7 8))",
-			want:        NewSequence([]float64{1, 2, 3, 4, 5, 6, 7, 8}, DimXY),
+			want:        geom.NewSequence([]float64{1, 2, 3, 4, 5, 6, 7, 8}, geom.DimXY),
 		},
 		{
 			description: "mix of empty and non-empty LineStrings",
 			inputWKT:    "MULTILINESTRING(EMPTY,(1 2,3 4))",
-			want:        NewSequence([]float64{1, 2, 3, 4}, DimXY),
+			want:        geom.NewSequence([]float64{1, 2, 3, 4}, geom.DimXY),
 		},
 		{
 			description: "Z coordinates",
 			inputWKT:    "MULTILINESTRING Z((1 2 3,3 4 5))",
-			want:        NewSequence([]float64{1, 2, 3, 3, 4, 5}, DimXYZ),
+			want:        geom.NewSequence([]float64{1, 2, 3, 3, 4, 5}, geom.DimXYZ),
 		},
 		{
 			description: "M coordinates",
 			inputWKT:    "MULTILINESTRING M((1 2 3,3 4 5))",
-			want:        NewSequence([]float64{1, 2, 3, 3, 4, 5}, DimXYM),
+			want:        geom.NewSequence([]float64{1, 2, 3, 3, 4, 5}, geom.DimXYM),
 		},
 		{
 			description: "ZM coordinates",
 			inputWKT:    "MULTILINESTRING ZM((1 2 3 4,3 4 5 6))",
-			want:        NewSequence([]float64{1, 2, 3, 4, 3, 4, 5, 6}, DimXYZM),
+			want:        geom.NewSequence([]float64{1, 2, 3, 4, 3, 4, 5, 6}, geom.DimXYZM),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -118,27 +118,27 @@ func TestDumpCoordinatesPolygon(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        Sequence
+		want        geom.Sequence
 	}{
 		{
 			description: "empty",
 			inputWKT:    "POLYGON EMPTY",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "contains single ring",
 			inputWKT:    "POLYGON((0 0,0 1,1 0,0 0))",
-			want:        NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0}, DimXY),
+			want:        geom.NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0}, geom.DimXY),
 		},
 		{
 			description: "multiple rings",
 			inputWKT:    "POLYGON((0 0,0 10,10 0,0 0),(1 1,1 2,2 2,2 1,1 1))",
-			want:        NewSequence([]float64{0, 0, 0, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1}, DimXY),
+			want:        geom.NewSequence([]float64{0, 0, 0, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1}, geom.DimXY),
 		},
 		{
 			description: "Z coordinates",
 			inputWKT:    "POLYGON Z((0 0 -1,0 10 -1,10 0 -1,0 0 -1),(1 1 -1,1 2 -1,2 2 -1,2 1 -1,1 1 -1))",
-			want: NewSequence([]float64{
+			want: geom.NewSequence([]float64{
 				0, 0, -1,
 				0, 10, -1,
 				10, 0, -1,
@@ -148,17 +148,17 @@ func TestDumpCoordinatesPolygon(t *testing.T) {
 				2, 2, -1,
 				2, 1, -1,
 				1, 1, -1,
-			}, DimXYZ),
+			}, geom.DimXYZ),
 		},
 		{
 			description: "M coordinates",
 			inputWKT:    "POLYGON M((0 0 10,0 1 10,1 0 10,0 0 10))",
-			want:        NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, DimXYM),
+			want:        geom.NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, geom.DimXYM),
 		},
 		{
 			description: "ZM coordinates",
 			inputWKT:    "POLYGON ZM((0 0 10 20,0 1 10 20,1 0 10 20,0 0 10 20))",
-			want:        NewSequence([]float64{0, 0, 10, 20, 0, 1, 10, 20, 1, 0, 10, 20, 0, 0, 10, 20}, DimXYZM),
+			want:        geom.NewSequence([]float64{0, 0, 10, 20, 0, 1, 10, 20, 1, 0, 10, 20, 0, 0, 10, 20}, geom.DimXYZM),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -172,47 +172,47 @@ func TestDumpCoordinatesMultiPolygon(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        Sequence
+		want        geom.Sequence
 	}{
 		{
 			description: "empty",
 			inputWKT:    "MULTIPOLYGON EMPTY",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "multi polygon with empty polygon",
 			inputWKT:    "MULTIPOLYGON(EMPTY)",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "contains single ring",
 			inputWKT:    "MULTIPOLYGON(((0 0,0 1,1 0,0 0)))",
-			want:        NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0}, DimXY),
+			want:        geom.NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0}, geom.DimXY),
 		},
 		{
 			description: "multiple rings in a single polygon",
 			inputWKT:    "MULTIPOLYGON(((0 0,0 10,10 0,0 0),(1 1,1 2,2 2,2 1,1 1)))",
-			want:        NewSequence([]float64{0, 0, 0, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1}, DimXY),
+			want:        geom.NewSequence([]float64{0, 0, 0, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1}, geom.DimXY),
 		},
 		{
 			description: "multiple polygons",
 			inputWKT:    "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((10 10,10 11,11 10,10 10)))",
-			want:        NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0, 10, 10, 10, 11, 11, 10, 10, 10}, DimXY),
+			want:        geom.NewSequence([]float64{0, 0, 0, 1, 1, 0, 0, 0, 10, 10, 10, 11, 11, 10, 10, 10}, geom.DimXY),
 		},
 		{
 			description: "Z coordinates",
 			inputWKT:    "MULTIPOLYGON Z(((0 0 10,0 1 10,1 0 10,0 0 10)))",
-			want:        NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, geom.DimXYZ),
 		},
 		{
 			description: "M coordinates",
 			inputWKT:    "MULTIPOLYGON M(((0 0 10,0 1 10,1 0 10,0 0 10)))",
-			want:        NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, DimXYM),
+			want:        geom.NewSequence([]float64{0, 0, 10, 0, 1, 10, 1, 0, 10, 0, 0, 10}, geom.DimXYM),
 		},
 		{
 			description: "ZM coordinates",
 			inputWKT:    "MULTIPOLYGON ZM(((0 0 20 10,0 1 20 10,1 0 20 10,0 0 20 10)))",
-			want:        NewSequence([]float64{0, 0, 20, 10, 0, 1, 20, 10, 1, 0, 20, 10, 0, 0, 20, 10}, DimXYZM),
+			want:        geom.NewSequence([]float64{0, 0, 20, 10, 0, 1, 20, 10, 1, 0, 20, 10, 0, 0, 20, 10}, geom.DimXYZM),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -226,32 +226,32 @@ func TestDumpCoordinatesGeometryCollection(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        Sequence
+		want        geom.Sequence
 	}{
 		{
 			description: "empty",
 			inputWKT:    "GEOMETRYCOLLECTION EMPTY",
-			want:        NewSequence(nil, DimXY),
+			want:        geom.NewSequence(nil, geom.DimXY),
 		},
 		{
 			description: "empty z",
 			inputWKT:    "GEOMETRYCOLLECTION Z EMPTY",
-			want:        NewSequence(nil, DimXYZ),
+			want:        geom.NewSequence(nil, geom.DimXYZ),
 		},
 		{
 			description: "single point",
 			inputWKT:    "GEOMETRYCOLLECTION(POINT(1 2))",
-			want:        NewSequence([]float64{1, 2}, DimXY),
+			want:        geom.NewSequence([]float64{1, 2}, geom.DimXY),
 		},
 		{
 			description: "single point z",
 			inputWKT:    "GEOMETRYCOLLECTION Z(POINT Z(1 2 0))",
-			want:        NewSequence([]float64{1, 2, 0}, DimXYZ),
+			want:        geom.NewSequence([]float64{1, 2, 0}, geom.DimXYZ),
 		},
 		{
 			description: "nested",
 			inputWKT:    "GEOMETRYCOLLECTION Z(GEOMETRYCOLLECTION Z(POINT Z(1 2 0)))",
-			want:        NewSequence([]float64{1, 2, 0}, DimXYZ),
+			want:        geom.NewSequence([]float64{1, 2, 0}, geom.DimXYZ),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -265,42 +265,42 @@ func TestDumpCoordinatesGeometry(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		inputWKT    string
-		want        Sequence
+		want        geom.Sequence
 	}{
 		{
 			description: "Point",
 			inputWKT:    "POINT Z(0 1 2)",
-			want:        NewSequence([]float64{0, 1, 2}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 1, 2}, geom.DimXYZ),
 		},
 		{
 			description: "LineString",
 			inputWKT:    "LINESTRING Z(0 1 2,3 4 5)",
-			want:        NewSequence([]float64{0, 1, 2, 3, 4, 5}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 1, 2, 3, 4, 5}, geom.DimXYZ),
 		},
 		{
 			description: "Polygon",
 			inputWKT:    "POLYGON Z((0 0 1,0 1 1,1 0 1,0 0 1))",
-			want:        NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, geom.DimXYZ),
 		},
 		{
 			description: "MultiPoint",
 			inputWKT:    "MULTIPOINT Z(0 1 2,3 4 5)",
-			want:        NewSequence([]float64{0, 1, 2, 3, 4, 5}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 1, 2, 3, 4, 5}, geom.DimXYZ),
 		},
 		{
 			description: "MultiLineString",
 			inputWKT:    "MULTILINESTRING Z((0 1 2,3 4 5))",
-			want:        NewSequence([]float64{0, 1, 2, 3, 4, 5}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 1, 2, 3, 4, 5}, geom.DimXYZ),
 		},
 		{
 			description: "MultiPolygon",
 			inputWKT:    "MULTIPOLYGON Z(((0 0 1,0 1 1,1 0 1,0 0 1)))",
-			want:        NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1}, geom.DimXYZ),
 		},
 		{
 			description: "GeometryCollection",
 			inputWKT:    "GEOMETRYCOLLECTION Z(POINT Z(0 1 2))",
-			want:        NewSequence([]float64{0, 1, 2}, DimXYZ),
+			want:        geom.NewSequence([]float64{0, 1, 2}, geom.DimXYZ),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {

--- a/geom/geojson_feature_collection_test.go
+++ b/geom/geojson_feature_collection_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestGeoJSONFeatureCollectionValidUnmarshal(t *testing.T) {
@@ -55,7 +55,7 @@ func TestGeoJSONFeatureCollectionValidUnmarshal(t *testing.T) {
 	   ]
 	}`
 
-	var fc GeoJSONFeatureCollection
+	var fc geom.GeoJSONFeatureCollection
 	err := json.NewDecoder(strings.NewReader(input)).Decode(&fc)
 	expectNoErr(t, err)
 
@@ -112,13 +112,13 @@ func TestGeoJSONFeatureCollectionInvalidUnmarshal(t *testing.T) {
 		if i == 0 {
 			// Ensure that the first feature collection is valid, since that's
 			// what the other test cases are based on.
-			var fc GeoJSONFeatureCollection
+			var fc geom.GeoJSONFeatureCollection
 			r := strings.NewReader(tt.input)
 			expectNoErr(t, json.NewDecoder(r).Decode(&fc))
 			continue
 		}
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			var fc GeoJSONFeatureCollection
+			var fc geom.GeoJSONFeatureCollection
 			r := strings.NewReader(tt.input)
 			err := json.NewDecoder(r).Decode(&fc)
 			if err == nil {
@@ -132,25 +132,25 @@ func TestGeoJSONFeatureCollectionInvalidUnmarshal(t *testing.T) {
 }
 
 func TestGeoJSONFeatureCollectionEmpty(t *testing.T) {
-	out, err := json.Marshal(GeoJSONFeatureCollection{})
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection{})
 	expectNoErr(t, err)
 	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
 }
 
 func TestGeoJSONFeatureCollectionNil(t *testing.T) {
-	out, err := json.Marshal(GeoJSONFeatureCollection(nil))
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection(nil))
 	expectNoErr(t, err)
 	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
 }
 
 func TestGeoJSONFeatureCollectionAndPropertiesNil(t *testing.T) {
-	out, err := json.Marshal(GeoJSONFeatureCollection{{Geometry: geomFromWKT(t, "POINT(1 2)")}})
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection{{Geometry: geomFromWKT(t, "POINT(1 2)")}})
 	expectNoErr(t, err)
 	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{}}]}`)
 }
 
 func TestGeoJSONFeatureCollectionAndPropertiesSet(t *testing.T) {
-	out, err := json.Marshal(GeoJSONFeatureCollection{{
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection{{
 		Geometry: geomFromWKT(t, "POINT(1 2)"),
 		ID:       "myid",
 		Properties: map[string]interface{}{

--- a/geom/twkb_test.go
+++ b/geom/twkb_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -525,7 +526,7 @@ func TestZigZagInt(t *testing.T) {
 		{-32768, 65535},
 		{32768, 65536},
 	} {
-		t.Run(fmt.Sprintf("%v", tc.n), func(t *testing.T) {
+		t.Run(strconv.Itoa(int(tc.n)), func(t *testing.T) {
 			t.Logf("ZigZag encode int64: %v", tc.n)
 			z := geom.EncodeZigZagInt64(tc.n)
 			if tc.z != z {

--- a/geom/type_coordinates_test.go
+++ b/geom/type_coordinates_test.go
@@ -4,32 +4,32 @@ import (
 	"strconv"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestCoordinatesString(t *testing.T) {
 	for i, tc := range []struct {
-		coords Coordinates
+		coords geom.Coordinates
 		want   string
 	}{
 		{
-			Coordinates{},
+			geom.Coordinates{},
 			"Coordinates[XY] 0 0",
 		},
 		{
-			Coordinates{XY: XY{X: 1, Y: 2}},
+			geom.Coordinates{XY: geom.XY{X: 1, Y: 2}},
 			"Coordinates[XY] 1 2",
 		},
 		{
-			Coordinates{XY: XY{X: 1, Y: 2}, Z: 3, Type: DimXYZ},
+			geom.Coordinates{XY: geom.XY{X: 1, Y: 2}, Z: 3, Type: geom.DimXYZ},
 			"Coordinates[XYZ] 1 2 3",
 		},
 		{
-			Coordinates{XY: XY{X: 1, Y: 2}, M: 3, Type: DimXYM},
+			geom.Coordinates{XY: geom.XY{X: 1, Y: 2}, M: 3, Type: geom.DimXYM},
 			"Coordinates[XYM] 1 2 3",
 		},
 		{
-			Coordinates{XY: XY{X: 1, Y: 2}, Z: 3, M: 4, Type: DimXYZM},
+			geom.Coordinates{XY: geom.XY{X: 1, Y: 2}, Z: 3, M: 4, Type: geom.DimXYZM},
 			"Coordinates[XYZM] 1 2 3 4",
 		},
 	} {

--- a/geom/type_geometry_test.go
+++ b/geom/type_geometry_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestZeroGeometry(t *testing.T) {
-	var z Geometry
+	var z geom.Geometry
 	expectBoolEq(t, z.IsGeometryCollection(), true)
 	z.MustAsGeometryCollection() // Doesn't crash.
 	expectStringEq(t, z.AsText(), "GEOMETRYCOLLECTION EMPTY")
@@ -24,7 +24,7 @@ func TestZeroGeometry(t *testing.T) {
 	expectNoErr(t, err)
 	expectStringEq(t, strings.TrimSpace(buf.String()), `{"type":"GeometryCollection","geometries":[]}`)
 
-	pt := XY{1, 2}.AsPoint()
+	pt := geom.XY{1, 2}.AsPoint()
 	z = pt.AsGeometry() // Set away from zero value
 	expectBoolEq(t, z.IsPoint(), true)
 	err = json.NewDecoder(&buf).Decode(&z)
@@ -32,7 +32,7 @@ func TestZeroGeometry(t *testing.T) {
 	expectBoolEq(t, z.IsPoint(), false)
 	expectBoolEq(t, z.IsGeometryCollection(), true)
 	expectBoolEq(t, z.IsEmpty(), true)
-	z = Geometry{}
+	z = geom.Geometry{}
 
 	_ = z.AsBinary() // Doesn't crash
 
@@ -45,24 +45,24 @@ func TestZeroGeometry(t *testing.T) {
 func TestGeometryType(t *testing.T) {
 	for i, tt := range []struct {
 		wkt     string
-		geoType GeometryType
+		geoType geom.GeometryType
 	}{
-		{"POINT(1 1)", TypePoint},
-		{"POINT EMPTY", TypePoint},
-		{"MULTIPOINT EMPTY", TypeMultiPoint},
-		{"MULTIPOINT ((10 40), (40 30), (20 20), (30 10))", TypeMultiPoint},
-		{"LINESTRING(1 2,3 4)", TypeLineString},
-		{"LINESTRING(1 2,3 4,5 6)", TypeLineString},
-		{"LINESTRING EMPTY", TypeLineString},
-		{"MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))", TypeMultiLineString},
-		{"MULTILINESTRING EMPTY", TypeMultiLineString},
-		{"MULTILINESTRING(EMPTY)", TypeMultiLineString},
-		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", TypePolygon},
-		{"POLYGON EMPTY", TypePolygon},
-		{"MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon},
-		{"MULTIPOLYGON EMPTY", TypeMultiPolygon},
-		{"MULTIPOLYGON(EMPTY)", TypeMultiPolygon},
-		{"GEOMETRYCOLLECTION EMPTY", TypeGeometryCollection},
+		{"POINT(1 1)", geom.TypePoint},
+		{"POINT EMPTY", geom.TypePoint},
+		{"MULTIPOINT EMPTY", geom.TypeMultiPoint},
+		{"MULTIPOINT ((10 40), (40 30), (20 20), (30 10))", geom.TypeMultiPoint},
+		{"LINESTRING(1 2,3 4)", geom.TypeLineString},
+		{"LINESTRING(1 2,3 4,5 6)", geom.TypeLineString},
+		{"LINESTRING EMPTY", geom.TypeLineString},
+		{"MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))", geom.TypeMultiLineString},
+		{"MULTILINESTRING EMPTY", geom.TypeMultiLineString},
+		{"MULTILINESTRING(EMPTY)", geom.TypeMultiLineString},
+		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", geom.TypePolygon},
+		{"POLYGON EMPTY", geom.TypePolygon},
+		{"MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", geom.TypeMultiPolygon},
+		{"MULTIPOLYGON EMPTY", geom.TypeMultiPolygon},
+		{"MULTIPOLYGON(EMPTY)", geom.TypeMultiPolygon},
+		{"GEOMETRYCOLLECTION EMPTY", geom.TypeGeometryCollection},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log("wkt:", tt.wkt)
@@ -76,16 +76,16 @@ func TestGeometryType(t *testing.T) {
 
 func TestGeometryTypeString(t *testing.T) {
 	for _, tc := range []struct {
-		typ  GeometryType
+		typ  geom.GeometryType
 		want string
 	}{
-		{TypeGeometryCollection, "GeometryCollection"},
-		{TypePoint, "Point"},
-		{TypeMultiPoint, "MultiPoint"},
-		{TypeLineString, "LineString"},
-		{TypeMultiLineString, "MultiLineString"},
-		{TypePolygon, "Polygon"},
-		{TypeMultiPolygon, "MultiPolygon"},
+		{geom.TypeGeometryCollection, "GeometryCollection"},
+		{geom.TypePoint, "Point"},
+		{geom.TypeMultiPoint, "MultiPoint"},
+		{geom.TypeLineString, "LineString"},
+		{geom.TypeMultiLineString, "MultiLineString"},
+		{geom.TypePolygon, "Polygon"},
+		{geom.TypeMultiPolygon, "MultiPolygon"},
 		{99, "invalid"},
 	} {
 		t.Run(tc.want, func(t *testing.T) {
@@ -177,37 +177,37 @@ func TestAsConcreteType(t *testing.T) {
 func TestGeometryIsCWandIsCCW(t *testing.T) {
 	for i, tt := range []struct {
 		wkt     string
-		geoType GeometryType
+		geoType geom.GeometryType
 		isCW    bool
 		isCCW   bool
 		note    string
 	}{
-		{"POINT(1 1)", TypePoint, true, true, "undefined"},
-		{"POINT EMPTY", TypePoint, true, true, "undefined"},
-		{"MULTIPOINT EMPTY", TypeMultiPoint, true, true, "undefined"},
-		{"MULTIPOINT ((10 40), (40 30), (20 20), (30 10))", TypeMultiPoint, true, true, "undefined"},
-		{"LINESTRING(1 2,3 4)", TypeLineString, true, true, "undefined"},
-		{"LINESTRING(1 2,3 4,5 6)", TypeLineString, true, true, "undefined"},
-		{"LINESTRING EMPTY", TypeLineString, true, true, "undefined"},
-		{"MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))", TypeMultiLineString, true, true, "undefined"},
-		{"MULTILINESTRING EMPTY", TypeMultiLineString, true, true, "undefined"},
-		{"MULTILINESTRING(EMPTY)", TypeMultiLineString, true, true, "undefined"},
-		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", TypePolygon, true, false, "CW"},
-		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", TypePolygon, false, true, "CCW"},
-		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", TypePolygon, true, false, "outer CW inner CCW"},
-		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", TypePolygon, false, true, "outer CCW inner CW"},
-		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,2 1,2 2,1 2,1 1))", TypePolygon, false, false, "outer CCW, inner CCW, inconsistent"},
-		{"POLYGON EMPTY", TypePolygon, true, true, "empty"},
-		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", TypeMultiPolygon, true, false, "all CW"},
-		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, true, "all CCW"},
-		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", TypeMultiPolygon, false, false, "first CW, next CCW, inconsistent"},
-		{"MULTIPOLYGON EMPTY", TypeMultiPolygon, true, true, "empty"},
-		{"MULTIPOLYGON(EMPTY)", TypeMultiPolygon, true, true, "empty"},
-		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", TypeGeometryCollection, true, false, "all CW"},
-		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))))", TypeGeometryCollection, false, false, "first CW, next CCW, inconsistent"},
-		{"GEOMETRYCOLLECTION EMPTY", TypeGeometryCollection, true, true, "empty"},
-		{"GEOMETRYCOLLECTION(POINT(1 1))", TypeGeometryCollection, true, true, "first undefined"},
-		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), POINT(1 1))", TypeGeometryCollection, true, false, "first CW, second undefined"},
+		{"POINT(1 1)", geom.TypePoint, true, true, "undefined"},
+		{"POINT EMPTY", geom.TypePoint, true, true, "undefined"},
+		{"MULTIPOINT EMPTY", geom.TypeMultiPoint, true, true, "undefined"},
+		{"MULTIPOINT ((10 40), (40 30), (20 20), (30 10))", geom.TypeMultiPoint, true, true, "undefined"},
+		{"LINESTRING(1 2,3 4)", geom.TypeLineString, true, true, "undefined"},
+		{"LINESTRING(1 2,3 4,5 6)", geom.TypeLineString, true, true, "undefined"},
+		{"LINESTRING EMPTY", geom.TypeLineString, true, true, "undefined"},
+		{"MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))", geom.TypeMultiLineString, true, true, "undefined"},
+		{"MULTILINESTRING EMPTY", geom.TypeMultiLineString, true, true, "undefined"},
+		{"MULTILINESTRING(EMPTY)", geom.TypeMultiLineString, true, true, "undefined"},
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0))", geom.TypePolygon, true, false, "CW"},
+		{"POLYGON((1 1,3 1,2 2,2 4,1 1))", geom.TypePolygon, false, true, "CCW"},
+		{"POLYGON((0 0,0 5,5 5,5 0,0 0), (1 1,3 1,2 2,2 4,1 1))", geom.TypePolygon, true, false, "outer CW inner CCW"},
+		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,1 2,2 2,2 1,1 1))", geom.TypePolygon, false, true, "outer CCW inner CW"},
+		{"POLYGON((0 0,5 0,5 5,0 5,0 0), (1 1,2 1,2 2,1 2,1 1))", geom.TypePolygon, false, false, "outer CCW, inner CCW, inconsistent"},
+		{"POLYGON EMPTY", geom.TypePolygon, true, true, "empty"},
+		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20)))", geom.TypeMultiPolygon, true, false, "all CW"},
+		{"MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", geom.TypeMultiPolygon, false, true, "all CCW"},
+		{"MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))", geom.TypeMultiPolygon, false, false, "first CW, next CCW, inconsistent"},
+		{"MULTIPOLYGON EMPTY", geom.TypeMultiPolygon, true, true, "empty"},
+		{"MULTIPOLYGON(EMPTY)", geom.TypeMultiPolygon, true, true, "empty"},
+		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 45 30, 20 45, 40 40)),((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),(30 20, 20 25, 20 15, 30 20))))", geom.TypeGeometryCollection, true, false, "all CW"},
+		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), MULTIPOLYGON(((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))))", geom.TypeGeometryCollection, false, false, "first CW, next CCW, inconsistent"},
+		{"GEOMETRYCOLLECTION EMPTY", geom.TypeGeometryCollection, true, true, "empty"},
+		{"GEOMETRYCOLLECTION(POINT(1 1))", geom.TypeGeometryCollection, true, true, "first undefined"},
+		{"GEOMETRYCOLLECTION(POLYGON((0 0,0 5,5 5,5 0,0 0)), POINT(1 1))", geom.TypeGeometryCollection, true, false, "first CW, second undefined"},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log("wkt:", tt.wkt)

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -5,13 +5,13 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 //nolint:unparam
-func geomFromWKT(tb testing.TB, wkt string, nv ...NoValidate) Geometry {
+func geomFromWKT(tb testing.TB, wkt string, nv ...geom.NoValidate) geom.Geometry {
 	tb.Helper()
-	geom, err := UnmarshalWKT(wkt, nv...)
+	geom, err := geom.UnmarshalWKT(wkt, nv...)
 	if err != nil {
 		tb.Fatalf("could not unmarshal WKT:\n  wkt: %s\n  err: %v", wkt, err)
 	}
@@ -19,11 +19,11 @@ func geomFromWKT(tb testing.TB, wkt string, nv ...NoValidate) Geometry {
 }
 
 //nolint:unparam
-func geomsFromWKTs(tb testing.TB, wkts []string, nv ...NoValidate) []Geometry {
+func geomsFromWKTs(tb testing.TB, wkts []string, nv ...geom.NoValidate) []geom.Geometry {
 	tb.Helper()
-	var gs []Geometry
+	var gs []geom.Geometry
 	for _, wkt := range wkts {
-		g, err := UnmarshalWKT(wkt, nv...)
+		g, err := geom.UnmarshalWKT(wkt, nv...)
 		if err != nil {
 			tb.Fatalf("could not unmarshal WKT:\n  wkt: %s\n  err: %v", wkt, err)
 		}
@@ -32,37 +32,37 @@ func geomsFromWKTs(tb testing.TB, wkts []string, nv ...NoValidate) []Geometry {
 	return gs
 }
 
-func geomFromGeoJSON(tb testing.TB, geojson string, nv ...NoValidate) Geometry {
+func geomFromGeoJSON(tb testing.TB, geojson string, nv ...geom.NoValidate) geom.Geometry {
 	tb.Helper()
-	g, err := UnmarshalGeoJSON([]byte(geojson), nv...)
+	g, err := geom.UnmarshalGeoJSON([]byte(geojson), nv...)
 	if err != nil {
 		tb.Fatalf("could not unmarshal GeoJSON:\n geojson: %s\n     err: %v", geojson, err)
 	}
 	return g
 }
 
-func xyCoords(x, y float64) Coordinates {
-	return Coordinates{XY: XY{x, y}, Type: DimXY}
+func xyCoords(x, y float64) geom.Coordinates {
+	return geom.Coordinates{XY: geom.XY{x, y}, Type: geom.DimXY}
 }
 
-func upcastPoints(ps []Point) []Geometry {
-	gs := make([]Geometry, len(ps))
+func upcastPoints(ps []geom.Point) []geom.Geometry {
+	gs := make([]geom.Geometry, len(ps))
 	for i, p := range ps {
 		gs[i] = p.AsGeometry()
 	}
 	return gs
 }
 
-func upcastLineStrings(lss []LineString) []Geometry {
-	gs := make([]Geometry, len(lss))
+func upcastLineStrings(lss []geom.LineString) []geom.Geometry {
+	gs := make([]geom.Geometry, len(lss))
 	for i, ls := range lss {
 		gs[i] = ls.AsGeometry()
 	}
 	return gs
 }
 
-func upcastPolygons(ps []Polygon) []Geometry {
-	gs := make([]Geometry, len(ps))
+func upcastPolygons(ps []geom.Polygon) []geom.Geometry {
+	gs := make([]geom.Geometry, len(ps))
 	for i, p := range ps {
 		gs[i] = p.AsGeometry()
 	}
@@ -94,17 +94,17 @@ func expectErr(tb testing.TB, err error) {
 	}
 }
 
-func expectGeomEq(tb testing.TB, got, want Geometry, opts ...ExactEqualsOption) {
+func expectGeomEq(tb testing.TB, got, want geom.Geometry, opts ...geom.ExactEqualsOption) {
 	tb.Helper()
-	if !ExactEquals(got, want, opts...) {
+	if !geom.ExactEquals(got, want, opts...) {
 		tb.Errorf("\ngot:  %v\nwant: %v\n", got.AsText(), want.AsText())
 	}
 }
 
 //nolint:deadcode,unused
-func expectGeomApproxEq(tb testing.TB, got, want Geometry) {
+func expectGeomApproxEq(tb testing.TB, got, want geom.Geometry) {
 	tb.Helper()
-	eq, err := Equals(got, want)
+	eq, err := geom.Equals(got, want)
 	if err != nil {
 		tb.Errorf("\ngot:  %v\nwant: %v\nerr: %v\n", got.AsText(), want.AsText(), err)
 	}
@@ -113,26 +113,26 @@ func expectGeomApproxEq(tb testing.TB, got, want Geometry) {
 	}
 }
 
-func expectGeomEqWKT(tb testing.TB, got Geometry, wantWKT string, opts ...ExactEqualsOption) {
+func expectGeomEqWKT(tb testing.TB, got geom.Geometry, wantWKT string, opts ...geom.ExactEqualsOption) {
 	tb.Helper()
 	want := geomFromWKT(tb, wantWKT)
 	expectGeomEq(tb, got, want, opts...)
 }
 
 //nolint:unparam
-func expectGeomsEq(tb testing.TB, got, want []Geometry, opts ...ExactEqualsOption) {
+func expectGeomsEq(tb testing.TB, got, want []geom.Geometry, opts ...geom.ExactEqualsOption) {
 	tb.Helper()
 	if len(got) != len(want) {
 		tb.Errorf("\ngot:  len %d\nwant: len %d\n", len(got), len(want))
 	}
 	for i := range got {
-		if !ExactEquals(got[i], want[i], opts...) {
+		if !geom.ExactEquals(got[i], want[i], opts...) {
 			tb.Errorf("\ngot:  %v\nwant: %v\n", got[i].AsText(), want[i].AsText())
 		}
 	}
 }
 
-func expectCoordsEq(tb testing.TB, got, want Coordinates) {
+func expectCoordsEq(tb testing.TB, got, want geom.Coordinates) {
 	tb.Helper()
 	if got != want {
 		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)
@@ -170,21 +170,21 @@ func expectFalse(tb testing.TB, got bool) {
 	expectBoolEq(tb, got, false)
 }
 
-func expectXYEq(tb testing.TB, got, want XY) {
+func expectXYEq(tb testing.TB, got, want geom.XY) {
 	tb.Helper()
 	if got != want {
 		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectXYWithinTolerance(tb testing.TB, got, want XY, tolerance float64) {
+func expectXYWithinTolerance(tb testing.TB, got, want geom.XY, tolerance float64) {
 	tb.Helper()
 	if delta := math.Abs(got.Sub(want).Length()); delta > tolerance {
 		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)
 	}
 }
 
-func expectCoordinatesTypeEq(tb testing.TB, got, want CoordinatesType) {
+func expectCoordinatesTypeEq(tb testing.TB, got, want geom.CoordinatesType) {
 	tb.Helper()
 	if got != want {
 		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)
@@ -205,16 +205,16 @@ func expectFloat64Eq(tb testing.TB, got, want float64) {
 	}
 }
 
-func expectEnvEq(tb testing.TB, got, want Envelope) {
+func expectEnvEq(tb testing.TB, got, want geom.Envelope) {
 	tb.Helper()
-	if ExactEquals(got.Min().AsGeometry(), want.Min().AsGeometry()) &&
-		ExactEquals(got.Max().AsGeometry(), want.Max().AsGeometry()) {
+	if geom.ExactEquals(got.Min().AsGeometry(), want.Min().AsGeometry()) &&
+		geom.ExactEquals(got.Max().AsGeometry(), want.Max().AsGeometry()) {
 		return
 	}
 	tb.Errorf("\ngot:  %v\nwant: %v", got, want)
 }
 
-func expectSequenceEq(tb testing.TB, got, want Sequence) {
+func expectSequenceEq(tb testing.TB, got, want geom.Sequence) {
 	tb.Helper()
 	show := func() {
 		tb.Logf("len(got): %d, ct(got): %s", got.Length(), got.CoordinatesType())

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func hexStringToBytes(tb testing.TB, s string) []byte {
@@ -390,7 +390,7 @@ var validWKBCases = []struct {
 func TestWKBParseValid(t *testing.T) {
 	for i, tt := range validWKBCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			geom, err := UnmarshalWKB(hexStringToBytes(t, tt.wkb))
+			geom, err := geom.UnmarshalWKB(hexStringToBytes(t, tt.wkb))
 			expectNoErr(t, err)
 			expectGeomEq(t, geom, geomFromWKT(t, tt.wkt))
 		})
@@ -496,7 +496,7 @@ func TestWKBParserSyntaxError(t *testing.T) {
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			wkb := hexStringToBytes(t, tc.wkbHex)
-			_, err := UnmarshalWKB(wkb)
+			_, err := geom.UnmarshalWKB(wkb)
 			if err == nil {
 				t.Fatal("expected an error but got nil")
 			}
@@ -535,11 +535,11 @@ func TestWKBMarshalValid(t *testing.T) {
 		"GEOMETRYCOLLECTION(POINT(1 2),LINESTRING(1 2,3 4))",
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			geom := geomFromWKT(t, wkt)
-			buf := geom.AsBinary()
-			readBackGeom, err := UnmarshalWKB(buf)
+			g := geomFromWKT(t, wkt)
+			buf := g.AsBinary()
+			readBackGeom, err := geom.UnmarshalWKB(buf)
 			expectNoErr(t, err)
-			expectGeomEq(t, readBackGeom, geom)
+			expectGeomEq(t, readBackGeom, g)
 		})
 	}
 }
@@ -673,7 +673,7 @@ func TestWKBUnmarshalEndianess(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			want := geomFromWKT(t, tt.wkt)
 			wkb := hexStringToBytes(t, tt.hex)
-			got, err := UnmarshalWKB(wkb)
+			got, err := geom.UnmarshalWKB(wkb)
 			expectNoErr(t, err)
 			expectGeomEq(t, got, want)
 		})

--- a/geom/wkt_test.go
+++ b/geom/wkt_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestUnmarshalWKTValidGrammar(t *testing.T) {
@@ -40,7 +40,7 @@ func TestUnmarshalWKTValidGrammar(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("WKT: %v", tt.wkt)
-			_, err := UnmarshalWKT(tt.wkt)
+			_, err := geom.UnmarshalWKT(tt.wkt)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -157,7 +157,7 @@ func TestUnmarshalWKTSyntaxErrors(t *testing.T) {
 		},
 	} {
 		t.Run(tt.description, func(t *testing.T) {
-			_, err := UnmarshalWKT(tt.wkt)
+			_, err := geom.UnmarshalWKT(tt.wkt)
 			if err == nil {
 				t.Fatalf("expected error but got nil")
 			}
@@ -199,15 +199,15 @@ func TestUnmarshalWKT(t *testing.T) {
 func TestAsTextEmpty(t *testing.T) {
 	for i, tt := range []struct {
 		want string
-		g    Geometry
+		g    geom.Geometry
 	}{
-		{"POINT EMPTY", Point{}.AsGeometry()},
-		{"LINESTRING EMPTY", LineString{}.AsGeometry()},
-		{"POLYGON EMPTY", Polygon{}.AsGeometry()},
-		{"MULTIPOINT EMPTY", MultiPoint{}.AsGeometry()},
-		{"MULTILINESTRING EMPTY", MultiLineString{}.AsGeometry()},
-		{"MULTIPOLYGON EMPTY", MultiPolygon{}.AsGeometry()},
-		{"GEOMETRYCOLLECTION EMPTY", GeometryCollection{}.AsGeometry()},
+		{"POINT EMPTY", geom.Point{}.AsGeometry()},
+		{"LINESTRING EMPTY", geom.LineString{}.AsGeometry()},
+		{"POLYGON EMPTY", geom.Polygon{}.AsGeometry()},
+		{"MULTIPOINT EMPTY", geom.MultiPoint{}.AsGeometry()},
+		{"MULTILINESTRING EMPTY", geom.MultiLineString{}.AsGeometry()},
+		{"MULTIPOLYGON EMPTY", geom.MultiPolygon{}.AsGeometry()},
+		{"GEOMETRYCOLLECTION EMPTY", geom.GeometryCollection{}.AsGeometry()},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := tt.g.AsText()

--- a/geom/zero_value_test.go
+++ b/geom/zero_value_test.go
@@ -3,76 +3,76 @@ package geom_test
 import (
 	"testing"
 
-	. "github.com/peterstace/simplefeatures/geom"
+	"github.com/peterstace/simplefeatures/geom"
 )
 
 func TestZeroValueGeometries(t *testing.T) {
 	t.Run("Point", func(t *testing.T) {
-		var pt Point
+		var pt geom.Point
 		expectBoolEq(t, pt.IsEmpty(), true)
-		expectCoordinatesTypeEq(t, pt.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, pt.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("LineString", func(t *testing.T) {
-		var ls LineString
+		var ls geom.LineString
 		expectIntEq(t, ls.Coordinates().Length(), 0)
-		expectCoordinatesTypeEq(t, ls.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, ls.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("Polygon", func(t *testing.T) {
-		var p Polygon
+		var p geom.Polygon
 		expectBoolEq(t, p.IsEmpty(), true)
-		expectCoordinatesTypeEq(t, p.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, p.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("MultiPoint", func(t *testing.T) {
-		var mp MultiPoint
+		var mp geom.MultiPoint
 		expectIntEq(t, mp.NumPoints(), 0)
-		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, mp.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("MultiLineString", func(t *testing.T) {
-		var mls MultiLineString
+		var mls geom.MultiLineString
 		expectIntEq(t, mls.NumLineStrings(), 0)
-		expectCoordinatesTypeEq(t, mls.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, mls.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("MultiPolygon", func(t *testing.T) {
-		var mp MultiPolygon
+		var mp geom.MultiPolygon
 		expectIntEq(t, mp.NumPolygons(), 0)
-		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, mp.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("GeometryCollection", func(t *testing.T) {
-		var gc GeometryCollection
+		var gc geom.GeometryCollection
 		expectIntEq(t, gc.NumGeometries(), 0)
-		expectCoordinatesTypeEq(t, gc.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, gc.CoordinatesType(), geom.DimXY)
 	})
 }
 
 func TestEmptySliceConstructors(t *testing.T) {
 	t.Run("Polygon", func(t *testing.T) {
-		p := NewPolygon(nil)
+		p := geom.NewPolygon(nil)
 		expectNoErr(t, p.Validate())
 		expectBoolEq(t, p.IsEmpty(), true)
-		expectCoordinatesTypeEq(t, p.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, p.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("MultiPoint", func(t *testing.T) {
-		mp := NewMultiPoint(nil)
+		mp := geom.NewMultiPoint(nil)
 		expectNoErr(t, mp.Validate())
 		expectIntEq(t, mp.NumPoints(), 0)
-		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, mp.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("MultiLineString", func(t *testing.T) {
-		mls := NewMultiLineString(nil)
+		mls := geom.NewMultiLineString(nil)
 		expectNoErr(t, mls.Validate())
 		expectIntEq(t, mls.NumLineStrings(), 0)
-		expectCoordinatesTypeEq(t, mls.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, mls.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("MultiPolygon", func(t *testing.T) {
-		mp := NewMultiPolygon(nil)
+		mp := geom.NewMultiPolygon(nil)
 		expectNoErr(t, mp.Validate())
 		expectIntEq(t, mp.NumPolygons(), 0)
-		expectCoordinatesTypeEq(t, mp.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, mp.CoordinatesType(), geom.DimXY)
 	})
 	t.Run("GeometryCollection", func(t *testing.T) {
-		gc := NewGeometryCollection(nil)
+		gc := geom.NewGeometryCollection(nil)
 		expectNoErr(t, gc.Validate())
 		expectIntEq(t, gc.NumGeometries(), 0)
-		expectCoordinatesTypeEq(t, gc.CoordinatesType(), DimXY)
+		expectCoordinatesTypeEq(t, gc.CoordinatesType(), geom.DimXY)
 	})
 }


### PR DESCRIPTION
## Description

Some of the changes involve the `revive` linter being a bit stricter, resulting in the removal of "dot" imports. This is probably a good thing, since the tests are now more similar to how users will see things. There is also a new linter used called `perfsprint` which checks for bad uses of `fmt.Sprintf`.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?)

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/522