### PR TITLE
Use `XY.Less` comparison func

### DIFF
--- a/geom/alg_convex_hull.go
+++ b/geom/alg_convex_hull.go
@@ -145,10 +145,7 @@ func convexHullPointSet(g Geometry) []XY {
 
 func monotoneChain(pts []XY) []XY {
 	sort.Slice(pts, func(i, j int) bool {
-		if pts[i].X != pts[j].X {
-			return pts[i].X < pts[j].X
-		}
-		return pts[i].Y < pts[j].Y
+		return pts[i].Less(pts[j])
 	})
 
 	// Calculate lower hull.

--- a/geom/line.go
+++ b/geom/line.go
@@ -197,9 +197,7 @@ func rightmostThenHighestIndex(ps []XY) int {
 func leftmostThenLowestIndex(ps []XY) int {
 	rpi := 0
 	for i := 1; i < len(ps); i++ {
-		if ps[i].X < ps[rpi].X ||
-			(ps[i].X == ps[rpi].X &&
-				ps[i].Y < ps[rpi].Y) {
+		if ps[i].Less(ps[rpi]) {
 			rpi = i
 		}
 	}


### PR DESCRIPTION
## Description
    
`XY` has `Less` method to compare two `XY` values. This logic was duplicated in two other places. This change removes the duplication, instead relying on the `Less` method.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A (change too small to both with release notes)

## Related Issue

- N/A