### PR TITLE
Implement Densify methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+YYYY-MM-DD
+
+- Adds new `Densify` methods on each concrete geometry types that add
+  additional linearly interpolated control points such that the distance
+  between any two consecutive control points is at most a fixed distance. This
+  can be useful when transforming geometries from one projection to another.
+
 ## v0.47.0
 
 2024-01-19

--- a/geom/alg_densify.go
+++ b/geom/alg_densify.go
@@ -1,0 +1,35 @@
+package geom
+
+import "math"
+
+// densify returns a copy of the sequence with additional sets of coordinates
+// inserted such that the distance between adjacent sets of coordinates is at
+// most maxDist.
+func densify(seq Sequence, maxDist float64) Sequence {
+	if seq.Length() == 0 {
+		return seq
+	}
+
+	var dense []float64
+	n := seq.Length()
+	for i := 0; i+1 < n; i++ {
+		c0 := seq.Get(i + 0)
+		c1 := seq.Get(i + 1)
+
+		// Copy start of segment:
+		dense = c0.appendFloat64s(dense)
+
+		// Copy any additional inter-segment coordinates:
+		dist := c0.XY.distanceTo(c1.XY)
+		subsections := int(math.Ceil(dist / maxDist))
+		for j := 1; j < subsections; j++ {
+			cj := interpolateCoords(c0, c1, float64(j)/float64(subsections))
+			dense = cj.appendFloat64s(dense)
+		}
+	}
+
+	// Copy end of last segment:
+	dense = seq.Get(n - 1).appendFloat64s(dense)
+
+	return NewSequence(dense, seq.CoordinatesType())
+}

--- a/geom/alg_densify.go
+++ b/geom/alg_densify.go
@@ -6,6 +6,10 @@ import "math"
 // inserted such that the distance between adjacent sets of coordinates is at
 // most maxDist.
 func densify(seq Sequence, maxDist float64) Sequence {
+	if maxDist <= 0 {
+		panic("maxDist must be positive")
+	}
+
 	if seq.Length() == 0 {
 		return seq
 	}

--- a/geom/alg_densify_test.go
+++ b/geom/alg_densify_test.go
@@ -73,3 +73,22 @@ func TestDensify(t *testing.T) {
 		})
 	}
 }
+
+func TestDensifyInvalidMaxDist(t *testing.T) {
+	for i, tc := range []struct {
+		input   string
+		maxDist float64
+	}{
+		{"LINESTRING(0 0,1 0)", -1},
+		{"LINESTRING(0 0,1 0)", 0},
+		{"POINT(0 0)", -1},
+		{"POINT(0 0)", 0},
+		{"MULTIPOINT((0 0))", -1},
+		{"MULTIPOINT((0 0))", 0},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			input := geomFromWKT(t, tc.input)
+			expectPanics(t, func() { input.Densify(tc.maxDist) })
+		})
+	}
+}

--- a/geom/alg_densify_test.go
+++ b/geom/alg_densify_test.go
@@ -1,0 +1,75 @@
+package geom_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+func TestDensifyEmpty(t *testing.T) {
+	for _, empty := range []geom.Geometry{
+		geom.Point{}.AsGeometry(),
+		geom.LineString{}.AsGeometry(),
+		geom.Polygon{}.AsGeometry(),
+		geom.MultiPoint{}.AsGeometry(),
+		geom.MultiLineString{}.AsGeometry(),
+		geom.MultiPolygon{}.AsGeometry(),
+		geom.GeometryCollection{}.AsGeometry(),
+	} {
+		t.Run(empty.String(), func(t *testing.T) {
+			for _, ct := range []geom.CoordinatesType{
+				geom.DimXY,
+				geom.DimXYZ,
+				geom.DimXYM,
+				geom.DimXYZM,
+			} {
+				t.Run(ct.String(), func(t *testing.T) {
+					input := empty.ForceCoordinatesType(ct)
+					got := input.Densify(1.0)
+					expectGeomEq(t, got, input)
+				})
+			}
+		})
+	}
+}
+
+func TestDensify(t *testing.T) {
+	for i, tc := range []struct {
+		input   string
+		minDist float64
+		want    string
+	}{
+		// LineString with a single segment (tests threshold logic):
+		{"LINESTRING(0 0,1 0)", 2.0, "LINESTRING(0 0,1 0)"},
+		{"LINESTRING(0 0,1 0)", 1.0, "LINESTRING(0 0,1 0)"},
+		{"LINESTRING(0 0,1 0)", 0.9, "LINESTRING(0 0,0.5 0,1 0)"},
+		{"LINESTRING(0 0,1 0)", 0.5, "LINESTRING(0 0,0.5 0,1 0)"},
+		{"LINESTRING(0 0,1 0)", 0.4, "LINESTRING(0 0,0.3333333333333333 0,0.6666666666666666 0,1 0)"},
+		{"LINESTRING(0 0,1 0)", 0.3, "LINESTRING(0 0,0.25 0,0.5 0,0.75 0,1 0)"},
+		{"LINESTRING(0 0,1 0)", 0.25, "LINESTRING(0 0,0.25 0,0.5 0,0.75 0,1 0)"},
+
+		// LineString with Z/M/ZM:
+		{"LINESTRING(1 2,3 4,5 6)", 1.5, "LINESTRING(1 2,2 3,3 4,4 5,5 6)"},
+		{"LINESTRING M(1 2 10,3 4 11,5 6 12)", 1.5, "LINESTRING M(1 2 10,2 3 10.5,3 4 11,4 5 11.5,5 6 12)"},
+		{"LINESTRING Z(1 2 10,3 4 11,5 6 12)", 1.5, "LINESTRING Z(1 2 10,2 3 10.5,3 4 11,4 5 11.5,5 6 12)"},
+		{"LINESTRING ZM(1 2 10 20,3 4 11 21,5 6 12 22)", 1.5, "LINESTRING ZM(1 2 10 20,2 3 10.5 20.5,3 4 11 21,4 5 11.5 21.5,5 6 12 22)"},
+
+		// LineString where each segment is broken into a different number of parts:
+		{"LINESTRING(0 0,2 0,2 1)", 0.5, "LINESTRING(0 0,0.5 0,1 0,1.5 0,2 0,2 0.5,2 1)"},
+
+		// Other geometry types:
+		{"POINT(0 0)", 1.0, "POINT(0 0)"},
+		{"MULTIPOINT((0 0),(1 1))", 1.0, "MULTIPOINT((0 0),(1 1))"},
+		{"MULTILINESTRING((0 0,1 1),(2 2,3 3))", 1.0, "MULTILINESTRING((0 0,0.5 0.5,1 1),(2 2,2.5 2.5,3 3))"},
+		{"POLYGON((0 0,0 1,1 0,0 0))", 1.0, "POLYGON((0 0,0 1,0.5 0.5,1 0,0 0))"},
+		{"MULTIPOLYGON(((0 0,0 1,1 0,0 0)))", 1.0, "MULTIPOLYGON(((0 0,0 1,0.5 0.5,1 0,0 0)))"},
+		{"GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,1 1))", 1.0, "GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,0.5 0.5,1 1))"},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			input := geomFromWKT(t, tc.input)
+			got := input.Densify(tc.minDist)
+			expectGeomEqWKT(t, got, tc.want)
+		})
+	}
+}

--- a/geom/alg_densify_test.go
+++ b/geom/alg_densify_test.go
@@ -37,7 +37,7 @@ func TestDensifyEmpty(t *testing.T) {
 func TestDensify(t *testing.T) {
 	for i, tc := range []struct {
 		input   string
-		minDist float64
+		maxDist float64
 		want    string
 	}{
 		// LineString with a single segment (tests threshold logic):
@@ -68,7 +68,7 @@ func TestDensify(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			input := geomFromWKT(t, tc.input)
-			got := input.Densify(tc.minDist)
+			got := input.Densify(tc.maxDist)
 			expectGeomEqWKT(t, got, tc.want)
 		})
 	}

--- a/geom/alg_linear_interpolation.go
+++ b/geom/alg_linear_interpolation.go
@@ -32,7 +32,7 @@ func (l linearInterpolator) interpolate(frac float64) Point {
 		return l.seq.Get(idx - 1).AsPoint()
 	}
 
-	p0 := l.seq.Get(idx)
+	p0 := l.seq.Get(idx + 0)
 	p1 := l.seq.Get(idx + 1)
 
 	partial := frac * l.total
@@ -41,17 +41,21 @@ func (l linearInterpolator) interpolate(frac float64) Point {
 	}
 	partial /= p0.XY.distanceTo(p1.XY)
 
-	return Coordinates{
-		XY: XY{
-			X: lerp(p0.X, p1.X, partial),
-			Y: lerp(p0.Y, p1.Y, partial),
-		},
-		Z:    lerp(p0.Z, p1.Z, partial),
-		M:    lerp(p0.M, p1.M, partial),
-		Type: l.seq.CoordinatesType(),
-	}.AsPoint()
+	return interpolateCoords(p0, p1, partial).AsPoint()
 }
 
 func lerp(a, b, ratio float64) float64 {
 	return a + ratio*(b-a)
+}
+
+func interpolateCoords(c0, c1 Coordinates, frac float64) Coordinates {
+	return Coordinates{
+		XY: XY{
+			X: lerp(c0.X, c1.X, frac),
+			Y: lerp(c0.Y, c1.Y, frac),
+		},
+		Z:    lerp(c0.Z, c1.Z, frac),
+		M:    lerp(c0.M, c1.M, frac),
+		Type: c0.Type & c1.Type,
+	}
 }

--- a/geom/line.go
+++ b/geom/line.go
@@ -1,8 +1,6 @@
 package geom
 
 import (
-	"math"
-
 	"github.com/peterstace/simplefeatures/rtree"
 )
 
@@ -43,9 +41,7 @@ func (ln line) box() rtree.Box {
 }
 
 func (ln line) length() float64 {
-	dx := ln.b.X - ln.a.X
-	dy := ln.b.Y - ln.a.Y
-	return math.Sqrt(dx*dx + dy*dy)
+	return ln.a.distanceTo(ln.b)
 }
 
 func (ln line) centroid() XY {

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -973,3 +973,25 @@ func (g Geometry) Validate() error {
 		panic("unknown type: " + g.Type().String())
 	}
 }
+
+// Densify returns a new Geometry with additional linearly interpolated control
+// points such that the distance between any two consecutive control points is
+// at most the given maxDistance.
+func (g Geometry) Densify(maxDistance float64) Geometry {
+	switch g.gtype {
+	case TypePoint, TypeMultiPoint:
+		return g
+	case TypeLineString:
+		return g.MustAsLineString().Densify(maxDistance).AsGeometry()
+	case TypeMultiLineString:
+		return g.MustAsMultiLineString().Densify(maxDistance).AsGeometry()
+	case TypePolygon:
+		return g.MustAsPolygon().Densify(maxDistance).AsGeometry()
+	case TypeMultiPolygon:
+		return g.MustAsMultiPolygon().Densify(maxDistance).AsGeometry()
+	case TypeGeometryCollection:
+		return g.MustAsGeometryCollection().Densify(maxDistance).AsGeometry()
+	default:
+		panic("unknown type: " + g.Type().String())
+	}
+}

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -978,9 +978,16 @@ func (g Geometry) Validate() error {
 // Densify returns a new Geometry with additional linearly interpolated control
 // points such that the distance between any two consecutive control points is
 // at most the given maxDistance.
+//
+// Panics if maxDistance is zero or negative.
 func (g Geometry) Densify(maxDistance float64) Geometry {
 	switch g.gtype {
 	case TypePoint, TypeMultiPoint:
+		// Points cannot be densified, but still check that the max distance is
+		// valid for consistency between types.
+		if maxDistance <= 0 {
+			panic("maxDistance must be positive")
+		}
 		return g
 	case TypeLineString:
 		return g.MustAsLineString().Densify(maxDistance).AsGeometry()

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -552,3 +552,14 @@ func (c GeometryCollection) Simplify(threshold float64, nv ...NoValidate) (Geome
 	}
 	return NewGeometryCollection(geoms), nil
 }
+
+// Densify returns a new GeometryCollection with additional linearly
+// interpolated control points such that the distance between any two
+// consecutive control points is at most the given maxDistance.
+func (c GeometryCollection) Densify(maxDistance float64) GeometryCollection {
+	gs := make([]Geometry, len(c.geoms))
+	for i, g := range c.geoms {
+		gs[i] = g.Densify(maxDistance)
+	}
+	return GeometryCollection{gs, c.ctype}
+}

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -556,6 +556,8 @@ func (c GeometryCollection) Simplify(threshold float64, nv ...NoValidate) (Geome
 // Densify returns a new GeometryCollection with additional linearly
 // interpolated control points such that the distance between any two
 // consecutive control points is at most the given maxDistance.
+//
+// Panics if maxDistance is zero or negative.
 func (c GeometryCollection) Densify(maxDistance float64) GeometryCollection {
 	gs := make([]Geometry, len(c.geoms))
 	for i, g := range c.geoms {

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -473,3 +473,10 @@ func (s LineString) InterpolateEvenlySpacedPoints(n int) MultiPoint {
 	}
 	return NewMultiPoint(pts)
 }
+
+// Densify returns a new LineString with additional linearly interpolated
+// control points such that the distance between any two consecutive control
+// points is at most the given maxDistance.
+func (s LineString) Densify(minDistance float64) LineString {
+	return NewLineString(densify(s.seq, minDistance))
+}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -477,6 +477,8 @@ func (s LineString) InterpolateEvenlySpacedPoints(n int) MultiPoint {
 // Densify returns a new LineString with additional linearly interpolated
 // control points such that the distance between any two consecutive control
 // points is at most the given maxDistance.
+//
+// Panics if maxDistance is zero or negative.
 func (s LineString) Densify(minDistance float64) LineString {
 	return NewLineString(densify(s.seq, minDistance))
 }

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -510,3 +510,14 @@ func (m MultiLineString) Simplify(threshold float64) MultiLineString {
 	}
 	return NewMultiLineString(lss)
 }
+
+// Densify returns a new MultiLineString with additional linearly interpolated
+// control points such that the distance between any two consecutive control
+// points is at most the given maxDistance.
+func (m MultiLineString) Densify(maxDistance float64) MultiLineString {
+	lss := make([]LineString, len(m.lines))
+	for i := range m.lines {
+		lss[i] = m.lines[i].Densify(maxDistance)
+	}
+	return MultiLineString{lss, m.ctype}
+}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -514,6 +514,8 @@ func (m MultiLineString) Simplify(threshold float64) MultiLineString {
 // Densify returns a new MultiLineString with additional linearly interpolated
 // control points such that the distance between any two consecutive control
 // points is at most the given maxDistance.
+//
+// Panics if maxDistance is zero or negative.
 func (m MultiLineString) Densify(maxDistance float64) MultiLineString {
 	lss := make([]LineString, len(m.lines))
 	for i := range m.lines {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -573,6 +573,8 @@ func (m MultiPolygon) Simplify(threshold float64, nv ...NoValidate) (MultiPolygo
 // Densify returns a new MultiPolygon with additional linearly interpolated
 // control points such that the distance between any two consecutive control
 // points is at most the given maxDistance.
+//
+// Panics if maxDistance is zero or negative.
 func (m MultiPolygon) Densify(maxDistance float64) MultiPolygon {
 	ps := make([]Polygon, len(m.polys))
 	for i, p := range m.polys {

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -569,3 +569,14 @@ func (m MultiPolygon) Simplify(threshold float64, nv ...NoValidate) (MultiPolygo
 	}
 	return simpl, nil
 }
+
+// Densify returns a new MultiPolygon with additional linearly interpolated
+// control points such that the distance between any two consecutive control
+// points is at most the given maxDistance.
+func (m MultiPolygon) Densify(maxDistance float64) MultiPolygon {
+	ps := make([]Polygon, len(m.polys))
+	for i, p := range m.polys {
+		ps[i] = p.Densify(maxDistance)
+	}
+	return MultiPolygon{ps, m.ctype}
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -681,3 +681,14 @@ func (p Polygon) Simplify(threshold float64, nv ...NoValidate) (Polygon, error) 
 	}
 	return simpl, nil
 }
+
+// Densify returns a new Polygon with additional linearly interpolated control
+// points such that the distance between any two consecutive control points is
+// at most the given maxDistance.
+func (p Polygon) Densify(maxDistance float64) Polygon {
+	rings := make([]LineString, len(p.rings))
+	for i, r := range p.rings {
+		rings[i] = r.Densify(maxDistance)
+	}
+	return Polygon{rings, p.ctype}
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -685,6 +685,8 @@ func (p Polygon) Simplify(threshold float64, nv ...NoValidate) (Polygon, error) 
 // Densify returns a new Polygon with additional linearly interpolated control
 // points such that the distance between any two consecutive control points is
 // at most the given maxDistance.
+//
+// Panics if maxDistance is zero or negative.
 func (p Polygon) Densify(maxDistance float64) Polygon {
 	rings := make([]LineString, len(p.rings))
 	for i, r := range p.rings {


### PR DESCRIPTION
## Description

These methods return copies of the input geometry that have additional control points inserted such that adjacent control points are at most a fixed distance apart.

This is useful when transforming geometries from one projection to another, since straight lines in one projection are not necessarily straight lines in other projections. The additional control points can help to retain the true shape of curves when they are transformed.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A