### PR TITLE
Fix misleading doc comments regarding validation

### DIFF
--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -256,10 +256,11 @@ func (g Geometry) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the encoding/json.Unmarshaller interface by
 // parsing the JSON stream as GeoJSON geometry object.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be unmarshalled into a
-// json.RawMessage value and then UnmarshalJSON called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the GeoJSON value should be scanned into a
+// json.RawMessage value and then UnmarshalJSON called manually (passing in
+// NoValidate{}).
 func (g *Geometry) UnmarshalJSON(p []byte) error {
 	geom, err := UnmarshalGeoJSON(p)
 	if err != nil {
@@ -345,10 +346,10 @@ func (g Geometry) Value() (driver.Value, error) {
 // Scan implements the database/sql.Scanner interface by parsing the src value
 // as WKB (Well Known Binary).
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (g *Geometry) Scan(src interface{}) error {
 	var wkb []byte
 	switch src := src.(type) {

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -175,10 +175,10 @@ func (c GeometryCollection) Value() (driver.Value, error) {
 // If the WKB doesn't represent a GeometryCollection geometry, then an error is
 // returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (c *GeometryCollection) Scan(src interface{}) error {
 	return scanAsType(src, c)
 }

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -241,10 +241,10 @@ func (s LineString) Value() (driver.Value, error) {
 //
 // If the WKB doesn't represent a LineString geometry, then an error is returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (s *LineString) Scan(src interface{}) error {
 	return scanAsType(src, s)
 }

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -266,10 +266,10 @@ func (m MultiLineString) Value() (driver.Value, error) {
 //
 // If the WKB doesn't represent a MultiLineString geometry, then an error is returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (m *MultiLineString) Scan(src interface{}) error {
 	return scanAsType(src, m)
 }

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -142,10 +142,10 @@ func (m MultiPoint) Value() (driver.Value, error) {
 //
 // If the WKB doesn't represent a MultiPoint geometry, then an error is returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (m *MultiPoint) Scan(src interface{}) error {
 	return scanAsType(src, m)
 }

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -270,10 +270,10 @@ func (m MultiPolygon) Value() (driver.Value, error) {
 //
 // If the WKB doesn't represent a MultiPolygon geometry, then an error is returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (m *MultiPolygon) Scan(src interface{}) error {
 	return scanAsType(src, m)
 }

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -119,10 +119,10 @@ func (p Point) Value() (driver.Value, error) {
 //
 // If the WKB doesn't represent a Point geometry, then an error is returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (p *Point) Scan(src interface{}) error {
 	return scanAsType(src, p)
 }

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -267,10 +267,10 @@ func (p Polygon) Value() (driver.Value, error) {
 //
 // If the WKB doesn't represent a Polygon geometry, then an error is returned.
 //
-// It constructs the resultant geometry with no ConstructionOptions. If
-// ConstructionOptions are needed, then the value should be scanned into a byte
-// slice and then UnmarshalWKB called manually (passing in the
-// ConstructionOptions as desired).
+// Geometry constraint validation is performed on the resultant geometry (an
+// error will be returned if the geometry is invalid). If this validation isn't
+// needed or is undesirable, then the WKB should be scanned into a byte slice
+// and then UnmarshalWKB called manually (passing in NoValidate{}).
 func (p *Polygon) Scan(src interface{}) error {
 	return scanAsType(src, p)
 }


### PR DESCRIPTION
## Description

There were some doc comments for JSON unmarshalling and SQL (WKB) scanning that referenced constructor options. This change updates the documentation to refer to `NoValidate` instead.

## Check List

Have you:

- Added unit tests? Yes

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A (this is too minor to bother with release notes)

## Related Issue

- N/A