### PR TITLE
Upgrade to golangci-lint v0.56.0

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.55.2
+FROM golangci/golangci-lint:v1.56.0
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -89,6 +89,7 @@ linters:
     - reassign
     - revive
     - rowserrcheck
+    - spancheck
     - sqlclosecheck
     - staticcheck
     - stylecheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ YYYY-MM-DD
 
 - Make LERP operations robust in all edge cases.
 
+- Upgrades `golangci-lint` to `v1.56.0`.
+
 ## v0.47.0
 
 2024-01-19

--- a/geom/dcel_extract_geometry.go
+++ b/geom/dcel_extract_geometry.go
@@ -1,7 +1,7 @@
 package geom
 
 import (
-	"fmt"
+	"errors"
 	"sort"
 )
 
@@ -85,7 +85,7 @@ func (d *doublyConnectedEdgeList) extractPolygons(include func([2]bool) bool) ([
 		}
 
 		if len(rings) == 0 {
-			return nil, fmt.Errorf("no rings to extract")
+			return nil, errors.New("no rings to extract")
 		}
 
 		// Construct the polygon.

--- a/geom/de9im.go
+++ b/geom/de9im.go
@@ -1,6 +1,7 @@
 package geom
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -68,10 +69,10 @@ func RelateMatches(intersectionMatrix, intersectionMatrixPattern string) (bool, 
 	mat := intersectionMatrix
 	pat := intersectionMatrixPattern
 	if len(mat) != 9 {
-		return false, fmt.Errorf("invalid matrix: length is not 9")
+		return false, errors.New("invalid matrix: length is not 9")
 	}
 	if len(pat) != 9 {
-		return false, fmt.Errorf("invalid matrix pattern: length is not 9")
+		return false, errors.New("invalid matrix pattern: length is not 9")
 	}
 
 	for i, m := range mat {

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -24,7 +24,7 @@ type wkbSyntaxError struct {
 }
 
 func (e wkbSyntaxError) Error() string {
-	return fmt.Sprintf("invalid WKB syntax: %s", e.reason)
+	return "invalid WKB syntax: " + e.reason
 }
 
 // wktSyntaxError is an error used to indicate that a serialised WKT geometry
@@ -36,7 +36,7 @@ type wktSyntaxError struct {
 }
 
 func (e wktSyntaxError) Error() string {
-	return fmt.Sprintf("invalid WKT syntax: %s", e.reason)
+	return "invalid WKT syntax: " + e.reason
 }
 
 // geojsonSyntaxError is an error used to indicate that a serialised GeoJSON geometry
@@ -48,7 +48,7 @@ type geojsonSyntaxError struct {
 }
 
 func (e geojsonSyntaxError) Error() string {
-	return fmt.Sprintf("invalid GeoJSON syntax: %s", e.reason)
+	return "invalid GeoJSON syntax: " + e.reason
 }
 
 func wrapWithGeoJSONSyntaxError(err error) error {

--- a/geom/geojson_feature_collection.go
+++ b/geom/geojson_feature_collection.go
@@ -47,7 +47,7 @@ func (f *GeoJSONFeature) UnmarshalJSON(p []byte) error {
 	f.Properties = topLevel.Properties
 
 	if topLevel.Geometry == nil {
-		return fmt.Errorf("geometry field missing or empty")
+		return errors.New("geometry field missing or empty")
 	}
 	f.Geometry = *topLevel.Geometry
 


### PR DESCRIPTION
## Description

- Introduces a new linter `spancheck` for opentelemetry spans. Even though these aren't used in simplefeatures, I figured we might as well enable it just in case those are added later.

- Adds a few fixes identified by the new version of the `perfsprint` linter.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A