### PR TITLE
Upgrade to golangci-lint v1.56.1

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.56.0
+FROM golangci/golangci-lint:v1.56.1
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ YYYY-MM-DD
 
 - Make LERP operations robust in all edge cases.
 
-- Upgrades `golangci-lint` to `v1.56.0`.
+- Upgrades `golangci-lint` to `v1.56.1`.
 
 ## v0.47.0
 


### PR DESCRIPTION
## Description

Upgrade to golangci-lint v1.56.1

Release notes are [here][1]. It's just upgraded linter versions, so no need for any config changes.

[1]: https://github.com/golangci/golangci-lint/releases/tag/v1.56.1.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A