### PR TITLE
Trigger CI when PRs are created/updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: build
 on:
   push:
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: build
 on:
   push:
+    branches:
+      - master
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
## Description

Right now, CI is not run when PRs are raised against forks. By adding `pull_request` as a triggering action, I *think* this will cause them to run for forks as well (this is a little bit experimental).

References:

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

N/A

## Benchmark Results

N/A