### PR TITLE
Add "foreign member" support for GeoJSON features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Adds "foreign member" support for GeoJSON features. This allows for
+  additional properties to be included in GeoJSON features that are not part of
+  the standard GeoJSON specification.
+
 ## v0.49.0
 
 2024-04-19

--- a/geom/geojson_feature_collection_test.go
+++ b/geom/geojson_feature_collection_test.go
@@ -187,6 +187,11 @@ func TestGeoJSONForeignMembers(t *testing.T) {
 			members: map[string]interface{}{"foo": "bar", "baz": 42.0},
 			json:    `{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{},"baz":42,"foo":"bar"}`,
 		},
+		{
+			name:    "nested",
+			members: map[string]interface{}{"metadata": map[string]interface{}{"foo": "bar", "baz": 42.0}},
+			json:    `{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{},"metadata":{"baz":42,"foo":"bar"}}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("marshal", func(t *testing.T) {

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -3,6 +3,8 @@ package geom_test
 import (
 	"bytes"
 	"math"
+	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -94,6 +96,13 @@ func expectErr(tb testing.TB, err error) {
 	}
 }
 
+func expectDeepEq(tb testing.TB, got, want interface{}) {
+	tb.Helper()
+	if !reflect.DeepEqual(got, want) {
+		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)
+	}
+}
+
 func expectGeomEq(tb testing.TB, got, want geom.Geometry, opts ...geom.ExactEqualsOption) {
 	tb.Helper()
 	if !geom.ExactEquals(got, want, opts...) {
@@ -142,8 +151,15 @@ func expectCoordsEq(tb testing.TB, got, want geom.Coordinates) {
 func expectStringEq(tb testing.TB, got, want string) {
 	tb.Helper()
 	if got != want {
-		tb.Errorf("\ngot:  %q\nwant: %q\n", got, want)
+		tb.Errorf("\ngot:  %s\nwant: %s\n", quotedString(got), quotedString(want))
 	}
+}
+
+func quotedString(s string) string {
+	if strconv.CanBackquote(s) {
+		return "`" + s + "`"
+	}
+	return strconv.Quote(s)
 }
 
 func expectIntEq(tb testing.TB, got, want int) {


### PR DESCRIPTION
## Description

Foreign members are top level feature members that are not explicitly mentioned in the GeoJSON spec, but are nonetheless allowed by it (see https://datatracker.ietf.org/doc/html/rfc7946#section-6.1).

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/596