### PR TITLE
Bugfix: check geometry collection coordinate types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Upgrades `golangci-lint` to `v1.58.0`.
 
+- Fixes a bug where geometry collections with mixed coordinate types were
+  erroneously allowed during WKT parsing.
+
 ## v0.50.0
 
 2024-05-07

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -1553,17 +1553,17 @@ func TestSummary(t *testing.T) {
 		},
 		{
 			name:        "XYZ single point",
-			wkt:         "GEOMETRYCOLLECTION (POINT Z(0 0 0.5))",
+			wkt:         "GEOMETRYCOLLECTION Z (POINT Z(0 0 0.5))",
 			wantSummary: "GeometryCollection[XYZ] with 1 child geometry consisting of 1 total point",
 		},
 		{
 			name:        "XYM single point",
-			wkt:         "GEOMETRYCOLLECTION (POINT M(0 0 0.8))",
+			wkt:         "GEOMETRYCOLLECTION M (POINT M(0 0 0.8))",
 			wantSummary: "GeometryCollection[XYM] with 1 child geometry consisting of 1 total point",
 		},
 		{
 			name:        "XYZM single point",
-			wkt:         "GEOMETRYCOLLECTION (POINT ZM(0 0 0.5 0.8))",
+			wkt:         "GEOMETRYCOLLECTION ZM (POINT ZM(0 0 0.5 0.8))",
 			wantSummary: "GeometryCollection[XYZM] with 1 child geometry consisting of 1 total point",
 		},
 		{

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -1553,17 +1553,17 @@ func TestSummary(t *testing.T) {
 		},
 		{
 			name:        "XYZ single point",
-			wkt:         "GEOMETRYCOLLECTION Z (POINT Z(0 0 0.5))",
+			wkt:         "GEOMETRYCOLLECTION (POINT Z(0 0 0.5))",
 			wantSummary: "GeometryCollection[XYZ] with 1 child geometry consisting of 1 total point",
 		},
 		{
 			name:        "XYM single point",
-			wkt:         "GEOMETRYCOLLECTION M (POINT M(0 0 0.8))",
+			wkt:         "GEOMETRYCOLLECTION (POINT M(0 0 0.8))",
 			wantSummary: "GeometryCollection[XYM] with 1 child geometry consisting of 1 total point",
 		},
 		{
 			name:        "XYZM single point",
-			wkt:         "GEOMETRYCOLLECTION ZM (POINT ZM(0 0 0.5 0.8))",
+			wkt:         "GEOMETRYCOLLECTION (POINT ZM(0 0 0.5 0.8))",
 			wantSummary: "GeometryCollection[XYZM] with 1 child geometry consisting of 1 total point",
 		},
 		{

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -58,10 +58,12 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 	return geojsonSyntaxError{err.Error()}
 }
 
-type mismatchedGeometryCollectionDimsError struct{}
+type mismatchedGeometryCollectionDimsError struct {
+	ct1, ct2 CoordinatesType
+}
 
 func (e mismatchedGeometryCollectionDimsError) Error() string {
-	return "mixed dimensions in geometry collection"
+	return fmt.Sprintf("mixed dimensions in geometry collection: %s and %s", e.ct1, e.ct2)
 }
 
 type ruleViolation string

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -58,6 +58,12 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 	return geojsonSyntaxError{err.Error()}
 }
 
+type mismatchedGeometryCollectionDimsError struct{}
+
+func (e mismatchedGeometryCollectionDimsError) Error() string {
+	return "mixed dimensions in geometry collection"
+}
+
 type ruleViolation string
 
 const (

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
@@ -152,6 +153,13 @@ func expectStringEq(tb testing.TB, got, want string) {
 	tb.Helper()
 	if got != want {
 		tb.Errorf("\ngot:  %s\nwant: %s\n", quotedString(got), quotedString(want))
+	}
+}
+
+func expectSubstring(tb testing.TB, got, wantSubstring string) {
+	tb.Helper()
+	if !strings.Contains(got, wantSubstring) {
+		tb.Errorf("\ngot:            %s\nwant substring: %s\n", quotedString(got), quotedString(wantSubstring))
 	}
 }
 

--- a/geom/wkt_parser.go
+++ b/geom/wkt_parser.go
@@ -426,6 +426,9 @@ func (p *parser) nextGeometryCollectionText(ctype CoordinatesType) (GeometryColl
 			if err != nil {
 				return GeometryCollection{}, err
 			}
+			//if g.CoordinatesType() != ctype {
+			//	return GeometryCollection{}, mismatchedGeometryCollectionDims{}
+			//}
 			geoms = append(geoms, g)
 			tok, err := p.nextCommaOrRightParen()
 			if err != nil {
@@ -436,8 +439,23 @@ func (p *parser) nextGeometryCollectionText(ctype CoordinatesType) (GeometryColl
 			}
 		}
 	}
+	if err := checkGeomCollectionCoordTypeConsistency(ctype, geoms); err != nil {
+		return GeometryCollection{}, err
+	}
 	if len(geoms) == 0 {
 		return GeometryCollection{}.ForceCoordinatesType(ctype), nil
 	}
 	return NewGeometryCollection(geoms), nil
+}
+
+func checkGeomCollectionCoordTypeConsistency(ct CoordinatesType, gs []Geometry) error {
+	if len(gs) == 0 {
+		return nil
+	}
+	for _, g := range gs {
+		if g.CoordinatesType() != ct {
+			return mismatchedGeometryCollectionDimsError{}
+		}
+	}
+	return nil
 }

--- a/geom/wkt_test.go
+++ b/geom/wkt_test.go
@@ -240,13 +240,16 @@ func TestInconsistentDimensionTypeInWKT(t *testing.T) {
 		{false, "GEOMETRYCOLLECTION ZM(POINT M(1 2 0))"},
 		{false, "GEOMETRYCOLLECTION ZM(POINT Z(1 2 0))"},
 
-		// NOTE: these forms are accepted by PostGIS, but banned by the OGC spec.
-		{false, "GEOMETRYCOLLECTION (POINT Z(1 2 0))"},
-		{false, "GEOMETRYCOLLECTION (POINT M(1 2 0))"},
-		{false, "GEOMETRYCOLLECTION (POINT ZM(1 2 0 0))"},
 		{false, "GEOMETRYCOLLECTION (POINT (1 2), POINT Z(2 3 0))"},
 		{false, "GEOMETRYCOLLECTION (POINT (1 2), POINT M(2 3 0))"},
 		{false, "GEOMETRYCOLLECTION (POINT (1 2), POINT ZM(2 3 0 0))"},
+
+		// These forms are accepted by PostGIS, but banned by the OGC spec.
+		// Simplefeatures follows the PostGIS behaviour (since it's a
+		// reasonable extension).
+		{true, "GEOMETRYCOLLECTION (POINT Z(1 2 0))"},
+		{true, "GEOMETRYCOLLECTION (POINT M(1 2 0))"},
+		{true, "GEOMETRYCOLLECTION (POINT ZM(1 2 0 0))"},
 	} {
 		t.Run(tc.wkt, func(t *testing.T) {
 			_, err := geom.UnmarshalWKT(tc.wkt)
@@ -255,7 +258,7 @@ func TestInconsistentDimensionTypeInWKT(t *testing.T) {
 				return
 			}
 			expectErr(t, err)
-			expectStringEq(t, err.Error(), "mixed dimensions in geometry collection")
+			expectSubstring(t, err.Error(), "mixed dimensions in geometry collection")
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes a bug where geometry collection coordinate types were allowed to mismatch. E.g. `GEOMETRYCOLLECTION M(POINT Z(1 2 0))` is not allowed because the collection is marked as `M` but the point is marked as `Z`.

An extension beyond the OGC standard is implemented, allowing untagged geometry collections to contain any coordinate types, so long as they are all the same. So `GEOMETRYCOLLECTION(POINT M(1 2 0), POINT M(2 3 0))` is allowed, but `GEOMETRYCOLLECTION(POINT Z(1 2 0), POINT M(2 3 4))` is not.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/397