### PR TITLE
Bump `golangci-lint` to v1.58.1

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.58.0
+FROM golangci/golangci-lint:v1.58.1
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Upgrades `golangci-lint` to `v1.58.0`.
+- Upgrades `golangci-lint` to `v1.58.1`.
 
 ## v0.50.0
 


### PR DESCRIPTION
## Description

    
There aren't any changes from v1.58.0 to v1.58.1 other than bumping the versions of some linters.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A