### PR TITLE
Add dimension check when parsing WKB GeometryCollections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Upgrades `golangci-lint` to `v1.58.0`.
 
 - Fixes a bug where geometry collections with mixed coordinate types were
-  erroneously allowed during WKT parsing.
+  erroneously allowed during WKT and WKB parsing.
 
 ## v0.50.0
 

--- a/geom/wkb_parser.go
+++ b/geom/wkb_parser.go
@@ -364,6 +364,13 @@ func (p *wkbParser) parseGeometryCollection(ctype CoordinatesType) (GeometryColl
 		if err != nil {
 			return GeometryCollection{}, err
 		}
+		if geoms[i].CoordinatesType() != ctype {
+			err := mismatchedGeometryCollectionDimsError{
+				ctype,
+				geoms[i].CoordinatesType(),
+			}
+			return GeometryCollection{}, err
+		}
 	}
 	return NewGeometryCollection(geoms), nil
 }


### PR DESCRIPTION
## Description

Add dimension check when parsing WKB GeometryCollections
    
This ensures that coordinate types are consistent between the geometry collection and its children.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/397