### PR TITLE
Better error assertions in tests

### DIFF
--- a/geom/errors.go
+++ b/geom/errors.go
@@ -59,11 +59,11 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 }
 
 type mismatchedGeometryCollectionDimsError struct {
-	ct1, ct2 CoordinatesType
+	CT1, CT2 CoordinatesType
 }
 
 func (e mismatchedGeometryCollectionDimsError) Error() string {
-	return fmt.Sprintf("mixed dimensions in geometry collection: %s and %s", e.ct1, e.ct2)
+	return fmt.Sprintf("mixed dimensions in geometry collection: %s and %s", e.CT1, e.CT2)
 }
 
 type ruleViolation string

--- a/geom/export_test.go
+++ b/geom/export_test.go
@@ -1,0 +1,3 @@
+package geom
+
+type MismatchedGeometryCollectionDimsError = mismatchedGeometryCollectionDimsError

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -2,6 +2,7 @@ package geom_test
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"reflect"
 	"strconv"
@@ -97,6 +98,21 @@ func expectErr(tb testing.TB, err error) {
 	}
 }
 
+func expectErrIs(tb testing.TB, err, want error) {
+	tb.Helper()
+	if !errors.Is(err, want) {
+		tb.Errorf("\ngot:  %v\nwant: %v\n", err, want)
+	}
+}
+
+func expectErrAs(tb testing.TB, err error, target interface{}) {
+	tb.Helper()
+	if !errors.As(err, target) {
+		targetType := reflect.ValueOf(target).Elem().Interface()
+		tb.Errorf("%#v not assignable after unwrapping to %T", err, targetType)
+	}
+}
+
 func expectDeepEq(tb testing.TB, got, want interface{}) {
 	tb.Helper()
 	if !reflect.DeepEqual(got, want) {
@@ -156,6 +172,7 @@ func expectStringEq(tb testing.TB, got, want string) {
 	}
 }
 
+//nolint:unused
 func expectSubstring(tb testing.TB, got, wantSubstring string) {
 	tb.Helper()
 	if !strings.Contains(got, wantSubstring) {

--- a/geom/wkb_test.go
+++ b/geom/wkb_test.go
@@ -716,7 +716,8 @@ func TestWKBGeometryCollectionMixedCoordinateTypes(t *testing.T) {
 				if gc.ct == point.ct {
 					expectNoErr(t, err)
 				} else {
-					expectErr(t, err)
+					wantErr := geom.MismatchedGeometryCollectionDimsError{gc.ct, point.ct}
+					expectErrIs(t, err, wantErr)
 				}
 			})
 		}

--- a/geom/wkt_test.go
+++ b/geom/wkt_test.go
@@ -257,8 +257,8 @@ func TestInconsistentDimensionTypeInWKT(t *testing.T) {
 				expectNoErr(t, err)
 				return
 			}
-			expectErr(t, err)
-			expectSubstring(t, err.Error(), "mixed dimensions in geometry collection")
+			want := geom.MismatchedGeometryCollectionDimsError{}
+			expectErrAs(t, err, &want)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This change introduces better error assertions, prompted by a comment from Albert Teoh here: https://github.com/peterstace/simplefeatures/pull/615#discussion_r1601290941

The change introduces two new test helper functions:

- `expectErrIs(tb testing.TB, err, want error)`

- `expectErrAs(tb testing.TB, err error, target interface{})`

These wrap `errors.Is` and `errors.As` functions from the standard library, respectively.

In order for this to work, the `mismatchedGeometryCollectionDimsError` must be exported, but _only during tests_ (because we don't want to expose it to users of the library). This is achieved by using type aliases in a `_test.go` file in the `geom` package. Because `_test.go` files are only included during tests, this is a safe way to expose the type only during tests.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A (internal change, so probably doesn't need them).

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/397