### PR TITLE
Further test error assertion improvements

### DIFF
--- a/geom/alg_simplify_test.go
+++ b/geom/alg_simplify_test.go
@@ -142,7 +142,8 @@ func TestSimplifyErrorCases(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			in := geomFromWKT(t, tc.wkt)
 			_, err := in.Simplify(tc.threshold)
-			expectErr(t, err)
+			var want geom.ValidationError
+			expectErrAs(t, err, &want)
 		})
 	}
 }

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -58,6 +58,18 @@ func wrapWithGeoJSONSyntaxError(err error) error {
 	return geojsonSyntaxError{err.Error()}
 }
 
+type unmarshalGeoJSONSourceDestinationMismatchError struct {
+	SourceType      GeometryType
+	DestinationType GeometryType
+}
+
+func (e unmarshalGeoJSONSourceDestinationMismatchError) Error() string {
+	return fmt.Sprintf(
+		"cannot unmarshal GeoJSON of type %s into %s",
+		e.SourceType, e.DestinationType,
+	)
+}
+
 type mismatchedGeometryCollectionDimsError struct {
 	CT1, CT2 CoordinatesType
 }
@@ -84,34 +96,34 @@ const (
 
 func (v ruleViolation) errAtXY(location XY) error {
 	return validationError{
-		ruleViolation: v,
-		hasLocation:   true,
-		location:      location,
+		RuleViolation: v,
+		HasLocation:   true,
+		Location:      location,
 	}
 }
 
 func (v ruleViolation) errAtPt(location Point) error {
 	xy, ok := location.XY()
 	return validationError{
-		ruleViolation: v,
-		hasLocation:   ok,
-		location:      xy,
+		RuleViolation: v,
+		HasLocation:   ok,
+		Location:      xy,
 	}
 }
 
 func (v ruleViolation) err() error {
-	return validationError{ruleViolation: v}
+	return validationError{RuleViolation: v}
 }
 
 type validationError struct {
-	ruleViolation ruleViolation
-	hasLocation   bool
-	location      XY
+	RuleViolation ruleViolation
+	HasLocation   bool
+	Location      XY
 }
 
 func (e validationError) Error() string {
-	if e.hasLocation {
-		return fmt.Sprintf("%s (at or near %v)", e.ruleViolation, e.location)
+	if e.HasLocation {
+		return fmt.Sprintf("%s (at or near %v)", e.RuleViolation, e.Location)
 	}
-	return string(e.ruleViolation)
+	return string(e.RuleViolation)
 }

--- a/geom/export_test.go
+++ b/geom/export_test.go
@@ -1,3 +1,30 @@
 package geom
 
+// The following types are exported for testing purposes only.
+//
+// Because this file ends in `_test.go`, it is not included in non-test builds.
+// But because it's in the `geom` package, it's able to access unexported types
+// from other files in the `geom` package.
+
 type MismatchedGeometryCollectionDimsError = mismatchedGeometryCollectionDimsError
+
+type UnmarshalGeoJSONSourceDestinationMismatchError = unmarshalGeoJSONSourceDestinationMismatchError
+
+type (
+	ValidationError = validationError
+	RuleViolation   = ruleViolation
+)
+
+const (
+	ViolateInf                = violateInf
+	ViolateNaN                = violateNaN
+	ViolateTwoPoints          = violateTwoPoints
+	ViolateRingEmpty          = violateRingEmpty
+	ViolateRingClosed         = violateRingClosed
+	ViolateRingSimple         = violateRingSimple
+	ViolateRingNested         = violateRingNested
+	ViolateInteriorInExterior = violateInteriorInExterior
+	ViolateInteriorConnected  = violateInteriorConnected
+	ViolateRingsMultiTouch    = violateRingsMultiTouch
+	ViolatePolysMultiTouch    = violatePolysMultiTouch
+)

--- a/geom/geojson_unmarshal_test.go
+++ b/geom/geojson_unmarshal_test.go
@@ -458,13 +458,18 @@ func TestGeoJSONUnmarshalIntoConcreteGeometryWrongType(t *testing.T) {
 			} {
 				srcTyp := geomFromGeoJSON(t, geojson).Type()
 				t.Run("source_"+srcTyp.String(), func(t *testing.T) {
-					if srcTyp == tc.dest.Type() {
+					destType := tc.dest.Type()
+					if srcTyp == destType {
 						// This test suite is for negative test cases, however
 						// this test case would always succeed.
 						return
 					}
 					err := json.Unmarshal([]byte(geojson), tc.dest)
-					expectErr(t, err)
+					want := geom.UnmarshalGeoJSONSourceDestinationMismatchError{
+						SourceType:      srcTyp,
+						DestinationType: destType,
+					}
+					expectErrIs(t, err, want)
 				})
 			}
 		})

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -280,7 +280,10 @@ func unmarshalGeoJSONAsType(p []byte, dst interface{}) error {
 	}
 	dstType := dst.(interface{ Type() GeometryType }).Type()
 	if g.Type() != dstType {
-		return fmt.Errorf("cannot unmarshal GeoJSON of type %s into %s", g.Type(), dstType)
+		return unmarshalGeoJSONSourceDestinationMismatchError{
+			SourceType:      g.Type(),
+			DestinationType: dstType,
+		}
 	}
 	assignToConcrete(dst, g)
 	return nil

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/peterstace/simplefeatures/geom"
 )
 
-//nolint:unparam
 func geomFromWKT(tb testing.TB, wkt string, nv ...geom.NoValidate) geom.Geometry {
 	tb.Helper()
 	geom, err := geom.UnmarshalWKT(wkt, nv...)
@@ -91,6 +90,7 @@ func expectNoErr(tb testing.TB, err error) {
 	}
 }
 
+//nolint:unused
 func expectErr(tb testing.TB, err error) {
 	tb.Helper()
 	if err == nil {
@@ -111,6 +111,25 @@ func expectErrAs(tb testing.TB, err error, target interface{}) {
 		targetType := reflect.ValueOf(target).Elem().Interface()
 		tb.Errorf("%#v not assignable after unwrapping to %T", err, targetType)
 	}
+}
+
+func expectValidationErrWithReason(tb testing.TB, err error, reason geom.RuleViolation) {
+	tb.Helper()
+	var ve geom.ValidationError
+	expectErrAs(tb, err, &ve)
+	expectStringEq(tb, string(ve.RuleViolation), string(reason))
+}
+
+// expectValidity either expects the geometry/envelope to be valid (when rv is
+// ""), or the geometry to be invalid with the given rule violation.
+func expectValidity(tb testing.TB, g interface{ Validate() error }, rv geom.RuleViolation) {
+	tb.Helper()
+	err := g.Validate()
+	if rv == "" {
+		expectNoErr(tb, err)
+		return
+	}
+	expectValidationErrWithReason(tb, err, rv)
 }
 
 func expectDeepEq(tb testing.TB, got, want interface{}) {


### PR DESCRIPTION
## Description

This is a follow-on from https://github.com/peterstace/simplefeatures/pull/616.

It adds additional improvements to error assertions during testing, including:

- Asserting on GeoJSON unmarshalling target mismatch errors (when GeoJSON is unmarshalled into the wrong type).

- Asserting on validation errors (with assertions that the expected validation rule violation occurred).

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A.

## Related Issue

- N/A