### PR TITLE
Fix doc comment for `geos.ConcaveHull`

### DIFF
--- a/geos/entrypoints.go
+++ b/geos/entrypoints.go
@@ -287,9 +287,13 @@ func UnaryUnion(g geom.Geometry) (geom.Geometry, error) {
 	return rawgeos.UnaryUnion(g)
 }
 
-// ConcaveHull returns concave hull of input geometry.
-// concavenessRatio - ratio 0 to 1 (0 - max concaveness, 1 - convex hull)
-// allowHoles - true to allow holes inside of polygons.
+// ConcaveHull returns a concave hull of the input. A concave hull is generally
+// a Polygon, but could also be a 2-point LineString or a Point in degenerate
+// cases. It will be made of vertices that are a subset of the input vertices.
+// The concavenessRatio parameter controls the concaveness of the hull (a value
+// of 1 will produce convex hulls, and a value of 0 will produce maximally
+// concave hulls). The allowHoles parameter controls whether holes are allowed
+// in the hull.
 func ConcaveHull(g geom.Geometry, concavenessRatio float64, allowHoles bool) (geom.Geometry, error) {
 	return rawgeos.ConcaveHull(g, concavenessRatio, allowHoles)
 }

--- a/internal/rawgeos/entrypoints.go
+++ b/internal/rawgeos/entrypoints.go
@@ -364,7 +364,7 @@ func ConvexHull(g geom.Geometry) (geom.Geometry, error) {
 	return result, wrap(err, "executing GEOSConvexHull_r")
 }
 
-func ConcaveHull(g geom.Geometry, pctconvex float64, allowHoles bool) (geom.Geometry, error) {
+func ConcaveHull(g geom.Geometry, ratio float64, allowHoles bool) (geom.Geometry, error) {
 	if C.CONCAVE_HULL_MISSING != 0 {
 		return geom.Geometry{}, unsupportedGEOSVersionError{
 			C.CONCAVE_HULL_MIN_VERSION, "ConcaveHull",
@@ -375,7 +375,7 @@ func ConcaveHull(g geom.Geometry, pctconvex float64, allowHoles bool) (geom.Geom
 		if allowHoles {
 			ah = 1
 		}
-		return C.GEOSConcaveHull_r(ctx, g, C.double(pctconvex), ah)
+		return C.GEOSConcaveHull_r(ctx, g, C.double(ratio), ah)
 	})
 	return result, wrap(err, "executing GEOSConcaveHull_r")
 }


### PR DESCRIPTION
## Description

Godoc was rendering the doc comment in a bit of a weird way. This commit fixes that (and also adds a bit more detail).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

## Related Issue

- N/A