### PR TITLE
Wrap `GEOSTopologyPreserveSimplify_r`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fixes a bug where the `Simplify` method would drop coordinate type to XY in
   some scenarios where the result is an empty geometry.
 
+- Adds a wrapper to the `geos` package for the `GEOSTopologyPreserveSimplify_r`
+  function (exposed as `TopologyPreserveSimplify`).
+
 ## v0.50.0
 
 2024-05-07

--- a/geos/entrypoints.go
+++ b/geos/entrypoints.go
@@ -231,12 +231,12 @@ func Simplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
 	return rawgeos.Simplify(g, tolerance)
 }
 
-// TopologyPresereSimplify creates a simplified version of a geometry using
+// TopologyPreserveSimplify creates a simplified version of a geometry using
 // the Douglas-Peucker algorithm. An attempt is made to preserve topological
 // invariants, e.g.  ring collapse and intersection.
 //
 // The validity of the result is not checked.
-func TopologyPresereSimplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
+func TopologyPreserveSimplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
 	return rawgeos.TopologyPreserveSimplify(g, tolerance)
 }
 

--- a/geos/entrypoints.go
+++ b/geos/entrypoints.go
@@ -231,6 +231,15 @@ func Simplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
 	return rawgeos.Simplify(g, tolerance)
 }
 
+// TopologyPresereSimplify creates a simplified version of a geometry using
+// the Douglas-Peucker algorithm. An attempt is made to preserve topological
+// invariants, e.g.  ring collapse and intersection.
+//
+// The validity of the result is not checked.
+func TopologyPresereSimplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
+	return rawgeos.TopologyPreserveSimplify(g, tolerance)
+}
+
 // Difference returns the geometry that represents the parts of input geometry
 // A that are not part of input geometry B.
 //

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -784,6 +784,16 @@ func TestSimplify(t *testing.T) {
 	}
 }
 
+func TestTopologyPreserveSimplify(t *testing.T) {
+	const (
+		input  = `POLYGON((0 0,0 1,-0.5 1.5,0 2,0 3,3 3,3 0,0 0),(-0.1 1.5,2 2,2 1,-0.1 1.5))`
+		output = `POLYGON((0 0,-0.5 1.5,0 3,3 3,3 0,0 0),(-0.1 1.5,2 2,2 1,-0.1 1.5))`
+	)
+	got, err := geos.TopologyPresereSimplify(geomFromWKT(t, input), 0.5)
+	expectNoErr(t, err)
+	expectGeomEq(t, got, geomFromWKT(t, output), geom.IgnoreOrder)
+}
+
 func TestDifference(t *testing.T) {
 	a := geomFromWKT(t, "POLYGON((0 0,0 2,2 2,2 0,0 0))")
 	b := geomFromWKT(t, "POLYGON((1 1,1 3,3 3,3 1,1 1))")

--- a/geos/entrypoints_test.go
+++ b/geos/entrypoints_test.go
@@ -789,7 +789,7 @@ func TestTopologyPreserveSimplify(t *testing.T) {
 		input  = `POLYGON((0 0,0 1,-0.5 1.5,0 2,0 3,3 3,3 0,0 0),(-0.1 1.5,2 2,2 1,-0.1 1.5))`
 		output = `POLYGON((0 0,-0.5 1.5,0 3,3 3,3 0,0 0),(-0.1 1.5,2 2,2 1,-0.1 1.5))`
 	)
-	got, err := geos.TopologyPresereSimplify(geomFromWKT(t, input), 0.5)
+	got, err := geos.TopologyPreserveSimplify(geomFromWKT(t, input), 0.5)
 	expectNoErr(t, err)
 	expectGeomEq(t, got, geomFromWKT(t, output), geom.IgnoreOrder)
 }

--- a/internal/rawgeos/entrypoints.go
+++ b/internal/rawgeos/entrypoints.go
@@ -222,6 +222,13 @@ func Simplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
 	return result, wrap(err, "executing GEOSSimplify_r")
 }
 
+func TopologyPreserveSimplify(g geom.Geometry, tolerance float64) (geom.Geometry, error) {
+	result, err := unaryOpG(g, func(ctx C.GEOSContextHandle_t, gh *C.GEOSGeometry) *C.GEOSGeometry {
+		return C.GEOSTopologyPreserveSimplify_r(ctx, gh, C.double(tolerance))
+	})
+	return result, wrap(err, "executing GEOSSimplifyPreserveTopology_r")
+}
+
 func Difference(a, b geom.Geometry) (geom.Geometry, error) {
 	result, err := binaryOpG(a, b, func(ctx C.GEOSContextHandle_t, a, b *C.GEOSGeometry) *C.GEOSGeometry {
 		return C.GEOSDifference_r(ctx, a, b)


### PR DESCRIPTION
## Description

`TopologyPreserveSimplify` is similar to `Simplify` but preserves (where possible) topological invariants, e.g. ring collapse and intersection.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- Resolves https://github.com/peterstace/simplefeatures/issues/424