### PR TITLE
Upgrade to `golangci-lint` `v1.59.0`

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.58.2
+FROM golangci/golangci-lint:v1.59.0
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -112,17 +112,7 @@ linters:
   disable:
 
     # Deprecated by golangci-lint:
-    - deadcode
     - execinquery
-    - exhaustivestruct
-    - golint
-    - ifshort
-    - interfacer
-    - maligned
-    - nosnakecase
-    - scopelint
-    - structcheck
-    - varcheck
 
     # The following are disabled because they're not a good match for
     # simplefeatures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Upgrades `golangci-lint` to `v1.58.2`.
+- Upgrades `golangci-lint` to `v1.59.0`.
 
 - Fixes a bug where geometry collections with mixed coordinate types were
   erroneously allowed during WKT and WKB parsing.


### PR DESCRIPTION
## Description

The linters removed from the configuration file have moved from "deprecated" to actually "removed" in `golangci-lint` `v1.59.0` (so would result in a warning being emitted if present in the config).

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A