### PR TITLE
Fix bug in polygon validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fixes a Polygon validation bug that falsely identified an invalid ring as
+  being valid. The bug occurred in the rare edge case where an inner ring is
+  outside the outer ring and the first control point of the inner ring touches
+  the outer ring.
+
 - Upgrades `golangci-lint` to `v1.59.1`.
 
 - Fixes a bug where geometry collections with mixed coordinate types were

--- a/geom/validation_test.go
+++ b/geom/validation_test.go
@@ -162,6 +162,14 @@ func TestPolygonValidation(t *testing.T) {
 			geom.ViolateRingEmpty,
 			`POLYGON((0 0,0 1,1 0,0 0),EMPTY)`,
 		},
+		{
+			// https://github.com/peterstace/simplefeatures/issues/631
+			geom.ViolateInteriorInExterior,
+			`POLYGON(
+				(1 1,5 1,5 5,1 5,1 1),
+				(3 1,6 0,6 6,0 6,0 0,3 1)
+			)`,
+		},
 	} {
 		t.Run("invalid_"+strconv.Itoa(i), func(t *testing.T) {
 			t.Run("Constructor", func(t *testing.T) {


### PR DESCRIPTION
## Description

The bug caused some invalid polygons to be incorrectly identified as valid. Specifically, the bug occurred when an inner ring is outside of the outer ring, and the first control point of the inner ring is touching the outer ring.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/631
