### PR TITLE
Upgrade to golangci-lint v0.60.3

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.60.1
+FROM golangci/golangci-lint:v1.60.3
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,10 @@ issues:
       linters:
         - thelper
 
+    - text: "G115.*"
+      linters:
+        - gosec
+
 linters-settings:
   depguard:
     rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Upgrades `golangci-lint` to `v1.60.1`.
+- Upgrades `golangci-lint` to `v1.60.3`.
 
 ## v0.51.0
 


### PR DESCRIPTION
## Description

The only breakages were related to `gosec`, with the "G115" rule being triggered (the rule relates to potential integer overflows). These were all false positives, so I just disabled that particular rule.


## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- N/A
