### PR TITLE
Geometry constructors that accept coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Upgrades `golangci-lint` to `v1.60.3`.
 
+- Adds a new group of functions to the `geom` package that construct
+  geometries. These functions have names in the form `New{Type}{Dimension}`,
+  where `Type` is one of {`Point`, `LineString`, `Polygon`, `MultiPoint`,
+  `MultiLineString`, `MultiPolygon`}, and `Dimension` is one of {`XY`, `XYZ`,
+  `XYM`, `XYZM`}. They accept coordinates at the appropriate level of nesting
+  that corresponds to the geometry type. These functions panic if the number of
+  coordinates provided is not consistent with the dimension (this behaviour is
+  consistent with the behaviour of the `NewSequence` function).
+
 ## v0.51.0
 
 2024-08-19

--- a/geom/ctor_from_coords.go
+++ b/geom/ctor_from_coords.go
@@ -309,30 +309,31 @@ func multiPointFromCoords(coords []float64, ct CoordinatesType) MultiPoint {
 		return MultiPoint{}.ForceCoordinatesType(ct)
 	}
 
-	if len(coords)%ct.Dimension() != 0 {
+	dim := ct.Dimension()
+	if len(coords)%dim != 0 {
 		msg := fmt.Sprintf(
 			"geom: coordinate arguments to %s constructor "+
 				"must have a length that is a multiple of %d",
-			ct.String(), ct.Dimension(),
+			ct.String(), dim,
 		)
 		panic(msg)
 	}
 
-	n := len(coords) / ct.Dimension()
+	n := len(coords) / dim
 	pts := make([]Point, n)
 	for i := 0; i < n; i++ {
 		c := Coordinates{
 			XY: XY{
-				coords[i*ct.Dimension()+0],
-				coords[i*ct.Dimension()+1],
+				coords[i*dim+0],
+				coords[i*dim+1],
 			},
 			Type: ct,
 		}
 		if ct.Is3D() {
-			c.Z = coords[i*ct.Dimension()+2]
+			c.Z = coords[i*dim+2]
 		}
 		if ct.IsMeasured() {
-			c.M = coords[i*ct.Dimension()+ct.Dimension()-1]
+			c.M = coords[i*dim+dim-1]
 		}
 		pts[i] = NewPoint(c)
 	}

--- a/geom/ctor_from_coords.go
+++ b/geom/ctor_from_coords.go
@@ -227,6 +227,53 @@ func NewPolygonXYZM(xyzms ...[]float64) Polygon {
 	return polygonFromCoords(xyzms, DimXYZM)
 }
 
+// NewSingleRingPolygonXY builds a new XY Polygon from the x and y coordinates
+// of its exterior ring, in the form x1, y1, x2, y2, ..., xn, yn, x1, y1 (the
+// first and last coordinates of the ring should be the same). If the number of
+// coordinates is not a multiple of 2 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewSingleRingPolygonXY(xys ...float64) Polygon {
+	return NewPolygonXY(xys)
+}
+
+// NewSingleRingPolygonXYZ builds a new XYZ Polygon from the x, y and z
+// coordinates of its exterior ring, in the form x1, y1, z1, x2, y2, z2, ...,
+// xn, yn, zn, x1, y1, z1 (the first and last coordinates of the ring should be
+// the same). If the number of coordinates is not a multiple of 3 the function
+// will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewSingleRingPolygonXYZ(xyzs ...float64) Polygon {
+	return NewPolygonXYZ(xyzs)
+}
+
+// NewSingleRingPolygonXYM builds a new XYM Polygon from the x, y and m
+// coordinates of its exterior ring, in the form x1, y1, m1, x2, y2, m2, ...,
+// xn, yn, mn, x1, y1, m1 (the first and last coordinates of the ring should be
+// the same). If the number of coordinates is not a multiple of 3 the function
+// will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewSingleRingPolygonXYM(xyms ...float64) Polygon {
+	return NewPolygonXYM(xyms)
+}
+
+// NewSingleRingPolygonXYZM builds a new XYZM Polygon from the x, y, z and m
+// coordinates of its exterior ring, in the form x1, y1, z1, m1, x2, y2, z2,
+// m2, ..., xn, yn, zn, mn, x1, y1, z1, m1 (the first and last coordinates of
+// the ring should be the same). If the number of coordinates is not a multiple
+// of 4 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewSingleRingPolygonXYZM(xyzms ...float64) Polygon {
+	return NewPolygonXYZM(xyzms)
+}
+
 // NewMultiPolygonXY builds a new XY MultiPolygon from the x and y coordinates
 // of its Polygons, each in its own slice of rings. Ring coordinates are in the
 // form x1, y1, x2, y2, ..., xn, yn, x1, y1 (the first and last coordinates of

--- a/geom/ctor_from_coords.go
+++ b/geom/ctor_from_coords.go
@@ -1,0 +1,384 @@
+package geom
+
+import "fmt"
+
+// NewPointXY builds a new XY Point from its x and y coordinates.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPointXY(x, y float64) Point {
+	c := Coordinates{XY: XY{x, y}, Type: DimXY}
+	return NewPoint(c)
+}
+
+// NewPointXYZ builds new XYZ Point from its x, y and z coordinates.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPointXYZ(x, y, z float64) Point {
+	c := Coordinates{XY: XY{x, y}, Z: z, Type: DimXYZ}
+	return NewPoint(c)
+}
+
+// NewPointXYM builds a new XYM Point from its x, y and m coordinates.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPointXYM(x, y, m float64) Point {
+	c := Coordinates{XY: XY{x, y}, M: m, Type: DimXYM}
+	return NewPoint(c)
+}
+
+// NewPointXYZM builds a new XYZM Point from its x, y, z and m coordinates.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPointXYZM(x, y, z, m float64) Point {
+	c := Coordinates{XY: XY{x, y}, Z: z, M: m, Type: DimXYZM}
+	return NewPoint(c)
+}
+
+// NewMultiPointXY builds a new XY MultiPoint from its x and y coordinates, x1,
+// y1, x2, y2, ..., xn, yn. If the number of coordinates is not a multiple of 2
+// the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPointXY(xys ...float64) MultiPoint {
+	xys = clone1DFloat64s(xys)
+	return multiPointFromCoords(xys, DimXY)
+}
+
+// NewMultiPointXYZ builds a new XYZ MultiPoint from its x, y and z
+// coordinates, x1, y1, z1, x2, y2, z2, ..., xn, yn, zn. If the number of
+// coordinates is not a multiple of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPointXYZ(xyzs ...float64) MultiPoint {
+	xyzs = clone1DFloat64s(xyzs)
+	return multiPointFromCoords(xyzs, DimXYZ)
+}
+
+// NewMultiPointXYM builds a new XYM MultiPoint from its x, y and m
+// coordinates, x1, y1, m1, x2, y2, m2, ..., xn, yn, mn. If the number of
+// coordinates is not a multiple of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPointXYM(xyms ...float64) MultiPoint {
+	xyms = clone1DFloat64s(xyms)
+	return multiPointFromCoords(xyms, DimXYM)
+}
+
+// NewMultiPointXYZM builds a new XYZM MultiPoint from its x, y, z and m
+// coordinates, x1, y1, z1, m1, x2, y2, z2, m2, ..., xn, yn, zn, mn. If the
+// number of coordinates is not a multiple of 4 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPointXYZM(xyzms ...float64) MultiPoint {
+	xyzms = clone1DFloat64s(xyzms)
+	return multiPointFromCoords(xyzms, DimXYZM)
+}
+
+// NewLineStringXY builds a new XY LineString from its x and y coordinates, x1,
+// y1, x2, y2, ..., xn, yn. If the number of coordinates is not a multiple of 2
+// the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewLineStringXY(xys ...float64) LineString {
+	xys = clone1DFloat64s(xys)
+	return lineStringFromCoords(xys, DimXY)
+}
+
+// NewLineStringXYZ builds a new XYZ LineString from its x, y and z
+// coordinates, x1, y1, z1, x2, y2, z2, ..., xn, yn, zn. If the number of
+// coordinates is not a multiple of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewLineStringXYZ(xyzs ...float64) LineString {
+	xyzs = clone1DFloat64s(xyzs)
+	return lineStringFromCoords(xyzs, DimXYZ)
+}
+
+// NewLineStringXYM builds a new XYM LineString from its x, y and m
+// coordinates, x1, y1, m1, x2, y2, m2, ..., xn, yn, mn. If the number of
+// coordinates is not a multiple of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewLineStringXYM(xyms ...float64) LineString {
+	xyms = clone1DFloat64s(xyms)
+	return lineStringFromCoords(xyms, DimXYM)
+}
+
+// NewLineStringXYZM builds a new XYZM LineString from its x, y, z and m
+// coordinates, x1, y1, z1, m1, x2, y2, z2, m2, ..., xn, yn, zn, mn. If the
+// number of coordinates is not a multiple of 4 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewLineStringXYZM(xyzms ...float64) LineString {
+	xyzms = clone1DFloat64s(xyzms)
+	return lineStringFromCoords(xyzms, DimXYZM)
+}
+
+// NewMultiLineStringXY builds a new XY MultiLineString from the x and y
+// coordinates of its LineStrings, each in its own slice, in the form x1, y1,
+// x2, y2, ..., xn, yn. If the number of coordinates for each LineString is not
+// a multiple of 2 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiLineStringXY(xys ...[]float64) MultiLineString {
+	xys = clone2DFloat64s(xys)
+	return multiLineStringFromCoords(xys, DimXY)
+}
+
+// NewMultiLineStringXYZ builds a new XYZ MultiLineString from the x, y and z
+// coordinates of its LineStrings, each in its own slice, in the form x1, y1,
+// z1, x2, y2, z2, ..., xn, yn, zn. If the number of coordinates for each
+// LineString is not a multiple of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiLineStringXYZ(xyzs ...[]float64) MultiLineString {
+	xyzs = clone2DFloat64s(xyzs)
+	return multiLineStringFromCoords(xyzs, DimXYZ)
+}
+
+// NewMultiLineStringXYM builds a new XYM MultiLineString from the x, y and m
+// coordinates of its LineStrings, each in its own slice, in the form x1, y1,
+// m1, x2, y2, m2, ..., xn, yn, mn. If the number of coordinates for each
+// LineString is not a multiple of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiLineStringXYM(xyms ...[]float64) MultiLineString {
+	xyms = clone2DFloat64s(xyms)
+	return multiLineStringFromCoords(xyms, DimXYM)
+}
+
+// NewMultiLineStringXYZM builds a new XYZM MultiLineString from the x, y, z
+// and m coordinates of its LineStrings, each in its own slice, in the form x1,
+// y1, z1, m1, x2, y2, z2, m2, ..., xn, yn, zn, mn. If the number of
+// coordinates for each LineString is not a multiple of 4 the function will
+// panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiLineStringXYZM(xyzms ...[]float64) MultiLineString {
+	xyzms = clone2DFloat64s(xyzms)
+	return multiLineStringFromCoords(xyzms, DimXYZM)
+}
+
+// NewPolygonXY builds a new XY Polygon from the x and y coordinates of its
+// rings, each in its own slice, in the form x1, y1, x2, y2, ..., xn, yn, x1,
+// y1 (the first and last coordinates of each ring should be the same). If the
+// number of coordinates for each ring is not a multiple of 2 the function will
+// panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPolygonXY(xys ...[]float64) Polygon {
+	xys = clone2DFloat64s(xys)
+	return polygonFromCoords(xys, DimXY)
+}
+
+// NewPolygonXYZ builds a new XYZ Polygon from the x, y and z coordinates of
+// its rings, each in its own slice, in the form x1, y1, z1, x2, y2, z2, ...,
+// xn, yn, zn, x1, y1, z1 (the first and last coordinates of each ring should
+// be the same). If the number of coordinates for each ring is not a multiple
+// of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPolygonXYZ(xyzs ...[]float64) Polygon {
+	xyzs = clone2DFloat64s(xyzs)
+	return polygonFromCoords(xyzs, DimXYZ)
+}
+
+// NewPolygonXYM builds a new XYM Polygon from the x, y and m coordinates of
+// its rings, each in its own slice, in the form x1, y1, m1, x2, y2, m2, ...,
+// xn, yn, mn, x1, y1, m1 (the first and last coordinates of each ring should
+// be the same). If the number of coordinates for each ring is not a multiple
+// of 3 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPolygonXYM(xyms ...[]float64) Polygon {
+	xyms = clone2DFloat64s(xyms)
+	return polygonFromCoords(xyms, DimXYM)
+}
+
+// NewPolygonXYZM builds a new XYZM Polygon from the x, y, z and m coordinates
+// of its rings, each in its own slice, in the form x1, y1, z1, m1, x2, y2, z2,
+// m2, ..., xn, yn, zn, mn, x1, y1, z1, m1 (the first and last coordinates of
+// each ring should be the same). If the number of coordinates for each ring is
+// not a multiple of 4 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewPolygonXYZM(xyzms ...[]float64) Polygon {
+	xyzms = clone2DFloat64s(xyzms)
+	return polygonFromCoords(xyzms, DimXYZM)
+}
+
+// NewMultiPolygonXY builds a new XY MultiPolygon from the x and y coordinates
+// of its Polygons, each in its own slice of rings. Ring coordinates are in the
+// form x1, y1, x2, y2, ..., xn, yn, x1, y1 (the first and last coordinates of
+// each ring should be the same). If the number of coordinates for each ring is
+// not a multiple of 2 the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPolygonXY(xys ...[][]float64) MultiPolygon {
+	xys = clone3DFloat64s(xys)
+	return multiPolygonFromCoords(xys, DimXY)
+}
+
+// NewMultiPolygonXYZ builds a new XYZ MultiPolygon from the x, y and z
+// coordinates of its Polygons, each in its own slice of rings. Ring
+// coordinates are in the form x1, y1, z1, x2, y2, z2, ..., xn, yn, zn, x1, y1,
+// z1 (the first and last coordinates of each ring should be the same). If the
+// number of coordinates for each ring is not a multiple of 3 the function will
+// panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPolygonXYZ(xyzs ...[][]float64) MultiPolygon {
+	xyzs = clone3DFloat64s(xyzs)
+	return multiPolygonFromCoords(xyzs, DimXYZ)
+}
+
+// NewMultiPolygonXYM builds a new XYM MultiPolygon from the x, y and m
+// coordinates of its Polygons, each in its own slice of rings. Ring
+// coordinates are in the form x1, y1, m1, x2, y2, m2, ..., xn, yn, mn, x1, y1,
+// m1 (the first and last coordinates of each ring should be the same). If the
+// number of coordinates for each ring is not a multiple of 3 the function will
+// panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPolygonXYM(xyms ...[][]float64) MultiPolygon {
+	xyms = clone3DFloat64s(xyms)
+	return multiPolygonFromCoords(xyms, DimXYM)
+}
+
+// NewMultiPolygonXYZM builds a new XYZM MultiPolygon from the x, y, z and m
+// coordinates of its Polygons, each in its own slice of rings. Ring
+// coordinates are in the form x1, y1, z1, m1, x2, y2, z2, m2, ..., xn, yn, zn,
+// mn, x1, y1, z1, m1 (the first and last coordinates of each ring should be
+// the same). If the number of coordinates for each ring is not a multiple of 4
+// the function will panic.
+//
+// It doesn't perform any validation on the result. The Validate method can be
+// used to check the validity of the result if needed.
+func NewMultiPolygonXYZM(xyzms ...[][]float64) MultiPolygon {
+	xyzms = clone3DFloat64s(xyzms)
+	return multiPolygonFromCoords(xyzms, DimXYZM)
+}
+
+func clone1DFloat64s(src []float64) []float64 {
+	dst := make([]float64, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func clone2DFloat64s(src [][]float64) [][]float64 {
+	dst := make([][]float64, len(src))
+	for i := range src {
+		dst[i] = clone1DFloat64s(src[i])
+	}
+	return dst
+}
+
+func clone3DFloat64s(src [][][]float64) [][][]float64 {
+	dst := make([][][]float64, len(src))
+	for i := range src {
+		dst[i] = clone2DFloat64s(src[i])
+	}
+	return dst
+}
+
+func multiPointFromCoords(coords []float64, ct CoordinatesType) MultiPoint {
+	if len(coords) == 0 {
+		return MultiPoint{}.ForceCoordinatesType(ct)
+	}
+
+	if len(coords)%ct.Dimension() != 0 {
+		msg := fmt.Sprintf(
+			"geom: coordinate arguments to %s constructor "+
+				"must have a length that is a multiple of %d",
+			ct.String(), ct.Dimension(),
+		)
+		panic(msg)
+	}
+
+	n := len(coords) / ct.Dimension()
+	pts := make([]Point, n)
+	for i := 0; i < n; i++ {
+		c := Coordinates{
+			XY: XY{
+				coords[i*ct.Dimension()+0],
+				coords[i*ct.Dimension()+1],
+			},
+			Type: ct,
+		}
+		if ct.Is3D() {
+			c.Z = coords[i*ct.Dimension()+2]
+		}
+		if ct.IsMeasured() {
+			c.M = coords[i*ct.Dimension()+ct.Dimension()-1]
+		}
+		pts[i] = NewPoint(c)
+	}
+	return NewMultiPoint(pts)
+}
+
+func lineStringFromCoords(coords []float64, ct CoordinatesType) LineString {
+	if len(coords) == 0 {
+		return LineString{}.ForceCoordinatesType(ct)
+	}
+	seq := NewSequence(coords, ct)
+	return NewLineString(seq)
+}
+
+func lineStringSliceFromCoords(coords [][]float64, ct CoordinatesType) []LineString {
+	lss := make([]LineString, len(coords))
+	for i := range coords {
+		seq := NewSequence(coords[i], ct)
+		lss[i] = NewLineString(seq)
+	}
+	return lss
+}
+
+func multiLineStringFromCoords(coords [][]float64, ct CoordinatesType) MultiLineString {
+	if len(coords) == 0 {
+		return MultiLineString{}.ForceCoordinatesType(ct)
+	}
+	lss := lineStringSliceFromCoords(coords, ct)
+	return NewMultiLineString(lss)
+}
+
+func polygonFromCoords(coords [][]float64, ct CoordinatesType) Polygon {
+	if len(coords) == 0 {
+		return Polygon{}.ForceCoordinatesType(ct)
+	}
+	rings := lineStringSliceFromCoords(coords, ct)
+	return NewPolygon(rings)
+}
+
+func multiPolygonFromCoords(coords [][][]float64, ct CoordinatesType) MultiPolygon {
+	if len(coords) == 0 {
+		return MultiPolygon{}.ForceCoordinatesType(ct)
+	}
+	polys := make([]Polygon, len(coords))
+	for i := range coords {
+		polys[i] = polygonFromCoords(coords[i], ct)
+	}
+	return NewMultiPolygon(polys)
+}

--- a/geom/ctor_from_coords_test.go
+++ b/geom/ctor_from_coords_test.go
@@ -75,6 +75,15 @@ func TestCoordinateConstructors(t *testing.T) {
 		{geom.NewPolygonXYZM([]float64{0, 0, 10, 100, 0, 4, 11, 101, 4, 4, 12, 102, 4, 0, 13, 103, 0, 0, 14, 104}), "POLYGON ZM((0 0 10 100,0 4 11 101,4 4 12 102,4 0 13 103,0 0 14 104))"},
 		{geom.NewPolygonXYZM([]float64{0, 0, 10, 100, 0, 4, 11, 101, 4, 4, 12, 102, 4, 0, 13, 103, 0, 0, 14, 104}, []float64{1, 1, 20, 200, 1, 2, 21, 201, 2, 2, 22, 202, 2, 1, 23, 203, 1, 1, 24, 204}), "POLYGON ZM((0 0 10 100,0 4 11 101,4 4 12 102,4 0 13 103,0 0 14 104),(1 1 20 200,1 2 21 201,2 2 22 202,2 1 23 203,1 1 24 204))"},
 
+		{geom.NewSingleRingPolygonXY(), "POLYGON EMPTY"},
+		{geom.NewSingleRingPolygonXY(0, 0, 0, 4, 4, 4, 4, 0, 0, 0), "POLYGON((0 0,0 4,4 4,4 0,0 0))"},
+		{geom.NewSingleRingPolygonXYZ(), "POLYGON Z EMPTY"},
+		{geom.NewSingleRingPolygonXYZ(0, 0, 10, 0, 4, 11, 4, 4, 12, 4, 0, 13, 0, 0, 14), "POLYGON Z((0 0 10,0 4 11,4 4 12,4 0 13,0 0 14))"},
+		{geom.NewSingleRingPolygonXYM(), "POLYGON M EMPTY"},
+		{geom.NewSingleRingPolygonXYM(0, 0, 10, 0, 4, 11, 4, 4, 12, 4, 0, 13, 0, 0, 14), "POLYGON M((0 0 10,0 4 11,4 4 12,4 0 13,0 0 14))"},
+		{geom.NewSingleRingPolygonXYZM(), "POLYGON ZM EMPTY"},
+		{geom.NewSingleRingPolygonXYZM(0, 0, 10, 100, 0, 4, 11, 101, 4, 4, 12, 102, 4, 0, 13, 103, 0, 0, 14, 104), "POLYGON ZM((0 0 10 100,0 4 11 101,4 4 12 102,4 0 13 103,0 0 14 104))"},
+
 		{geom.NewMultiPolygonXY(), "MULTIPOLYGON EMPTY"},
 		{geom.NewMultiPolygonXY(nil), "MULTIPOLYGON(EMPTY)"},
 		{geom.NewMultiPolygonXY([][]float64{{0, 0, 0, 1, 1, 1, 1, 0, 0, 0}}, [][]float64{{2, 2, 2, 1, 1, 2, 2, 2}}), "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 2,2 1,1 2,2 2)))"},

--- a/geom/ctor_from_coords_test.go
+++ b/geom/ctor_from_coords_test.go
@@ -1,0 +1,92 @@
+package geom_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+// TODO: Test panics.
+
+func TestCoordinateConstructors(t *testing.T) {
+	for i, tc := range []struct {
+		got     interface{ AsGeometry() geom.Geometry }
+		wantWKT string
+	}{
+		{geom.NewPointXY(1, 2), "POINT(1 2)"},
+		{geom.NewPointXYZ(1, 2, 3), "POINT Z(1 2 3)"},
+		{geom.NewPointXYM(1, 2, 3), "POINT M(1 2 3)"},
+		{geom.NewPointXYZM(1, 2, 3, 4), "POINT ZM(1 2 3 4)"},
+
+		{geom.NewMultiPointXY(), "MULTIPOINT EMPTY"},
+		{geom.NewMultiPointXY(1, 2), "MULTIPOINT(1 2)"},
+		{geom.NewMultiPointXY(1, 2, 3, 4), "MULTIPOINT(1 2,3 4)"},
+		{geom.NewMultiPointXYZ(), "MULTIPOINT Z EMPTY"},
+		{geom.NewMultiPointXYZ(1, 2, 3), "MULTIPOINT Z(1 2 3)"},
+		{geom.NewMultiPointXYZ(1, 2, 3, 4, 5, 6), "MULTIPOINT Z(1 2 3,4 5 6)"},
+		{geom.NewMultiPointXYM(), "MULTIPOINT M EMPTY"},
+		{geom.NewMultiPointXYM(1, 2, 3), "MULTIPOINT M(1 2 3)"},
+		{geom.NewMultiPointXYM(1, 2, 3, 4, 5, 6), "MULTIPOINT M(1 2 3,4 5 6)"},
+		{geom.NewMultiPointXYZM(), "MULTIPOINT ZM EMPTY"},
+		{geom.NewMultiPointXYZM(1, 2, 3, 4), "MULTIPOINT ZM(1 2 3 4)"},
+		{geom.NewMultiPointXYZM(1, 2, 3, 4, 5, 6, 7, 8), "MULTIPOINT ZM(1 2 3 4,5 6 7 8)"},
+
+		{geom.NewLineStringXY(), "LINESTRING EMPTY"},
+		{geom.NewLineStringXY(1, 2, 3, 4), "LINESTRING(1 2,3 4)"},
+		{geom.NewLineStringXYZ(), "LINESTRING Z EMPTY"},
+		{geom.NewLineStringXYZ(1, 2, 3, 4, 5, 6), "LINESTRING Z(1 2 3,4 5 6)"},
+		{geom.NewLineStringXYM(), "LINESTRING M EMPTY"},
+		{geom.NewLineStringXYM(1, 2, 3, 4, 5, 6), "LINESTRING M(1 2 3,4 5 6)"},
+		{geom.NewLineStringXYZM(), "LINESTRING ZM EMPTY"},
+		{geom.NewLineStringXYZM(1, 2, 3, 4, 5, 6, 7, 8), "LINESTRING ZM(1 2 3 4,5 6 7 8)"},
+
+		{geom.NewMultiLineStringXY(), "MULTILINESTRING EMPTY"},
+		{geom.NewMultiLineStringXY(nil), "MULTILINESTRING(EMPTY)"},
+		{geom.NewMultiLineStringXY([]float64{1, 2, 3, 4}), "MULTILINESTRING((1 2,3 4))"},
+		{geom.NewMultiLineStringXY([]float64{1, 2, 3, 4}, nil), "MULTILINESTRING((1 2,3 4),EMPTY)"},
+		{geom.NewMultiLineStringXY([]float64{1, 2, 3, 4}, []float64{5, 6, 7, 8}), "MULTILINESTRING((1 2,3 4),(5 6,7 8))"},
+		{geom.NewMultiLineStringXYZ(), "MULTILINESTRING Z EMPTY"},
+		{geom.NewMultiLineStringXYZ(nil), "MULTILINESTRING Z(EMPTY)"},
+		{geom.NewMultiLineStringXYZ([]float64{1, 2, 3, 4, 5, 6}), "MULTILINESTRING Z((1 2 3,4 5 6))"},
+		{geom.NewMultiLineStringXYZ([]float64{1, 2, 3, 4, 5, 6}, nil), "MULTILINESTRING Z((1 2 3,4 5 6),EMPTY)"},
+		{geom.NewMultiLineStringXYZ([]float64{1, 2, 3, 4, 5, 6}, []float64{7, 8, 9, 10, 11, 12}), "MULTILINESTRING Z((1 2 3,4 5 6),(7 8 9,10 11 12))"},
+		{geom.NewMultiLineStringXYM(), "MULTILINESTRING M EMPTY"},
+		{geom.NewMultiLineStringXYM(nil), "MULTILINESTRING M(EMPTY)"},
+		{geom.NewMultiLineStringXYM([]float64{1, 2, 3, 4, 5, 6}), "MULTILINESTRING M((1 2 3,4 5 6))"},
+		{geom.NewMultiLineStringXYM([]float64{1, 2, 3, 4, 5, 6}, nil), "MULTILINESTRING M((1 2 3,4 5 6),EMPTY)"},
+		{geom.NewMultiLineStringXYM([]float64{1, 2, 3, 4, 5, 6}, []float64{7, 8, 9, 10, 11, 12}), "MULTILINESTRING M((1 2 3,4 5 6),(7 8 9,10 11 12))"},
+		{geom.NewMultiLineStringXYZM(), "MULTILINESTRING ZM EMPTY"},
+		{geom.NewMultiLineStringXYZM(nil), "MULTILINESTRING ZM(EMPTY)"},
+		{geom.NewMultiLineStringXYZM([]float64{1, 2, 3, 4, 5, 6, 7, 8}), "MULTILINESTRING ZM((1 2 3 4,5 6 7 8))"},
+		{geom.NewMultiLineStringXYZM([]float64{1, 2, 3, 4, 5, 6, 7, 8}, nil), "MULTILINESTRING ZM((1 2 3 4,5 6 7 8),EMPTY)"},
+		{geom.NewMultiLineStringXYZM([]float64{1, 2, 3, 4, 5, 6, 7, 8}, []float64{9, 10, 11, 12, 13, 14, 15, 16}), "MULTILINESTRING ZM((1 2 3 4,5 6 7 8),(9 10 11 12,13 14 15 16))"},
+
+		{geom.NewPolygonXY(), "POLYGON EMPTY"},
+		{geom.NewPolygonXY([]float64{0, 0, 0, 4, 4, 4, 4, 0, 0, 0}), "POLYGON((0 0,0 4,4 4,4 0,0 0))"},
+		{geom.NewPolygonXY([]float64{0, 0, 0, 4, 4, 4, 4, 0, 0, 0}, []float64{1, 1, 1, 2, 2, 1, 1, 1}), "POLYGON((0 0,0 4,4 4,4 0,0 0),(1 1,1 2,2 1,1 1))"},
+		{geom.NewPolygonXYZ(), "POLYGON Z EMPTY"},
+		{geom.NewPolygonXYZ([]float64{0, 0, 10, 0, 4, 11, 4, 4, 12, 4, 0, 13, 0, 0, 14}), "POLYGON Z((0 0 10,0 4 11,4 4 12,4 0 13,0 0 14))"},
+		{geom.NewPolygonXYZ([]float64{0, 0, 10, 0, 4, 11, 4, 4, 12, 4, 0, 13, 0, 0, 14}, []float64{1, 1, 20, 1, 2, 21, 2, 2, 22, 2, 1, 23, 1, 1, 24}), "POLYGON Z((0 0 10,0 4 11,4 4 12,4 0 13,0 0 14),(1 1 20,1 2 21,2 2 22,2 1 23,1 1 24))"},
+		{geom.NewPolygonXYM(), "POLYGON M EMPTY"},
+		{geom.NewPolygonXYM([]float64{0, 0, 10, 0, 4, 11, 4, 4, 12, 4, 0, 13, 0, 0, 14}), "POLYGON M((0 0 10,0 4 11,4 4 12,4 0 13,0 0 14))"},
+		{geom.NewPolygonXYM([]float64{0, 0, 10, 0, 4, 11, 4, 4, 12, 4, 0, 13, 0, 0, 14}, []float64{1, 1, 20, 1, 2, 21, 2, 2, 22, 2, 1, 23, 1, 1, 24}), "POLYGON M((0 0 10,0 4 11,4 4 12,4 0 13,0 0 14),(1 1 20,1 2 21,2 2 22,2 1 23,1 1 24))"},
+		{geom.NewPolygonXYZM(), "POLYGON ZM EMPTY"},
+		{geom.NewPolygonXYZM([]float64{0, 0, 10, 100, 0, 4, 11, 101, 4, 4, 12, 102, 4, 0, 13, 103, 0, 0, 14, 104}), "POLYGON ZM((0 0 10 100,0 4 11 101,4 4 12 102,4 0 13 103,0 0 14 104))"},
+		{geom.NewPolygonXYZM([]float64{0, 0, 10, 100, 0, 4, 11, 101, 4, 4, 12, 102, 4, 0, 13, 103, 0, 0, 14, 104}, []float64{1, 1, 20, 200, 1, 2, 21, 201, 2, 2, 22, 202, 2, 1, 23, 203, 1, 1, 24, 204}), "POLYGON ZM((0 0 10 100,0 4 11 101,4 4 12 102,4 0 13 103,0 0 14 104),(1 1 20 200,1 2 21 201,2 2 22 202,2 1 23 203,1 1 24 204))"},
+
+		{geom.NewMultiPolygonXY(), "MULTIPOLYGON EMPTY"},
+		{geom.NewMultiPolygonXY(nil), "MULTIPOLYGON(EMPTY)"},
+		{geom.NewMultiPolygonXY([][]float64{{0, 0, 0, 1, 1, 1, 1, 0, 0, 0}}, [][]float64{{2, 2, 2, 1, 1, 2, 2, 2}}), "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 2,2 1,1 2,2 2)))"},
+		{geom.NewMultiPolygonXYZ(), "MULTIPOLYGON Z EMPTY"},
+		{geom.NewMultiPolygonXYZ(nil), "MULTIPOLYGON Z(EMPTY)"},
+		{geom.NewMultiPolygonXYZ([][]float64{{0, 0, 10, 0, 1, 11, 1, 1, 12, 0, 0, 13}}, [][]float64{{2, 2, 20, 2, 1, 21, 1, 2, 22, 2, 2, 23}}), "MULTIPOLYGON Z(((0 0 10,0 1 11,1 1 12,0 0 13)),((2 2 20,2 1 21,1 2 22,2 2 23)))"},
+		{geom.NewMultiPolygonXYM(), "MULTIPOLYGON M EMPTY"},
+		{geom.NewMultiPolygonXYM(nil), "MULTIPOLYGON M(EMPTY)"},
+		{geom.NewMultiPolygonXYM([][]float64{{0, 0, 10, 0, 1, 11, 1, 1, 12, 0, 0, 13}}, [][]float64{{2, 2, 20, 2, 1, 21, 1, 2, 22, 2, 2, 23}}), "MULTIPOLYGON M(((0 0 10,0 1 11,1 1 12,0 0 13)),((2 2 20,2 1 21,1 2 22,2 2 23)))"},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			expectGeomEqWKT(t, tc.got.AsGeometry(), tc.wantWKT)
+		})
+	}
+}


### PR DESCRIPTION
## Description

## Motivation

Constructing geometries _not_ from WKTs, WKBs, TWKBs, or GeoJSON is currently
very arduous. E.g, this is how you would construct a `Polygon` from a list of
coordinates:

```go
coords := []float64{
    144.9324481856,
    -37.8083179153,
    151.1946474301,
    -33.8532673806,
    153.0114915954,
    -27.4656438380,
    130.8453394819,
    -12.4509481385,
    115.8443383313,
    -31.9673982240,
    144.9324481856,
    -37.8083179153,
}
seq := geom.NewSequence(coords, geom.DimXY)
ring := geom.NewLineString(seq)
poly := geom.NewPolygon([]geom.LineString{ring})
```

This is annoying in particular for users of simplefeatures who wish to
construct geometries programmatically (e.g. for their own unit tests, or other
"hardcoded" geometries).

## Mechanism

This change adds a new group of functions to the `geom` package that construct
geometries, in an easier way than the existing `Sequence` -> `LineString` ->
`Polygon` -> `MultiPolygon` etc. chain.

These functions have names in the form `New{Type}{Dimension}`, where `Type` is
one of {`Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`,
`MultiPolygon`}, and `Dimension` is one of {`XY`, `XYZ`, `XYM`, `XYZM`}.

They accept coordinates at the appropriate level of nesting that corresponds to
the geometry type. For example, `NewPolygonXY` accepts a variadic number of
slices of `float64` (each slice represents a ring). `NewMultiPolygonXY` accepts
a variadic number of slices of slices of `float64` (each outer slice represents
a polygon, and each inner slice represents a ring).

These functions panic if the number of coordinates provided is not consistent
with the dimension (this behaviour is consistent with the behaviour of the
`NewSequence` function).

The example above can no be written as:

```go
coords := []float64{
    144.9324481856,
    -37.8083179153,
    151.1946474301,
    -33.8532673806,
    153.0114915954,
    -27.4656438380,
    130.8453394819,
    -12.4509481385,
    115.8443383313,
    -31.9673982240,
    144.9324481856,
    -37.8083179153,
}
poly := geom.NewPolygonXY(coords)
```

## Alternatives considered

The main alternative I considered was not having `Dimension` suffix variants,
and instead accepting a `geom.CoordinatesType` value as the first argument
(which can take one of the values {`geom.DimXY`, `geom.DimXYZ`, `geom.DimXYM`,
`geom.DimXYZM`}). This would have the advantage that the number of functions is
reduced by a factor of 4, but introduces some other disadvantages:

- The length of the invocation is longer at the callsite. E.g.
  `geom.NewPolygonFromCoords(geom.DimXY, coords)` vs
  `geom.NewPolygonXY(coords)` (the `geom.NewPolygon` function is already taken,
  so the `FromCoords` suffix is necessary).

- The `NewPointFromCoords` function would have suboptimal ergonomics, as it
  would accept a `geom.CoordinatesType` value and a variadic number of
  `float64` values. Typically, the `geom.CoordinatesType` would be hardcoded,
  so the dimensionality is encoded twice even though it doesn\'t have to be
  (once in the `geom.CoordinatesType`, and once in the number of `float64`
  values). Alternatively, the `geom.CoordinatesType` could be omitted, but then
  `NewPointFromCoords` would be inconsistent with the other `NewXXXFromCoords`
  functions.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/477
- https://github.com/peterstace/simplefeatures/issues/595
