### PR TITLE
Upgrade `golangci-lint` to `v1.61.0`.

### DIFF
--- a/.ci/golint.Dockerfile
+++ b/.ci/golint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.60.3
+FROM golangci/golangci-lint:v1.61.0
 
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Upgrades `golangci-lint` to `v1.60.3`.
+- Upgrades `golangci-lint` to `v1.61.0`.
 
 ## v0.51.0
 


### PR DESCRIPTION
## Description

Upgrades `golangci-lint` to `v0.61.0`.

## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A
 
- Updated release notes? (if appropriate?) Yes.
