### PR TITLE
Add basic projections between angular (lon/lat) and planar (x/y) coordinate systems

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,10 @@ issues:
       linters:
         - gosec
 
+    - path: "carto/*"
+      linters:
+        - asciicheck
+
 linters-settings:
   depguard:
     rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Adds a new package `github.com/nearmap/simplefeatures/carto` package that
+  provides cartography functionality for working with and making maps.
+  Initially this includes transformations between angular (lon/lat) and planar
+  (x/y) coordinates for various simple projections.
+
 ## v0.52.0
 
 2024-10-08

--- a/carto/docs.go
+++ b/carto/docs.go
@@ -1,0 +1,10 @@
+// Package carto provides cartography functionality for working with and making
+// maps.
+//
+// This includes:
+//
+//   - Various projections between angular coordinates (longitude and latitude)
+//     and planar coordinates (x and y).
+//
+//   - Earth radius definitions.
+package carto

--- a/carto/proj_albers_equal_area_conic.go
+++ b/carto/proj_albers_equal_area_conic.go
@@ -1,0 +1,90 @@
+package carto
+
+import "github.com/peterstace/simplefeatures/geom"
+
+// AlbersEqualAreaConic allows projecting (longitude, latitude) coordinates to
+// (x, y) pairs via the Albers equal area conic projection.
+//
+// The Albers equal area conic projection is a conic projection that is:
+//   - Configured by setting two standard parallels.
+//   - Equal area.
+//   - Not conformal, but preserves shape locally at the standard parallels.
+type AlbersEqualAreaConic struct {
+	radius       float64
+	origin       geom.XY
+	stdParallels [2]float64
+}
+
+// NewAlbersEqualAreaConic returns a new AlbersEqualAreaConic projection with
+// the given earth radius.
+func NewAlbersEqualAreaConic(earthRadius float64) *AlbersEqualAreaConic {
+	return &AlbersEqualAreaConic{
+		radius:       earthRadius,
+		stdParallels: [2]float64{30, 60},
+	}
+}
+
+// SetStandardParallels sets the standard parallels of the projection to the
+// given latitudes expressed in degrees.
+func (c *AlbersEqualAreaConic) SetStandardParallels(lat1, lat2 float64) {
+	c.stdParallels[0] = lat1
+	c.stdParallels[1] = lat2
+}
+
+// SetOrigin sets the origin of the projection to the given (longitude,
+// latitude) pair. The origin have projected coordinates (0, 0).
+func (c *AlbersEqualAreaConic) SetOrigin(origin geom.XY) {
+	c.origin = origin
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (c *AlbersEqualAreaConic) Forward(lonlat geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		φ  = dtor(lonlat.Y)
+		φ0 = dtor(c.origin.Y)
+		φ1 = dtor(c.stdParallels[0])
+		φ2 = dtor(c.stdParallels[1])
+		λ  = dtor(lonlat.X)
+		λ0 = dtor(c.origin.X)
+	)
+	var (
+		n  = (sin(φ1) + sin(φ2)) / 2
+		θ  = n * (λ - λ0)
+		C  = sq(cos(φ1)) + 2*n*sin(φ1)
+		ρ  = R * sqrt(C-2*n*sin(φ)) / n
+		ρ0 = R * sqrt(C-2*n*sin(φ0)) / n
+	)
+	var (
+		x = ρ * sin(θ)
+		y = ρ0 - ρ*cos(θ)
+	)
+	return geom.XY{X: x, Y: y}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (c *AlbersEqualAreaConic) Reverse(xy geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		x  = xy.X
+		y  = xy.Y
+		φ0 = dtor(c.origin.Y)
+		φ1 = dtor(c.stdParallels[0])
+		φ2 = dtor(c.stdParallels[1])
+		λ0 = dtor(c.origin.X)
+	)
+	var (
+		n  = (sin(φ1) + sin(φ2)) / 2
+		C  = sq(cos(φ1)) + 2*n*sin(φ1)
+		ρ0 = R * sqrt(C-2*n*sin(φ0)) / n
+		ρ  = R * sqrt(sq(x)+sq(ρ0-y))
+		θ  = atan(x / (ρ0 - y))
+	)
+	var (
+		φ = asin((C - ρ*ρ*n*n) / (2 * n))
+		λ = λ0 + θ/n
+	)
+	return geom.XY{X: rtod(λ), Y: rtod(φ)}
+}

--- a/carto/proj_albers_equal_area_conic.go
+++ b/carto/proj_albers_equal_area_conic.go
@@ -16,7 +16,8 @@ type AlbersEqualAreaConic struct {
 }
 
 // NewAlbersEqualAreaConic returns a new AlbersEqualAreaConic projection with
-// the given earth radius.
+// the given earth radius. The standard parallels are set to 30 and 60 degrees
+// north.
 func NewAlbersEqualAreaConic(earthRadius float64) *AlbersEqualAreaConic {
 	return &AlbersEqualAreaConic{
 		radius:       earthRadius,
@@ -32,7 +33,7 @@ func (c *AlbersEqualAreaConic) SetStandardParallels(lat1, lat2 float64) {
 }
 
 // SetOrigin sets the origin of the projection to the given (longitude,
-// latitude) pair. The origin have projected coordinates (0, 0).
+// latitude) pair. The origin has projected coordinates (0, 0).
 func (c *AlbersEqualAreaConic) SetOrigin(origin geom.XY) {
 	c.origin = origin
 }

--- a/carto/proj_azimuthal_equidistant.go
+++ b/carto/proj_azimuthal_equidistant.go
@@ -1,0 +1,77 @@
+package carto
+
+import (
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+// AzimuthalEquidistant allows projecting (longitude, latitude) coordinates to
+// (x, y) pairs via the azimuthal equidistant projection.
+//
+// The azimuthal equidistant projection is a projection that is:
+//   - Configured by setting a center point.
+//   - Equidistant. Distances from the center point are correctly scaled.
+//   - Azimuthal. Directions from the center point are correctly preserved.
+//   - Not conformal, but preserves shape locally at the center point.
+//   - Not equal area, but preserves area locally at the center point.
+type AzimuthalEquidistant struct {
+	radius       float64
+	centerLonLat geom.XY
+}
+
+// NewAzimuthalEquidistant returns a new AzimuthalEquidistant projection with
+// the given earth radius.
+func NewAzimuthalEquidistant(earthRadius float64) *AzimuthalEquidistant {
+	return &AzimuthalEquidistant{
+		radius:       earthRadius,
+		centerLonLat: geom.XY{},
+	}
+}
+
+// SetCenterLonLat sets the center of the projection to the given (longitude,
+// latitude) pair. The center have projected coordinates (0, 0) and be the
+// center of the circular map.
+func (a *AzimuthalEquidistant) SetCenter(centerLonLat geom.XY) {
+	a.centerLonLat = centerLonLat
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (a *AzimuthalEquidistant) Forward(lonLat geom.XY) geom.XY {
+	R := a.radius
+	λd := lonLat.X
+	φd := lonLat.Y
+	λr := dtor(λd)
+	φr := dtor(φd)
+	λ0r := dtor(a.centerLonLat.X)
+	φ0r := dtor(a.centerLonLat.Y)
+
+	ρ := R * acos(sin(φ0r)*sin(φr)+cos(φ0r)*cos(φr)*cos(λr-λ0r))
+	θ := atan2(
+		cos(φr)*sin(λr-λ0r),
+		cos(φ0r)*sin(φr)-sin(φ0r)*cos(φr)*cos(λr-λ0r),
+	)
+	return geom.XY{
+		X: ρ * sin(θ),
+		Y: ρ * cos(θ),
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (a *AzimuthalEquidistant) Reverse(xy geom.XY) geom.XY {
+	R := a.radius
+	x := xy.X
+	y := xy.Y
+	λ0r := dtor(a.centerLonLat.X)
+	φ0r := dtor(a.centerLonLat.Y)
+
+	ρ := sqrt(x*x + y*y)
+	φr := asin(cos(ρ/R)*sin(φ0r) + (y*sin(ρ/R)*cos(φ0r))/ρ)
+	λr := λ0r + atan2(
+		x*sin(ρ/R),
+		ρ*cos(φ0r)*cos(ρ/R)-y*sin(φ0r)*sin(ρ/R),
+	)
+	λd := rtod(λr)
+	φd := rtod(φr)
+	return geom.XY{X: λd, Y: φd}
+}

--- a/carto/proj_equidistant_conic.go
+++ b/carto/proj_equidistant_conic.go
@@ -1,0 +1,113 @@
+package carto
+
+import (
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+// EquidistantConic allows projecting (longitude, latitude) coordinates to
+// (x, y) pairs via the equidistant conic projection.
+//
+// The equidistant conic projection is a conic projection that is:
+//   - Configured by setting two standard parallels.
+//   - Not equidistant, but has correctly scaled distance along all meridians
+//     and the two standard parallels.
+//   - Not conformal, but preserves shape locally at the standard parallels.
+//   - Not equal area, but preserves area locally at the standard parallels.
+type EquidistantConic struct {
+	earthRadius  float64
+	stdParallels [2]float64
+	origin       geom.XY
+}
+
+// NewEquidistantConic returns a new EquidistantConic projection with the given
+// earth radius.
+func NewEquidistantConic(earthRadius float64) *EquidistantConic {
+	return &EquidistantConic{
+		earthRadius:  earthRadius,
+		stdParallels: [2]float64{0, 45},
+	}
+}
+
+// SetStandardParallels sets the standard parallels of the projection to the
+// given latitudes expressed in degrees.
+func (c *EquidistantConic) SetStandardParallels(lat1, lat2 float64) *EquidistantConic {
+	c.stdParallels[0] = lat1
+	c.stdParallels[1] = lat2
+	return c
+}
+
+// SetOrigin sets the origin of the projection to the given (longitude,
+// latitude) pair. The origin have projected coordinates (0, 0).
+func (c *EquidistantConic) SetOrigin(lonLat geom.XY) *EquidistantConic {
+	c.origin = lonLat
+	return c
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (c *EquidistantConic) Forward(lonlat geom.XY) geom.XY {
+	var (
+		R = c.earthRadius
+
+		φd  = lonlat.Y
+		φ0d = c.origin.Y
+		φ1d = c.stdParallels[0]
+		φ2d = c.stdParallels[1]
+
+		φr  = dtor(φd)
+		φ0r = dtor(φ0d)
+		φ1r = dtor(φ1d)
+		φ2r = dtor(φ2d)
+
+		λd  = lonlat.X
+		λ0d = c.origin.X
+
+		λr  = dtor(λd)
+		λ0r = dtor(λ0d)
+	)
+	var (
+		n  = (cos(φ1r) - cos(φ2r)) / (φ2r - φ1r)
+		G  = cos(φ1r)/n + φ1r
+		ρ0 = G - φ0r
+
+		ρ = G - φr
+		x = ρ * sin(n*(λr-λ0r))
+		y = ρ0 - ρ*cos(n*(λr-λ0r))
+	)
+	return geom.XY{X: R * x, Y: R * y}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (c *EquidistantConic) Reverse(xy geom.XY) geom.XY {
+	var (
+		R = c.earthRadius
+
+		x = xy.X / R
+		y = xy.Y / R
+
+		φ0d = c.origin.Y
+		φ1d = c.stdParallels[0]
+		φ2d = c.stdParallels[1]
+
+		λ0d = c.origin.X
+		λ0r = dtor(λ0d)
+
+		φ0r = dtor(φ0d)
+		φ1r = dtor(φ1d)
+		φ2r = dtor(φ2d)
+	)
+	var (
+		n  = (cos(φ1r) - cos(φ2r)) / (φ2r - φ1r)
+		G  = cos(φ1r)/n + φ1r
+		ρ0 = G - φ0r
+
+		ρ = sign(n) * sqrt(x*x+(ρ0-y)*(ρ0-y))
+
+		θ = atan(x / (ρ0 - y))
+
+		φr = G - ρ
+		λr = λ0r + θ/n
+	)
+	return geom.XY{X: rtod(λr), Y: rtod(φr)}
+}

--- a/carto/proj_equirectangular.go
+++ b/carto/proj_equirectangular.go
@@ -6,8 +6,8 @@ import "github.com/peterstace/simplefeatures/geom"
 // pairs via the equirectangular projection.
 //
 // The equirectangular projection is a cylindrical projection that is:
-//   - Configured by setting the central meridian and two symmetric standard
-//     parallels.
+//   - Configured by setting the central meridian and two standard parallels
+//     that are symmetric about the equator.
 //   - Not equal area, but preserves area locally at the standard parallels.
 //   - Not conformal, but preserves shape locally at the standard parallels.
 //   - Not equidistant, but preserves distance locally at the standard parallels.

--- a/carto/proj_equirectangular.go
+++ b/carto/proj_equirectangular.go
@@ -1,0 +1,75 @@
+package carto
+
+import "github.com/peterstace/simplefeatures/geom"
+
+// Equirectangular allows projecting (longitude, latitude) coordinates to (x, y)
+// pairs via the equirectangular projection.
+//
+// The equirectangular projection is a cylindrical projection that is:
+//   - Configured by setting the central meridian and two symmetric standard
+//     parallels.
+//   - Not equal area, but preserves area locally at the standard parallels.
+//   - Not conformal, but preserves shape locally at the standard parallels.
+//   - Not equidistant, but preserves distance locally at the standard parallels.
+type Equirectangular struct {
+	λ0     float64
+	cosφ1  float64
+	radius float64
+}
+
+// NewEquirectangular returns a new Equirectangular projection with the given
+// earth radius.
+func NewEquirectangular(earthRadius float64) *Equirectangular {
+	return &Equirectangular{
+		λ0:     0,
+		cosφ1:  1, // φ1 = 0 (equator)
+		radius: earthRadius,
+	}
+}
+
+// SetCentralMeridian sets the central meridian of the projection to the given
+// longitude expressed in degrees.
+func (e *Equirectangular) SetCentralMeridian(lon float64) {
+	e.λ0 = dtor(lon)
+}
+
+// SetStandardParallels sets the standard parallels of the projection to the
+// given latitude and its negative, expressed in degrees. E.g. providing 35
+// will set the standard parallels to 35 and -35.
+func (e *Equirectangular) SetStandardParallels(lat float64) {
+	φ1 := dtor(lat)
+	e.cosφ1 = cos(φ1)
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (e *Equirectangular) Forward(lonLat geom.XY) geom.XY {
+	var (
+		R     = e.radius
+		λ     = dtor(lonLat.X)
+		φ     = dtor(lonLat.Y)
+		λ0    = e.λ0
+		cosφ1 = e.cosφ1
+	)
+	return geom.XY{
+		X: R * (λ - λ0) * cosφ1,
+		Y: R * φ,
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (e *Equirectangular) Reverse(xy geom.XY) geom.XY {
+	var (
+		R     = e.radius
+		x     = xy.X
+		y     = xy.Y
+		λ0    = e.λ0
+		cosφ1 = e.cosφ1
+	)
+	var (
+		λ = x/(R*cosφ1) + λ0
+		φ = y / R
+	)
+	return rtodxy(λ, φ)
+}

--- a/carto/proj_lambert_conformal_conic.go
+++ b/carto/proj_lambert_conformal_conic.go
@@ -1,0 +1,93 @@
+package carto
+
+import "github.com/peterstace/simplefeatures/geom"
+
+// LambertConformalConic allows projecting (longitude, latitude) coordinates to
+// (x, y) pairs via the Lambert conformal conic projection.
+//
+// The Lambert conformal conic projection is a conic projection that is:
+//   - Configured by setting two standard parallels.
+//   - Conformal. Shape is preserved locally at all points.
+//   - Not equal area, but preserves area locally at the standard parallels.
+//   - Not equidistant, but preserves distance locally along the standard
+//     parallels.
+type LambertConformalConic struct {
+	radius       float64
+	origin       geom.XY
+	stdParallels [2]float64
+}
+
+// NewLambertConformalConic returns a new LambertConformalConic projection with
+// the given earth radius.
+func NewLambertConformalConic(earthRadius float64) *LambertConformalConic {
+	return &LambertConformalConic{
+		radius:       earthRadius,
+		origin:       geom.XY{0, 0},
+		stdParallels: [2]float64{0, 0},
+	}
+}
+
+// SetOrigin sets the origin of the projection to the given (longitude,
+// latitude) pair. The origin have projected coordinates (0, 0).
+func (c *LambertConformalConic) SetOrigin(origin geom.XY) {
+	c.origin = origin
+}
+
+// SetStandardParallels sets the standard parallels of the projection to the
+// given latitudes expressed in degrees.
+func (c *LambertConformalConic) SetStandardParallels(lat1, lat2 float64) {
+	c.stdParallels[0] = lat1
+	c.stdParallels[1] = lat2
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (c *LambertConformalConic) Forward(lonlat geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		φ  = dtor(lonlat.Y)
+		λ  = dtor(lonlat.X)
+		φ0 = dtor(c.origin.Y)
+		λ0 = dtor(c.origin.X)
+		φ1 = dtor(c.stdParallels[0])
+		φ2 = dtor(c.stdParallels[1])
+	)
+	var (
+		n  = ln(cos(φ1)*sec(φ2)) / ln(tan(π/4+φ2/2)*cot(π/4+φ1/2))
+		F  = cos(φ1) * pow(tan(π/4+φ1/2), n) / n
+		ρ  = R * F * pow(cot(π/4+φ/2), n)
+		ρ0 = R * F * pow(cot(π/4+φ0/2), n)
+	)
+	return geom.XY{
+		X: ρ * sin(n*(λ-λ0)),
+		Y: ρ0 - ρ*cos(n*(λ-λ0)),
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (c *LambertConformalConic) Reverse(xy geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		x  = xy.X
+		y  = xy.Y
+		φ0 = dtor(c.origin.Y)
+		λ0 = dtor(c.origin.X)
+		φ1 = dtor(c.stdParallels[0])
+		φ2 = dtor(c.stdParallels[1])
+	)
+	var (
+		n  = ln(cos(φ1)*sec(φ2)) / ln(tan(π/4+φ2/2)*cot(π/4+φ1/2))
+		F  = cos(φ1) * pow(tan(π/4+φ1/2), n) / n
+		ρ0 = R * F * pow(cot(π/4+φ0/2), n)
+	)
+	var (
+		ρ = sign(n) * sqrt(sq(x)+sq(ρ0-y))
+		θ = atan(x / (ρ0 - y))
+	)
+	var (
+		φ = 2*atan(pow(R*F/ρ, 1/n)) - π/2
+		λ = λ0 + θ/n
+	)
+	return geom.XY{X: rtod(λ), Y: rtod(φ)}
+}

--- a/carto/proj_lambert_conformal_conic.go
+++ b/carto/proj_lambert_conformal_conic.go
@@ -22,7 +22,7 @@ type LambertConformalConic struct {
 func NewLambertConformalConic(earthRadius float64) *LambertConformalConic {
 	return &LambertConformalConic{
 		radius:       earthRadius,
-		origin:       geom.XY{0, 0},
+		origin:       geom.XY{X: 0, Y: 0},
 		stdParallels: [2]float64{0, 0},
 	}
 }

--- a/carto/proj_lambert_cylindrical_equal_area.go
+++ b/carto/proj_lambert_cylindrical_equal_area.go
@@ -1,0 +1,64 @@
+package carto
+
+import "github.com/peterstace/simplefeatures/geom"
+
+// LambertCylindricalEqualArea allows projecting (longitude, latitude)
+// coordinates to (x, y) pairs via the Lambert cylindrical equal area
+// projection.
+//
+// The Lambert cylindrical equal area projection is a cylindrical projection
+// that is:
+//   - Configured by setting the central meridian.
+//   - Equal area.
+//   - Not conformal, but preserves shape locally along the equator.
+//   - Not equidistant, but preserves distance along the equator.
+type LambertCylindricalEqualArea struct {
+	radius float64
+	λ0     float64
+}
+
+// NewLambertCylindricalEqualArea returns a new LambertCylindricalEqualArea
+// projection with the given earth radius.
+func NewLambertCylindricalEqualArea(radius float64) *LambertCylindricalEqualArea {
+	return &LambertCylindricalEqualArea{
+		radius: radius,
+		λ0:     0,
+	}
+}
+
+// SetCentralMeridian sets the central meridian of the projection to the given
+// longitude expressed in degrees.
+func (c *LambertCylindricalEqualArea) SetCentralMeridian(lon float64) {
+	c.λ0 = dtor(lon)
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (c *LambertCylindricalEqualArea) Forward(lonLat geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		λ  = dtor(lonLat.X)
+		λ0 = c.λ0
+		φ  = dtor(lonLat.Y)
+	)
+	return geom.XY{
+		X: R * (λ - λ0),
+		Y: R * sin(φ),
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (c *LambertCylindricalEqualArea) Reverse(xy geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		x  = xy.X
+		y  = xy.Y
+		λ0 = c.λ0
+	)
+	var (
+		λ = x/R + λ0
+		φ = asin(y / R)
+	)
+	return rtodxy(λ, φ)
+}

--- a/carto/proj_orthographic.go
+++ b/carto/proj_orthographic.go
@@ -1,8 +1,6 @@
 package carto
 
-import (
-	. "github.com/peterstace/simplefeatures/geom"
-)
+import "github.com/peterstace/simplefeatures/geom"
 
 // Orthographic allows projecting (longitude, latitude) coordinates to (x, y)
 // pairs via the orthographic projection.
@@ -36,7 +34,7 @@ func NewOrthographic(radius float64) *Orthographic {
 // SetCenterLonLat sets the center of the projection to the given (longitude,
 // latitude) pair. The center have projected coordinates (0, 0) and be the
 // center of the circular map.
-func (m *Orthographic) SetCenter(centerLonLat XY) {
+func (m *Orthographic) SetCenter(centerLonLat geom.XY) {
 	m.λ0 = dtor(centerLonLat.X)
 	φ0 := dtor(centerLonLat.Y)
 	m.sinφ0 = sin(φ0)
@@ -45,7 +43,7 @@ func (m *Orthographic) SetCenter(centerLonLat XY) {
 
 // Forward converts a (longitude, latitude) pair expressed in degrees to a
 // projected (x, y) pair.
-func (m *Orthographic) Forward(lonLat XY) XY {
+func (m *Orthographic) Forward(lonLat geom.XY) geom.XY {
 	var (
 		R     = m.radius
 		λ     = dtor(lonLat.X)
@@ -54,7 +52,7 @@ func (m *Orthographic) Forward(lonLat XY) XY {
 		cosφ0 = m.cosφ0
 		sinφ0 = m.sinφ0
 	)
-	return XY{
+	return geom.XY{
 		X: R * cos(φ) * sin(λ-λ0),
 		Y: R * (cosφ0*sin(φ) - sinφ0*cos(φ)*cos(λ-λ0)),
 	}
@@ -62,7 +60,7 @@ func (m *Orthographic) Forward(lonLat XY) XY {
 
 // Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
 // expressed in degrees.
-func (m *Orthographic) Reverse(xy XY) XY {
+func (m *Orthographic) Reverse(xy geom.XY) geom.XY {
 	var (
 		R     = m.radius
 		x     = xy.X

--- a/carto/proj_orthographic.go
+++ b/carto/proj_orthographic.go
@@ -5,9 +5,9 @@ import "github.com/peterstace/simplefeatures/geom"
 // Orthographic allows projecting (longitude, latitude) coordinates to (x, y)
 // pairs via the orthographic projection.
 //
-// The orthographic is a projection where the sphere is projected onto a
-// tangent plane, with a point of perspective that is infinitely far away. It
-// gives a view of the sphere as seen from outer space.
+// The orthographic projection projects the sphere onto a tangent plane with a
+// point of perspective that is infinitely far away. It gives a view of the
+// earth as seen from outer space.
 //
 // It is:
 //   - Configured by setting the center of the projection.
@@ -31,7 +31,7 @@ func NewOrthographic(radius float64) *Orthographic {
 	}
 }
 
-// SetCenterLonLat sets the center of the projection to the given (longitude,
+// SetCenter sets the center of the projection to the given (longitude,
 // latitude) pair. The center have projected coordinates (0, 0) and be the
 // center of the circular map.
 func (m *Orthographic) SetCenter(centerLonLat geom.XY) {

--- a/carto/proj_orthographic.go
+++ b/carto/proj_orthographic.go
@@ -1,0 +1,81 @@
+package carto
+
+import (
+	. "github.com/peterstace/simplefeatures/geom"
+)
+
+// Orthographic allows projecting (longitude, latitude) coordinates to (x, y)
+// pairs via the orthographic projection.
+//
+// The orthographic is a projection where the sphere is projected onto a
+// tangent plane, with a point of perspective that is infinitely far away. It
+// gives a view of the sphere as seen from outer space.
+//
+// It is:
+//   - Configured by setting the center of the projection.
+//   - Not conformal, equal area or equidistant, but preserves shape, area, and
+//     distance locally at the center of the projection.
+type Orthographic struct {
+	radius float64
+	λ0     float64
+	cosφ0  float64
+	sinφ0  float64
+}
+
+// NewOrthographic returns a new Orthographic projection with the given earth
+// radius.
+func NewOrthographic(radius float64) *Orthographic {
+	return &Orthographic{
+		radius: radius,
+		λ0:     0,
+		cosφ0:  1, // φ0 = 0
+		sinφ0:  0, // φ0 = 0
+	}
+}
+
+// SetCenterLonLat sets the center of the projection to the given (longitude,
+// latitude) pair. The center have projected coordinates (0, 0) and be the
+// center of the circular map.
+func (m *Orthographic) SetCenter(centerLonLat XY) {
+	m.λ0 = dtor(centerLonLat.X)
+	φ0 := dtor(centerLonLat.Y)
+	m.sinφ0 = sin(φ0)
+	m.cosφ0 = cos(φ0)
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (m *Orthographic) Forward(lonLat XY) XY {
+	var (
+		R     = m.radius
+		λ     = dtor(lonLat.X)
+		φ     = dtor(lonLat.Y)
+		λ0    = m.λ0
+		cosφ0 = m.cosφ0
+		sinφ0 = m.sinφ0
+	)
+	return XY{
+		X: R * cos(φ) * sin(λ-λ0),
+		Y: R * (cosφ0*sin(φ) - sinφ0*cos(φ)*cos(λ-λ0)),
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (m *Orthographic) Reverse(xy XY) XY {
+	var (
+		R     = m.radius
+		x     = xy.X
+		y     = xy.Y
+		λ0    = m.λ0
+		cosφ0 = m.cosφ0
+		sinφ0 = m.sinφ0
+	)
+	var (
+		ρ = xy.Length()
+		c = asin(ρ / R)
+		φ = asin(cos(c)*sinφ0 + y*sin(c)*cosφ0/ρ)
+		λ = λ0 + atan(x*sin(c)/(ρ*cos(c)*cosφ0-y*sin(c)*sinφ0))
+	)
+	return rtodxy(λ, φ)
+}

--- a/carto/proj_sinusoidal.go
+++ b/carto/proj_sinusoidal.go
@@ -1,0 +1,64 @@
+package carto
+
+import "github.com/peterstace/simplefeatures/geom"
+
+// Sinusoidal allows projecting (longitude, latitude) coordinates to (x, y)
+// pairs via the sinusoidal projection.
+//
+// The sinusoidal projection is a pseudocylindrical projection that is:
+//   - Configured by setting the central meridian.
+//   - Equal area.
+//   - Not conformal, but preserves shape locally along the central meridian
+//     and equator.
+//   - Not equidistant, but preserves distance locally along all parallels and
+//     the central meridian.
+type Sinusoidal struct {
+	radius float64
+	λ0     float64
+}
+
+// NewSinusoidal returns a new Sinusoidal projection with the given earth
+// radius.
+func NewSinusoidal(earthRadius float64) *Sinusoidal {
+	return &Sinusoidal{
+		radius: earthRadius,
+		λ0:     0,
+	}
+}
+
+// SetCentralMeridian sets the central meridian of the projection to the given
+// longitude expressed in degrees.
+func (c *Sinusoidal) SetCentralMeridian(lon float64) {
+	c.λ0 = dtor(lon)
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (c *Sinusoidal) Forward(lonLat geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		λ0 = c.λ0
+		λ  = dtor(lonLat.X)
+		φ  = dtor(lonLat.Y)
+	)
+	return geom.XY{
+		X: R * cos(φ) * (λ - λ0),
+		Y: R * φ,
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (c *Sinusoidal) Reverse(xy geom.XY) geom.XY {
+	var (
+		R  = c.radius
+		λ0 = c.λ0
+		x  = xy.X
+		y  = xy.Y
+	)
+	var (
+		λ = x/(R*cos(y/R)) + λ0
+		φ = y / R
+	)
+	return rtodxy(λ, φ)
+}

--- a/carto/proj_web_mercator.go
+++ b/carto/proj_web_mercator.go
@@ -1,0 +1,58 @@
+package carto
+
+import (
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+// WebMercator is a variant of the Web Mercator projection that is used for web
+// maps. The projection maps between (latitude, longitude) pairs expressed in
+// degrees, and (x, y) pairs. The x and y coordinates are in the range 0 to
+// 2^zoom, where zoom is the zoom level of the map.
+//
+// The x coordinate increases from left to right, and the y coordinate
+// increases from top to bottom.
+//
+// It is:
+//   - Conformal (shape is preserved locally at all points).
+//   - Not equal area.
+//   - Not equidistant.
+type WebMercator struct {
+	zoom int
+}
+
+// NewWebMercator returns a new WebMercator projection with the given zoom.
+func NewWebMercator(zoom int) *WebMercator {
+	return &WebMercator{zoom}
+}
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (x, y) pair.
+func (m *WebMercator) Forward(lonlat geom.XY) geom.XY {
+	var (
+		λd = lonlat.X
+		φ  = dtor(lonlat.Y)
+		P  = float64(int(1) << m.zoom)
+	)
+	return geom.XY{
+		X: (λd + 180) / 360 * P,
+		Y: (π - ln(tan(π/4+φ/2))) * P / (2 * π),
+	}
+}
+
+// Reverse converts a projected (x, y) pair to a (longitude, latitude) pair
+// expressed in degrees.
+func (m *WebMercator) Reverse(xy geom.XY) geom.XY {
+	var (
+		x = xy.X
+		y = xy.Y
+		P = float64(int(1) << m.zoom)
+	)
+	var (
+		λd = x/P*360 - 180
+		φr = 2 * (atan(exp(π-2*π*y/P)) - π/4)
+	)
+	return geom.XY{
+		X: λd,
+		Y: rtod(φr),
+	}
+}

--- a/carto/projections_test.go
+++ b/carto/projections_test.go
@@ -19,6 +19,10 @@ type projectionSubTest struct {
 	projected geom.XY
 }
 
+func xy(x, y float64) geom.XY {
+	return geom.XY{X: x, Y: y}
+}
+
 func TestProjections(t *testing.T) {
 	for _, pc := range []struct {
 		name      string
@@ -32,12 +36,12 @@ func TestProjections(t *testing.T) {
 			threshold: 1.0 / (1 << 16), // 1/65536th of a tile.
 			subtests: []projectionSubTest{
 				{
-					geom.XY{0, 0},
-					geom.XY{0.5, 0.5},
+					xy(0, 0),
+					xy(0.5, 0.5),
 				},
 				{
-					geom.XY{151.20756306500027, -33.86648215268569},
-					geom.XY{0.9200210085138897, 0.6000844973286593},
+					xy(151.20756306500027, -33.86648215268569),
+					xy(0.9200210085138897, 0.6000844973286593),
 				},
 			},
 		},
@@ -47,8 +51,8 @@ func TestProjections(t *testing.T) {
 			threshold: 1.0 / (1 << 16), // 1/65536th of a tile.
 			subtests: []projectionSubTest{
 				{
-					geom.XY{151.20756306500027, -33.86648215268569},
-					geom.XY{1929423.8980469208, 1258468.4037417925},
+					xy(151.20756306500027, -33.86648215268569),
+					xy(1929423.8980469208, 1258468.4037417925),
 				},
 			},
 		},
@@ -58,24 +62,24 @@ func TestProjections(t *testing.T) {
 				p := carto.NewOrthographic(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetCenter(geom.XY{151, -34})
+				p.SetCenter(xy(151, -34))
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{
-					geom.XY{151, -34},
-					geom.XY{0, 0},
+					xy(151, -34),
+					xy(0, 0),
 				},
 				{
 					// 1km north of origin.
-					geom.XY{151, -33.99100679628548},
-					geom.XY{0, 1000},
+					xy(151, -33.99100679628548),
+					xy(0, 1000),
 				},
 				{
 					// ~100km south west of origin.
-					geom.XY{150.29102511044510493, -34.68753125394282932},
-					geom.XY{-64821.441153708925, -76672.52425247061},
+					xy(150.29102511044510493, -34.68753125394282932),
+					xy(-64821.441153708925, -76672.52425247061),
 				},
 			},
 		},
@@ -86,8 +90,8 @@ func TestProjections(t *testing.T) {
 			),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{{
-				geom.XY{151, -34},
-				geom.XY{1.679045703992921e7, -3.5626228929251498e6},
+				xy(151, -34),
+				xy(1.679045703992921e7, -3.5626228929251498e6),
 			}},
 		},
 		{
@@ -99,8 +103,8 @@ func TestProjections(t *testing.T) {
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{{
-				geom.XY{151, -34},
-				geom.XY{0, -3.5626228929251498e6},
+				xy(151, -34),
+				xy(0, -3.5626228929251498e6),
 			}},
 		},
 		{
@@ -108,8 +112,8 @@ func TestProjections(t *testing.T) {
 			proj:      carto.NewSinusoidal(carto.WGS84EllipsoidMeanRadiusM),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{{
-				geom.XY{151, -34},
-				geom.XY{1.3919919746472625e+07, -3.780632710977439e+06},
+				xy(151, -34),
+				xy(1.3919919746472625e+07, -3.780632710977439e+06),
 			}},
 		},
 		{
@@ -121,8 +125,8 @@ func TestProjections(t *testing.T) {
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{{
-				geom.XY{151, -34},
-				geom.XY{0, -3.780632710977439e+06},
+				xy(151, -34),
+				xy(0, -3.780632710977439e+06),
 			}},
 		},
 		{
@@ -132,8 +136,8 @@ func TestProjections(t *testing.T) {
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{{
-				geom.XY{151, -34},
-				geom.XY{1.679045703992921e+07, -3.780632710977439e+06},
+				xy(151, -34),
+				xy(1.679045703992921e+07, -3.780632710977439e+06),
 			}},
 		},
 		{
@@ -146,8 +150,8 @@ func TestProjections(t *testing.T) {
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{{
 				// Gibraltar, ~480km west of 0 degrees and at ~36 degrees latitude.
-				geom.XY{-5.34660683624621225, 36.1335656729737309},
-				geom.XY{-480973.8495682527, 4.0178747161028227e+06},
+				xy(-5.34660683624621225, 36.1335656729737309),
+				xy(-480973.8495682527, 4.0178747161028227e+06),
 			}},
 		},
 		{
@@ -156,18 +160,18 @@ func TestProjections(t *testing.T) {
 				p := carto.NewAzimuthalEquidistant(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetCenter(geom.XY{0, 90})
+				p.SetCenter(xy(0, 90))
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{ // Hamburg:
-					geom.XY{9.988519873740467, 53.434757149649016},
-					geom.XY{705229.5, -4004246.7},
+					xy(9.988519873740467, 53.434757149649016),
+					xy(705229.5, -4004246.7),
 				},
 				{ // Port Moresby:
-					geom.XY{147.1827863021232, -9.36844599194037},
-					geom.XY{5988277, 9285859},
+					xy(147.1827863021232, -9.36844599194037),
+					xy(5988277, 9285859),
 				},
 			},
 		},
@@ -177,14 +181,14 @@ func TestProjections(t *testing.T) {
 				p := carto.NewAzimuthalEquidistant(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetCenter(geom.XY{0, 0})
+				p.SetCenter(xy(0, 0))
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{ // Cape Town:
-					geom.XY{18.483735820900083, -33.95848592499432},
-					geom.XY{1805674, -3835659},
+					xy(18.483735820900083, -33.95848592499432),
+					xy(1805674, -3835659),
 				},
 			},
 		},
@@ -194,19 +198,19 @@ func TestProjections(t *testing.T) {
 				p := carto.NewEquidistantConic(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetOrigin(geom.XY{X: -60, Y: -32})
+				p.SetOrigin(xy(-60, -32))
 				p.SetStandardParallels(-5, -42)
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{ // Rio de Janeiro:
-					geom.XY{X: -43.2, Y: -22.8},
-					geom.XY{1629961.7759447654, 929251.645477184},
+					xy(-43.2, -22.8),
+					xy(1629961.7759447654, 929251.645477184),
 				},
 				{ // Baltimore:
-					geom.XY{X: -76.6, Y: 39.3},
-					geom.XY{X: -2392910.752006106, Y: 7792228.9404544085},
+					xy(-76.6, 39.3),
+					xy(-2392910.752006106, 7792228.9404544085),
 				},
 			},
 		},
@@ -216,15 +220,15 @@ func TestProjections(t *testing.T) {
 				p := carto.NewEquidistantConic(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetOrigin(geom.XY{X: 95, Y: 30})
+				p.SetOrigin(xy(95, 30))
 				p.SetStandardParallels(15, 65)
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{ // Beijing:
-					geom.XY{X: 116.44497408510593, Y: 39.890737551498475},
-					geom.XY{X: 1643407.6, Y: 1292149.5},
+					xy(116.44497408510593, 39.890737551498475),
+					xy(1643407.6, 1292149.5),
 				},
 			},
 		},
@@ -234,19 +238,19 @@ func TestProjections(t *testing.T) {
 				p := carto.NewLambertConformalConic(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetOrigin(geom.XY{X: -96, Y: 40})
+				p.SetOrigin(xy(-96, 40))
 				p.SetStandardParallels(50, 70)
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{ // Toronto:
-					geom.XY{X: -79.3832, Y: 43.6532},
-					geom.XY{X: 1353292.7229285287, Y: 590902.0666354574},
+					xy(-79.3832, 43.6532),
+					xy(1353292.7229285287, 590902.0666354574),
 				},
 				{ // Vancouver:
-					geom.XY{X: -123.1216, Y: 49.2827},
-					geom.XY{X: -1916086.3118012992, Y: 1453088.303860319},
+					xy(-123.1216, 49.2827),
+					xy(-1916086.3118012992, 1453088.303860319),
 				},
 			},
 		},
@@ -256,19 +260,19 @@ func TestProjections(t *testing.T) {
 				p := carto.NewAlbersEqualAreaConic(
 					carto.WGS84EllipsoidMeanRadiusM,
 				)
-				p.SetOrigin(geom.XY{X: 132, Y: 0})
+				p.SetOrigin(xy(132, 0))
 				p.SetStandardParallels(-18, -36)
 				return p
 			}(),
 			threshold: 1e-3, // 1mm
 			subtests: []projectionSubTest{
 				{ // Sydney:
-					geom.XY{151.2146821, -33.8574973},
-					geom.XY{1757815.279206157, -3843578.921069043},
+					xy(151.2146821, -33.8574973),
+					xy(1757815.279206157, -3843578.921069043),
 				},
 				{ // Perth:
-					geom.XY{115.5397172, -31.9949202},
-					geom.XY{-1534150.6162269458, -3601473.816874394},
+					xy(115.5397172, -31.9949202),
+					xy(-1534150.6162269458, -3601473.816874394),
 				},
 			},
 		},

--- a/carto/projections_test.go
+++ b/carto/projections_test.go
@@ -1,0 +1,299 @@
+package carto_test
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/peterstace/simplefeatures/carto"
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+type projection interface {
+	Forward(lonlat geom.XY) geom.XY
+	Reverse(xy geom.XY) geom.XY
+}
+
+type projectionSubTest struct {
+	lotLat    geom.XY
+	projected geom.XY
+}
+
+func TestProjections(t *testing.T) {
+	for _, pc := range []struct {
+		name      string
+		proj      projection
+		threshold float64
+		subtests  []projectionSubTest
+	}{
+		{
+			name:      "WebMercator0",
+			proj:      carto.NewWebMercator(0),
+			threshold: 1.0 / (1 << 16), // 1/65536th of a tile.
+			subtests: []projectionSubTest{
+				{
+					geom.XY{0, 0},
+					geom.XY{0.5, 0.5},
+				},
+				{
+					geom.XY{151.20756306500027, -33.86648215268569},
+					geom.XY{0.9200210085138897, 0.6000844973286593},
+				},
+			},
+		},
+		{
+			name:      "WebMercator21",
+			proj:      carto.NewWebMercator(21),
+			threshold: 1.0 / (1 << 16), // 1/65536th of a tile.
+			subtests: []projectionSubTest{
+				{
+					geom.XY{151.20756306500027, -33.86648215268569},
+					geom.XY{1929423.8980469208, 1258468.4037417925},
+				},
+			},
+		},
+		{
+			name: "OrthographicAtSydney",
+			proj: func() projection {
+				p := carto.NewOrthographic(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetCenter(geom.XY{151, -34})
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{
+					geom.XY{151, -34},
+					geom.XY{0, 0},
+				},
+				{
+					// 1km north of origin.
+					geom.XY{151, -33.99100679628548},
+					geom.XY{0, 1000},
+				},
+				{
+					// ~100km south west of origin.
+					geom.XY{150.29102511044510493, -34.68753125394282932},
+					geom.XY{-64821.441153708925, -76672.52425247061},
+				},
+			},
+		},
+		{
+			name: "LambertCylindricalEqual",
+			proj: carto.NewLambertCylindricalEqualArea(
+				carto.WGS84EllipsoidMeanRadiusM,
+			),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{{
+				geom.XY{151, -34},
+				geom.XY{1.679045703992921e7, -3.5626228929251498e6},
+			}},
+		},
+		{
+			name: "LambertCylindricalEqualAtSydney",
+			proj: func() projection {
+				p := carto.NewLambertCylindricalEqualArea(carto.WGS84EllipsoidMeanRadiusM)
+				p.SetCentralMeridian(151)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{{
+				geom.XY{151, -34},
+				geom.XY{0, -3.5626228929251498e6},
+			}},
+		},
+		{
+			name:      "Sinusoidal",
+			proj:      carto.NewSinusoidal(carto.WGS84EllipsoidMeanRadiusM),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{{
+				geom.XY{151, -34},
+				geom.XY{1.3919919746472625e+07, -3.780632710977439e+06},
+			}},
+		},
+		{
+			name: "SinusoidalAtSydney",
+			proj: func() projection {
+				p := carto.NewSinusoidal(carto.WGS84EllipsoidMeanRadiusM)
+				p.SetCentralMeridian(151)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{{
+				geom.XY{151, -34},
+				geom.XY{0, -3.780632710977439e+06},
+			}},
+		},
+		{
+			name: "Equirectangular - Plate Carree",
+			proj: func() projection {
+				return carto.NewEquirectangular(carto.WGS84EllipsoidMeanRadiusM)
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{{
+				geom.XY{151, -34},
+				geom.XY{1.679045703992921e+07, -3.780632710977439e+06},
+			}},
+		},
+		{
+			name: "Equirectangular - Marinus of Tyre",
+			proj: func() projection {
+				p := carto.NewEquirectangular(carto.WGS84EllipsoidMeanRadiusM)
+				p.SetStandardParallels(36)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{{
+				// Gibraltar, ~480km west of 0 degrees and at ~36 degrees latitude.
+				geom.XY{-5.34660683624621225, 36.1335656729737309},
+				geom.XY{-480973.8495682527, 4.0178747161028227e+06},
+			}},
+		},
+		{
+			name: "Azimuthal Equidistant - North Pole",
+			proj: func() projection {
+				p := carto.NewAzimuthalEquidistant(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetCenter(geom.XY{0, 90})
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{ // Hamburg:
+					geom.XY{9.988519873740467, 53.434757149649016},
+					geom.XY{705229.5, -4004246.7},
+				},
+				{ // Port Moresby:
+					geom.XY{147.1827863021232, -9.36844599194037},
+					geom.XY{5988277, 9285859},
+				},
+			},
+		},
+		{
+			name: "Azimuthal Equidistant - Africa",
+			proj: func() projection {
+				p := carto.NewAzimuthalEquidistant(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetCenter(geom.XY{0, 0})
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{ // Cape Town:
+					geom.XY{18.483735820900083, -33.95848592499432},
+					geom.XY{1805674, -3835659},
+				},
+			},
+		},
+		{
+			name: "Equidistant Conic - South America",
+			proj: func() projection {
+				p := carto.NewEquidistantConic(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetOrigin(geom.XY{X: -60, Y: -32})
+				p.SetStandardParallels(-5, -42)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{ // Rio de Janeiro:
+					geom.XY{X: -43.2, Y: -22.8},
+					geom.XY{1629961.7759447654, 929251.645477184},
+				},
+				{ // Baltimore:
+					geom.XY{X: -76.6, Y: 39.3},
+					geom.XY{X: -2392910.752006106, Y: 7792228.9404544085},
+				},
+			},
+		},
+		{
+			name: "Equidistant Conic - North Asia",
+			proj: func() projection {
+				p := carto.NewEquidistantConic(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetOrigin(geom.XY{X: 95, Y: 30})
+				p.SetStandardParallels(15, 65)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{ // Beijing:
+					geom.XY{X: 116.44497408510593, Y: 39.890737551498475},
+					geom.XY{X: 1643407.6, Y: 1292149.5},
+				},
+			},
+		},
+		{
+			name: "Lambert Conformal Conic - Canada",
+			proj: func() projection {
+				p := carto.NewLambertConformalConic(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetOrigin(geom.XY{X: -96, Y: 40})
+				p.SetStandardParallels(50, 70)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{ // Toronto:
+					geom.XY{X: -79.3832, Y: 43.6532},
+					geom.XY{X: 1353292.7229285287, Y: 590902.0666354574},
+				},
+				{ // Vancouver:
+					geom.XY{X: -123.1216, Y: 49.2827},
+					geom.XY{X: -1916086.3118012992, Y: 1453088.303860319},
+				},
+			},
+		},
+		{
+			name: "Albers Equal Area Conic - Australia",
+			proj: func() projection {
+				p := carto.NewAlbersEqualAreaConic(
+					carto.WGS84EllipsoidMeanRadiusM,
+				)
+				p.SetOrigin(geom.XY{X: 132, Y: 0})
+				p.SetStandardParallels(-18, -36)
+				return p
+			}(),
+			threshold: 1e-3, // 1mm
+			subtests: []projectionSubTest{
+				{ // Sydney:
+					geom.XY{151.2146821, -33.8574973},
+					geom.XY{1757815.279206157, -3843578.921069043},
+				},
+				{ // Perth:
+					geom.XY{115.5397172, -31.9949202},
+					geom.XY{-1534150.6162269458, -3601473.816874394},
+				},
+			},
+		},
+	} {
+		t.Run(pc.name, func(t *testing.T) {
+			for i, st := range pc.subtests {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					t.Run("Forward", func(t *testing.T) {
+						got := pc.proj.Forward(st.lotLat)
+						expectXYWithinTolerance(t, got, st.projected, pc.threshold)
+					})
+					t.Run("Reverse", func(t *testing.T) {
+						got := pc.proj.Reverse(st.projected)
+						const threshold = 1e-8 // 1e-8 degrees is about 1mm.
+						expectXYWithinTolerance(t, got, st.lotLat, threshold)
+					})
+				})
+			}
+		})
+	}
+}
+
+func expectXYWithinTolerance(tb testing.TB, got, want geom.XY, tolerance float64) {
+	tb.Helper()
+	if delta := math.Abs(got.Sub(want).Length()); delta > tolerance {
+		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)
+	}
+}

--- a/carto/radius.go
+++ b/carto/radius.go
@@ -1,0 +1,13 @@
+package carto
+
+const (
+	// WGS84EllipsoidEquatorialRadiusM is the radius of the WGS84 ellipsoid at
+	// the equator.
+	WGS84EllipsoidEquatorialRadiusM = 6378137.0
+
+	// WGS84EllipsoidPolarRadiusM is the radius of the WGS84 ellipsoid at the poles.
+	WGS84EllipsoidPolarRadiusM = 6356752.314245
+
+	// WGS84EllipsoidMeanRadiusM is the mean radius of the WGS84 ellipsoid.
+	WGS84EllipsoidMeanRadiusM = (2*WGS84EllipsoidEquatorialRadiusM + WGS84EllipsoidPolarRadiusM) / 3
+)

--- a/carto/util.go
+++ b/carto/util.go
@@ -1,0 +1,87 @@
+package carto
+
+import (
+	"math"
+
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+// This file contains utility functions that make projection formulas terser.
+// While terse code is usually _harder_ to read, the opposite is true for
+// mathematical formulas.
+
+func dtor(d float64) float64 {
+	return d * π / 180
+}
+
+func rtod(r float64) float64 {
+	return r * 180 / π
+}
+
+func rtodxy(λ, φ float64) geom.XY {
+	return geom.XY{X: rtod(λ), Y: rtod(φ)}
+}
+
+const (
+	π = math.Pi
+)
+
+func sqrt(x float64) float64 {
+	return math.Sqrt(x)
+}
+
+func tan(x float64) float64 {
+	return math.Tan(x)
+}
+
+func ln(x float64) float64 {
+	return math.Log(x)
+}
+
+func sin(x float64) float64 {
+	return math.Sin(x)
+}
+
+func cos(x float64) float64 {
+	return math.Cos(x)
+}
+
+func atan(x float64) float64 {
+	return math.Atan(x)
+}
+
+func atan2(y, x float64) float64 {
+	return math.Atan2(y, x)
+}
+
+func asin(x float64) float64 {
+	return math.Asin(x)
+}
+
+func acos(x float64) float64 {
+	return math.Acos(x)
+}
+
+func exp(x float64) float64 {
+	return math.Exp(x)
+}
+
+func pow(x, y float64) float64 {
+	return math.Pow(x, y)
+}
+
+func sign(x float64) float64 {
+	return math.Copysign(1, x)
+}
+
+func sec(x float64) float64 {
+	return 1 / cos(x)
+}
+
+func cot(x float64) float64 {
+	return 1 / tan(x)
+}
+
+func sq(x float64) float64 {
+	return x * x
+}


### PR DESCRIPTION
## Description

This functionality is added to a new package `github.com/peterstace/simplefeatures/carto`, which will (in the future) house other functionality that is useful when working with maps.

Only a handful of the most basic projections are initially added.


## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/629
