### PR TITLE
Pull Request: Add FlipCoordinates method to all geometry types

### DIFF
--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -580,3 +580,10 @@ func (c GeometryCollection) Densify(maxDistance float64) GeometryCollection {
 func (c GeometryCollection) SnapToGrid(decimalPlaces int) GeometryCollection {
 	return c.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new GeometryCollection with X and Y swapped for each point in all geometries.
+func (gc GeometryCollection) FlipCoordinates() GeometryCollection {
+	return gc.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_geometry_collection_test.go
+++ b/geom/type_geometry_collection_test.go
@@ -1,0 +1,22 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestGeometryCollectionFlipCoordinates(t *testing.T) {
+	pt := NewPointXY(1, 2)
+	ls := NewLineStringXY(3, 4, 5, 6)
+	gc := NewGeometryCollection([]Geometry{pt.AsGeometry(), ls.AsGeometry()})
+	flipped := gc.FlipCoordinates()
+	geoms := flipped.Dump()
+	g0 := geoms[0].MustAsPoint()
+	g1 := geoms[1].MustAsLineString()
+	xy0, _ := g0.XY()
+	seq := g1.Coordinates()
+	xy1 := seq.GetXY(0)
+	xy2 := seq.GetXY(1)
+	if xy0 != (XY{2, 1}) || xy1 != (XY{4, 3}) || xy2 != (XY{6, 5}) {
+		t.Errorf("expected [(2,1),(4,3),(6,5)], got [%v,%v,%v]", xy0, xy1, xy2)
+	}
+}

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -497,3 +497,10 @@ func (s LineString) Densify(minDistance float64) LineString {
 func (s LineString) SnapToGrid(decimalPlaces int) LineString {
 	return s.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new LineString with X and Y swapped for each point.
+func (ls LineString) FlipCoordinates() LineString {
+	return ls.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_line_string_test.go
+++ b/geom/type_line_string_test.go
@@ -1,0 +1,16 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestLineStringFlipCoordinates(t *testing.T) {
+	ls := NewLineStringXY(1, 2, 3, 4)
+	flipped := ls.FlipCoordinates()
+	seq := flipped.Coordinates()
+	xy0 := seq.GetXY(0)
+	xy1 := seq.GetXY(1)
+	if xy0 != (XY{2, 1}) || xy1 != (XY{4, 3}) {
+		t.Errorf("expected [(2,1),(4,3)], got [%v,%v]", xy0, xy1)
+	}
+}

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -538,3 +538,10 @@ func (m MultiLineString) Densify(maxDistance float64) MultiLineString {
 func (m MultiLineString) SnapToGrid(decimalPlaces int) MultiLineString {
 	return m.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new MultiLineString with X and Y swapped for each point.
+func (mls MultiLineString) FlipCoordinates() MultiLineString {
+	return mls.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_multi_line_string_test.go
+++ b/geom/type_multi_line_string_test.go
@@ -1,0 +1,17 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestMultiLineStringFlipCoordinates(t *testing.T) {
+	mls := NewMultiLineStringXY([]float64{1, 2, 3, 4})
+	flipped := mls.FlipCoordinates()
+	ls := flipped.LineStringN(0)
+	seq := ls.Coordinates()
+	xy0 := seq.GetXY(0)
+	xy1 := seq.GetXY(1)
+	if xy0 != (XY{2, 1}) || xy1 != (XY{4, 3}) {
+		t.Errorf("expected [(2,1),(4,3)], got [%v,%v]", xy0, xy1)
+	}
+}

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -350,3 +350,10 @@ func (m MultiPoint) String() string {
 func (m MultiPoint) SnapToGrid(decimalPlaces int) MultiPoint {
 	return m.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new MultiPoint with X and Y swapped for each point.
+func (mp MultiPoint) FlipCoordinates() MultiPoint {
+	return mp.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_multi_point_test.go
+++ b/geom/type_multi_point_test.go
@@ -1,0 +1,16 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestMultiPointFlipCoordinates(t *testing.T) {
+	mp := NewMultiPointXY(1, 2, 3, 4)
+	flipped := mp.FlipCoordinates()
+	seq := flipped.Coordinates()
+	xy0 := seq.GetXY(0)
+	xy1 := seq.GetXY(1)
+	if xy0 != (XY{2, 1}) || xy1 != (XY{4, 3}) {
+		t.Errorf("expected [(2,1),(4,3)], got [%v,%v]", xy0, xy1)
+	}
+}

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -597,3 +597,10 @@ func (m MultiPolygon) Densify(maxDistance float64) MultiPolygon {
 func (m MultiPolygon) SnapToGrid(decimalPlaces int) MultiPolygon {
 	return m.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new MultiPolygon with X and Y swapped for each point.
+func (mp MultiPolygon) FlipCoordinates() MultiPolygon {
+	return mp.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_multi_polygon_test.go
+++ b/geom/type_multi_polygon_test.go
@@ -1,0 +1,17 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestMultiPolygonFlipCoordinates(t *testing.T) {
+	mp := NewMultiPolygonXY([][]float64{{1, 2, 3, 4, 1, 2}})
+	flipped := mp.FlipCoordinates()
+	poly := flipped.PolygonN(0)
+	seq := poly.ExteriorRing().Coordinates()
+	xy0 := seq.GetXY(0)
+	xy1 := seq.GetXY(1)
+	if xy0 != (XY{2, 1}) || xy1 != (XY{4, 3}) {
+		t.Errorf("expected [(2,1),(4,3)], got [%v,%v]", xy0, xy1)
+	}
+}

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -280,3 +280,10 @@ func (p Point) String() string {
 func (p Point) SnapToGrid(decimalPlaces int) Point {
 	return p.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new Point with X and Y swapped.
+func (p Point) FlipCoordinates() Point {
+	return p.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_point_test.go
+++ b/geom/type_point_test.go
@@ -1,0 +1,14 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestPointFlipCoordinates(t *testing.T) {
+	p := NewPointXY(1, 2)
+	flipped := p.FlipCoordinates()
+	xy, _ := flipped.XY()
+	if xy != (XY{2, 1}) {
+		t.Errorf("expected (2,1), got %v", xy)
+	}
+}

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -715,3 +715,10 @@ func (p Polygon) Densify(maxDistance float64) Polygon {
 func (p Polygon) SnapToGrid(decimalPlaces int) Polygon {
 	return p.TransformXY(snapToGridXY(decimalPlaces))
 }
+
+// FlipCoordinates returns a new Polygon with X and Y swapped for each point.
+func (p Polygon) FlipCoordinates() Polygon {
+	return p.TransformXY(func(xy XY) XY {
+		return XY{xy.Y, xy.X}
+	})
+}

--- a/geom/type_polygon_test.go
+++ b/geom/type_polygon_test.go
@@ -1,0 +1,16 @@
+package geom
+
+import (
+	"testing"
+)
+
+func TestPolygonFlipCoordinates(t *testing.T) {
+	poly := NewPolygonXY([]float64{1, 2, 3, 4, 1, 2})
+	flipped := poly.FlipCoordinates()
+	seq := flipped.ExteriorRing().Coordinates()
+	xy0 := seq.GetXY(0)
+	xy1 := seq.GetXY(1)
+	if xy0 != (XY{2, 1}) || xy1 != (XY{4, 3}) {
+		t.Errorf("expected [(2,1),(4,3)], got [%v,%v]", xy0, xy1)
+	}
+}


### PR DESCRIPTION
This PR implements the FlipCoordinates() method for all geometry types as described in issue #386.
Added FlipCoordinates() to:
Point
LineString
Polygon
MultiPoint
MultiLineString
MultiPolygon
GeometryCollection
Each method uses the existing TransformXY function internally to swap X and Y coordinates.
Added a unit test for each geometry type to verify correct behavior.
All tests pass locally.
Let me know if you would like any changes or improvements. Thank you for the opportunity to contribute!