### PR TITLE
Add UTM projections

### DIFF
--- a/carto/proj_utm.go
+++ b/carto/proj_utm.go
@@ -1,0 +1,254 @@
+package carto
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+// UTM allows projecting (longitude, latitude) coordinates to (x, y) pairs via
+// a UTM (Universal Transverse Mercator) projection.
+//
+// There are 60 UTM zones, each covering 6 degrees of longitude. There is a
+// different set of projections for the northern and southern hemispheres,
+// resulting in 120 distinct UTM projections in total.
+//
+// UTM projections are:
+//   - Configured by a UTM zone and hemisphere designator.
+//   - Conformal, but not equal area or equidistant. Despite not being equal
+//     area or equidistant, area and distance are only degrade a small amount
+//     within the bounds of a particular UTM zone.
+type UTM struct {
+	zone  int
+	north bool // true for northern hemisphere, false for southern hemisphere.
+}
+
+// Code returns the UTM code for this projection, which is the zone (with leading
+// zero to pad to 2 digits) and an N or S designator. E.g. "06N" and "56S".
+func (u *UTM) Code() string {
+	hemisphere := "N"
+	if !u.north {
+		hemisphere = "S"
+	}
+	return fmt.Sprintf("%02d%s", u.zone, hemisphere)
+}
+
+type invalidUTMCodeError struct {
+	code string
+}
+
+func (e invalidUTMCodeError) Error() string {
+	return fmt.Sprintf(
+		"invalid UTM code '%s': must be 3 characters long, with the first "+
+			"two being digits (01-60) and the last being 'N' or 'S'", e.code)
+}
+
+// NewUTMFromCode creates a UTM projection using the given UTM zone and
+// hemisphere code. Codes are composed the zone (with leading zero to pad to 2
+// digits) and an N or S designator. E.g. "06N" and "56S".
+func NewUTMFromCode(code string) (*UTM, error) {
+	if len(code) != 3 {
+		return nil, invalidUTMCodeError{code}
+	}
+
+	zone, err := strconv.Atoi(code[:2])
+	if err != nil {
+		return nil, invalidUTMCodeError{code}
+	}
+	if zone < 1 || zone > 60 {
+		return nil, invalidUTMCodeError{code}
+	}
+
+	switch hemisphere := code[2:3]; hemisphere {
+	case "S":
+		return &UTM{zone, false}, nil
+	case "N":
+		return &UTM{zone, true}, nil
+	default:
+		return nil, invalidUTMCodeError{code}
+	}
+}
+
+// NewUTMFromLocation creates a UTM projection using the appropriate UTM zone
+// and hemisphere for the given location.
+func NewUTMFromLocation(lonlat geom.XY) (*UTM, error) {
+	λ := lonlat.X
+	φ := lonlat.Y
+	if φ < -80 || φ > 84 {
+		return nil, fmt.Errorf("latitude %v out of range (must be between -80 and 84, both inclusive)", φ)
+	}
+	if λ < -180 || λ > 180 {
+		return nil, fmt.Errorf("longitude %v out of range (must be between -180 and 180, both inclusive)", λ)
+	}
+
+	// Norway exception:
+	if λ >= 3 && λ <= 6 && φ >= 56 && φ <= 64 {
+		return &UTM{32, true}, nil
+	}
+
+	// Svalbard exception:
+	if φ >= 72 && λ >= 0 && λ < 42 {
+		if λ < 9 {
+			return &UTM{31, true}, nil
+		}
+		if λ < 21 {
+			return &UTM{33, true}, nil
+		}
+		if λ < 33 {
+			return &UTM{35, true}, nil
+		}
+		return &UTM{37, true}, nil
+	}
+
+	z := int((λ+180)/6) + 1
+	if z > 60 {
+		// Handle the edge case where λ is exactly 180 degrees.
+		z = 60
+	}
+	return &UTM{z, φ >= 0}, nil
+}
+
+// Projection formulas taken from:
+//
+// Map projections: A working manual (Professional Paper 1395) by John P. Snyder.
+//
+// https://doi.org/10.3133/pp1395
+
+func (u *UTM) centralMeridian() float64 {
+	var (
+		zone    = float64(u.zone)
+		degrees = (zone-1)*6 - 180 + 3
+		radians = dtor(degrees)
+	)
+	return radians
+}
+
+func (u *UTM) falseNorthing() float64 {
+	if u.north {
+		return 0
+	}
+	return 10e6
+}
+
+const (
+	utm_a            = 6378137
+	utm_k0           = 0.9996
+	utm_e2           = 0.00669438
+	utm_falseEasting = 500e3
+)
+
+// Forward converts a (longitude, latitude) pair expressed in degrees to a
+// projected (easting, northing) pair expressed in meters.
+func (u *UTM) Forward(lonlat geom.XY) geom.XY {
+	var (
+		λ  = dtor(lonlat.X)
+		φ  = dtor(lonlat.Y)
+		λ0 = u.centralMeridian()
+		N0 = u.falseNorthing()
+	)
+	const (
+		a  = utm_a
+		k0 = utm_k0
+		e2 = utm_e2
+		E0 = utm_falseEasting
+	)
+	var (
+		ê2 = e2 / (1 - e2) // Called e'² in Snyder.
+		N  = a / sqrt(1-e2*sq(sin(φ)))
+		T  = sq(tan(φ))
+		C  = ê2 * sq(cos(φ))
+		A  = (λ - λ0) * cos(φ)
+	)
+	var (
+		e4 = e2 * e2
+		e6 = e4 * e2
+		J1 = (1 - e2/4 - 3*e4/64 - 5*e6/256) * φ
+		J2 = (3*e2/8 + 3*e4/32 + 45*e6/1024) * sin(2*φ)
+		J3 = (15*e4/256 + 45*e6/1024) * sin(4*φ)
+		J4 = (35 * e6 / 3072) * sin(6*φ)
+		M  = a * (J1 - J2 + J3 - J4)
+	)
+	var (
+		A2 = A * A
+		A3 = A2 * A
+		A4 = A3 * A
+		A5 = A4 * A
+		A6 = A5 * A
+		T2 = T * T
+	)
+	var (
+		Q1 = (1 - T + C) * A3 / 6
+		Q2 = (5 - 18*T + T2 + 72*C - 58*ê2) * A5 / 120
+		x  = E0 + k0*N*(A+Q1+Q2)
+	)
+	var (
+		Q3 = (5 - T + 9*C + 4*C*C) * A4 / 24
+		Q4 = (61 - 58*T + T2 + 600*C - 330*ê2) * A6 / 720
+		y  = N0 + k0*(M+N*tan(φ)*(A2/2+Q3+Q4))
+	)
+	return geom.XY{X: x, Y: y}
+}
+
+// Reverse converts a projected (easting, northing) pair expressed in meters to
+// a (longitude, latitude) pair expressed in degrees.
+func (u *UTM) Reverse(xy geom.XY) geom.XY {
+	var (
+		y = xy.Y - u.falseNorthing()
+		x = xy.X - utm_falseEasting
+	)
+
+	const (
+		a  = utm_a
+		k0 = utm_k0
+		e2 = utm_e2
+		e4 = e2 * e2
+		e6 = e4 * e2
+	)
+	var (
+		ε = (1 - sqrt(1-e2)) / (1 + sqrt(1-e2)) // Called e₁ in Snyder.
+		M = y / k0
+		μ = M / (a * (1 - e2/4 - 3*e4/64 - 5*e6/256))
+	)
+
+	var (
+		ε2 = ε * ε
+		ε3 = ε2 * ε
+		ε4 = ε3 * ε
+		J1 = 3*ε/2 - 27*ε3/32
+		J2 = 21*ε2/16 - 55*ε4/32
+		J3 = 151 * ε3 / 96
+		J4 = 1097 * ε4 / 512
+		φ0 = μ + J1*sin(2*μ) + J2*sin(4*μ) + J3*sin(6*μ) + J4*sin(8*μ)
+	)
+
+	var (
+		ê2 = e2 / (1 - e2) // Called e'² in Snyder.
+		C1 = ê2 * sq(cos(φ0))
+		T1 = sq(tan(φ0))
+		N1 = a / sqrt(1-e2*sq(sin(φ0)))
+		R1 = a * (1 - e2) / pow(1-e2*sq(sin(φ0)), 1.5)
+		D  = x / (N1 * k0)
+	)
+	var (
+		D2 = D * D
+		D3 = D2 * D
+		D4 = D3 * D
+		D5 = D4 * D
+		D6 = D5 * D
+	)
+	var (
+		Q1 = N1 * tan(φ0) / R1
+		Q2 = (5 + 3*T1 + 10*C1 - 4*C1*C1 - 9*ê2) * D4 / 24
+		Q3 = (61 + 90*T1 + 298*C1 + 45*T1*T1 - 3*C1*C1 - 252*ê2) * D6 / 720
+		φ  = φ0 - Q1*(D2/2-Q2+Q3)
+	)
+	var (
+		Q4 = (1 + 2*T1 + C1) * D3 / 6
+		Q5 = (5 - 2*C1 + 28*T1 - 3*C1*C1 + 8*ê2 + 24*T1*T1) * D5 / 120
+		λ0 = u.centralMeridian()
+		λ  = λ0 + (D-Q4+Q5)/cos(φ0)
+	)
+
+	return rtodxy(λ, φ)
+}

--- a/carto/proj_utm_test.go
+++ b/carto/proj_utm_test.go
@@ -1,0 +1,226 @@
+package carto_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/peterstace/simplefeatures/carto"
+	"github.com/peterstace/simplefeatures/geom"
+)
+
+func TestUTMFromCode(t *testing.T) {
+	for zone := 1; zone <= 60; zone++ {
+		for _, designator := range []string{"N", "S"} {
+			code := fmt.Sprintf("%02d%s", zone, designator)
+			t.Run(code, func(t *testing.T) {
+				proj, err := carto.NewUTMFromCode(code)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if proj.Code() != code {
+					t.Errorf("got code %s, want %s", proj.Code(), code)
+				}
+			})
+		}
+	}
+}
+
+func TestUTMFromLocation(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		ptWKT    string
+		wantCode string
+	}{
+		{
+			"in the southern hemisphere",
+			"POINT(151.2020581 -33.8557148)", "56S",
+		},
+		{
+			"zone 01N",
+			"POINT(-178.03 51.865)", "01N",
+		},
+		{
+			"zone 02N",
+			"POINT(-171.694 63.767)", "02N",
+		},
+		{
+			"zone 59N",
+			"POINT(170.249 60.071)", "59N",
+		},
+		{
+			"zone 60N",
+			"POINT(177.142 62.652)", "60N",
+		},
+		{
+			"in the east of a zone",
+			"POINT(17.9999 10)", "33N",
+		},
+		{
+			"in the west of a zone",
+			"POINT(18.0001 10)", "34N",
+		},
+		{
+			"on the boundary between two zones",
+			"POINT(18 10)", "34N", // By arbitrary convention, the zone to the east is chosen.
+		},
+		{
+			"at 180 degrees east",
+			"POINT(180 10)", "60N",
+		},
+		{
+			"at 180 degrees west",
+			"POINT(-180 10)", "01N",
+		},
+		{
+			"at 0 degrees east",
+			"POINT(0 10)", "31N",
+		},
+		{
+			"on the equator",
+			"POINT(1 0)", "31N", // By arbitrary convention, the zone to the north is chosen.
+		},
+		{
+			"at the northern limit",
+			"POINT(1 84)", "31N",
+		},
+		{
+			"at the southern limit",
+			"POINT(1 -80)", "31S",
+		},
+
+		// Norway exception testing:
+		{"Norway exception  1", "POINT(2.9 55.9)", "31N"},
+		{"Norway exception  2", "POINT(3.1 55.9)", "31N"},
+		{"Norway exception  3", "POINT(2.9 64.1)", "31N"},
+		{"Norway exception  4", "POINT(3.1 64.1)", "31N"},
+		{"Norway exception  5", "POINT(2.9 56.1)", "31N"},
+		{"Norway exception  6", "POINT(3.1 56.1)", "32N"},
+		{"Norway exception  7", "POINT(2.9 63.9)", "31N"},
+		{"Norway exception  8", "POINT(3.1 63.9)", "32N"},
+		{"Norway exception  9", "POINT(11.9 55.9)", "32N"},
+		{"Norway exception 10", "POINT(12.1 55.9)", "33N"},
+		{"Norway exception 11", "POINT(11.9 56.1)", "32N"},
+		{"Norway exception 12", "POINT(12.1 56.1)", "33N"},
+		{"Norway exception 13", "POINT(11.9 63.9)", "32N"},
+		{"Norway exception 14", "POINT(12.1 63.9)", "33N"},
+		{"Norway exception 15", "POINT(11.9 64.1)", "32N"},
+		{"Norway exception 16", "POINT(12.1 64.1)", "33N"},
+
+		// Svalbard exception testing:
+		{"Svalbard exception  1", "POINT(-0.1 71.9)", "30N"},
+		{"Svalbard exception  2", "POINT( 0.1 71.9)", "31N"},
+		{"Svalbard exception  3", "POINT(-0.1 72.1)", "30N"},
+		{"Svalbard exception  4", "POINT( 0.1 72.1)", "31N"},
+		{"Svalbard exception  5", "POINT( 8.9 71.9)", "32N"},
+		{"Svalbard exception  6", "POINT( 9.1 71.9)", "32N"},
+		{"Svalbard exception  7", "POINT( 8.9 72.1)", "31N"},
+		{"Svalbard exception  8", "POINT( 9.1 72.1)", "33N"},
+		{"Svalbard exception  9", "POINT(20.9 71.9)", "34N"},
+		{"Svalbard exception 10", "POINT(21.1 71.9)", "34N"},
+		{"Svalbard exception 11", "POINT(20.9 72.1)", "33N"},
+		{"Svalbard exception 12", "POINT(21.1 72.1)", "35N"},
+		{"Svalbard exception 13", "POINT(32.9 71.9)", "36N"},
+		{"Svalbard exception 14", "POINT(33.1 71.9)", "36N"},
+		{"Svalbard exception 15", "POINT(32.9 72.1)", "35N"},
+		{"Svalbard exception 16", "POINT(33.1 72.1)", "37N"},
+		{"Svalbard exception 17", "POINT(-0.1 83.9)", "30N"},
+		{"Svalbard exception 18", "POINT( 0.1 83.9)", "31N"},
+		{"Svalbard exception 19", "POINT( 8.9 83.9)", "31N"},
+		{"Svalbard exception 20", "POINT( 9.1 83.9)", "33N"},
+		{"Svalbard exception 21", "POINT(20.9 83.9)", "33N"},
+		{"Svalbard exception 22", "POINT(21.1 83.9)", "35N"},
+		{"Svalbard exception 23", "POINT(32.9 83.9)", "35N"},
+		{"Svalbard exception 24", "POINT(33.1 83.9)", "37N"},
+		{"Svalbard exception 25", "POINT(41.9 83.9)", "37N"},
+		{"Svalbard exception 26", "POINT(42.1 83.9)", "38N"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pt, err := geom.UnmarshalWKT(tc.ptWKT)
+			if err != nil {
+				t.Fatal(err)
+			}
+			loc, ok := pt.MustAsPoint().XY()
+			if !ok {
+				t.Fatalf("empty point")
+			}
+			proj, err := carto.NewUTMFromLocation(loc)
+			if err != nil {
+				t.Fatalf("got err %v, want nil", err)
+			}
+			if proj.Code() != tc.wantCode {
+				t.Errorf("got code %s, want %s", proj.Code(), tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestUTMFromLocationErrorCases(t *testing.T) {
+	for _, tc := range []struct {
+		ptWKT string
+		name  string
+	}{
+		{"POINT(-180.1 0)", "longitude less than -180"},
+		{"POINT(180.1 0)", "longitude greater than 180"},
+		{"POINT(0 84.1)", "latitude greater than 84"},
+		{"POINT(0 -80.1)", "latitude less than -80"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pt, err := geom.UnmarshalWKT(tc.ptWKT)
+			if err != nil {
+				t.Fatal(err)
+			}
+			loc, ok := pt.MustAsPoint().XY()
+			if !ok {
+				t.Fatalf("expected a point")
+			}
+			if _, err := carto.NewUTMFromLocation(loc); err == nil {
+				t.Errorf("expected an error for %s", tc.ptWKT)
+			}
+		})
+	}
+}
+
+func TestUTMForwardReverse(t *testing.T) {
+	for i, tc := range []struct {
+		code     string
+		inputWKT string
+		wantWKT  string
+	}{
+		// echo '151.2020581 -33.8557148' | cs2cs +to EPSG:32756 -d 3
+		// 333673.327      6252387.751 0.000
+		{"56S", "POINT(151.2020581 -33.8557148)", "POINT(333673.327 6252387.751)"},
+
+		// echo '14.5186965 35.9019739' | cs2cs +to EPSG:32633 -d 3
+		// 456567.479      3973182.990 0.000
+		{"33N", "POINT(14.5186965 35.9019739)", "POINT(456567.479 3973182.990)"},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			pre, err := geom.UnmarshalWKT(tc.inputWKT)
+			if err != nil {
+				t.Error(err)
+			}
+			want, err := geom.UnmarshalWKT(tc.wantWKT)
+			if err != nil {
+				t.Error(err)
+			}
+
+			proj, err := carto.NewUTMFromCode(tc.code)
+			if err != nil {
+				t.Error(err)
+			}
+
+			const toleranceInMeters = 1e-3 // 1mm
+			got := pre.TransformXY(proj.Forward)
+			if !geom.ExactEquals(got, want, geom.ToleranceXY(toleranceInMeters)) {
+				t.Errorf("got %v, want %v", got.AsText(), want.AsText())
+			}
+
+			const toleranceInDegrees = 1e-9 // ~0.1mm
+			roundTrip := got.TransformXY(proj.Reverse)
+			if !geom.ExactEquals(roundTrip, pre, geom.ToleranceXY(toleranceInDegrees)) {
+				t.Errorf("round trip got %v, want %v", roundTrip.AsText(), pre.AsText())
+			}
+		})
+	}
+}

--- a/carto/util.go
+++ b/carto/util.go
@@ -42,8 +42,16 @@ func sin(x float64) float64 {
 	return math.Sin(x)
 }
 
+func sinh(x float64) float64 {
+	return math.Sinh(x)
+}
+
 func cos(x float64) float64 {
 	return math.Cos(x)
+}
+
+func cosh(x float64) float64 {
+	return math.Cosh(x)
 }
 
 func atan(x float64) float64 {
@@ -52,6 +60,10 @@ func atan(x float64) float64 {
 
 func atan2(y, x float64) float64 {
 	return math.Atan2(y, x)
+}
+
+func atanh(x float64) float64 {
+	return math.Atanh(x)
 }
 
 func asin(x float64) float64 {
@@ -84,4 +96,8 @@ func cot(x float64) float64 {
 
 func sq(x float64) float64 {
 	return x * x
+}
+
+func abs(x float64) float64 {
+	return math.Abs(x)
 }


### PR DESCRIPTION
## Description

This change adds support to the `carto` package for UTM projections.

The formulas are taken from https://pubs.usgs.gov/publication/pp1395.



## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?)

## Related Issue

- N/A
