### PR TITLE
Support XYZM in GeoJSON unmarshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Adds support for XYZM coordinate types when unmarshalling GeoJSON.
+
 ## v0.54.0
 
 2025-06-16

--- a/geom/geojson_unmarshal.go
+++ b/geom/geojson_unmarshal.go
@@ -19,7 +19,7 @@ func UnmarshalGeoJSON(input []byte, nv ...NoValidate) (Geometry, error) {
 		return Geometry{}, err
 	}
 
-	hasLength := make(map[int]bool)
+	hasLength := make(map[int]struct{})
 	if err := detectCoordinatesLengths(rootObj, hasLength); err != nil {
 		return Geometry{}, err
 	}
@@ -34,7 +34,7 @@ func UnmarshalGeoJSON(input []byte, nv ...NoValidate) (Geometry, error) {
 	return g, nil
 }
 
-func chooseGeoJSONCoordinatesType(hasLength map[int]bool) CoordinatesType {
+func chooseGeoJSONCoordinatesType(hasLength map[int]struct{}) CoordinatesType {
 	// The GeoJSON spec allows (but doesn't require) parsers to ignore any
 	// "extra" coordinate values in addition to the normal 3 coordinate values
 	// used to specify a 3D position. We choose to interpret a 4th dimension as
@@ -169,11 +169,11 @@ func geojsonInvalidCoordinatesLengthError(n int) error {
 	return geojsonSyntaxError{fmt.Sprintf("invalid geojson coordinate length: %d", n)}
 }
 
-func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
+func detectCoordinatesLengths(node interface{}, hasLength map[int]struct{}) error {
 	switch node := node.(type) {
 	case geojsonPoint:
 		n := len(node.coords)
-		hasLength[n] = true
+		hasLength[n] = struct{}{}
 		if n == 1 {
 			return geojsonInvalidCoordinatesLengthError(n)
 		}
@@ -181,7 +181,7 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
 	case geojsonLineString:
 		for _, c := range node.coords {
 			n := len(c)
-			hasLength[n] = true
+			hasLength[n] = struct{}{}
 			if n < 2 {
 				return geojsonInvalidCoordinatesLengthError(n)
 			}
@@ -191,7 +191,7 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
 		for _, outer := range node.coords {
 			for _, inner := range outer {
 				n := len(inner)
-				hasLength[n] = true
+				hasLength[n] = struct{}{}
 				if n < 2 {
 					return geojsonInvalidCoordinatesLengthError(n)
 				}
@@ -202,7 +202,7 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
 		for _, c := range node.coords {
 			// GeoJSON MultiPoints do not allow empty Points inside them.
 			n := len(c)
-			hasLength[n] = true
+			hasLength[n] = struct{}{}
 			if n < 2 {
 				return geojsonInvalidCoordinatesLengthError(n)
 			}
@@ -212,7 +212,7 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
 		for _, outer := range node.coords {
 			for _, inner := range outer {
 				n := len(inner)
-				hasLength[n] = true
+				hasLength[n] = struct{}{}
 				if n < 2 {
 					return geojsonInvalidCoordinatesLengthError(n)
 				}
@@ -224,7 +224,7 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]bool) error {
 			for _, middle := range outer {
 				for _, inner := range middle {
 					n := len(inner)
-					hasLength[n] = true
+					hasLength[n] = struct{}{}
 					if n < 2 {
 						return geojsonInvalidCoordinatesLengthError(n)
 					}

--- a/geom/geojson_unmarshal.go
+++ b/geom/geojson_unmarshal.go
@@ -333,14 +333,17 @@ func oneDimFloat64sToCoordinates(fs []float64, ctype CoordinatesType) (Coordinat
 	}
 
 	switch ctype {
+	case DimXY:
+		// Do nothing, already set XY.
 	case DimXYZ:
 		coords.Z = fs[2]
 	case DimXYZM:
 		coords.Z = fs[2]
 		coords.M = fs[3]
 	case DimXYM:
-		// This should not happen because DimXYM is never be chosen as the ctype.
-		panic("unexpected DimXYM ctype in oneDimFloat64sToCoordinates")
+		fallthrough // Cannot happen because DimXYM is never chosen as the ctype.
+	default:
+		panic(fmt.Sprintf("unexpected ctype %v in oneDimFloat64sToCoordinates", ctype))
 	}
 
 	return coords, true


### PR DESCRIPTION
## Description

The GeoJSON spec states:

> Implementations SHOULD NOT extend positions beyond three elements because the
> semantics of extra elements are unspecified and ambiguous. Historically, some
> implementations have used a fourth element to carry a linear referencing
> measure (sometimes denoted as "M") or a numerical timestamp, but in most
> situations a parser will not be able to properly interpret these values. The
> interpretation and meaning of additional elements is beyond the scope of this
> specification, and additional elements MAY be ignored by parsers.

In particular `additional elements MAY be ignored by parsers` indicates that parsers may (or may not, in our case) choose to interpret additional elements.

This changes interprets the 4th element as a measure (M) value.

Marshalling behaviour is unchanged, so the 4th element will not be included in the marshalled GeoJSON output. This is required as per the first sentence in the quote above.


## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/650
