### PR TITLE
Simplify GeoJSONFeature marshaling by removing unnecessary checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Simplifies some internals for GeoJSON marshalling. This change is not
+  detectable externally.
+
 ## v0.54.0
 
 2025-06-16

--- a/geom/geojson_feature_collection.go
+++ b/geom/geojson_feature_collection.go
@@ -1,7 +1,6 @@
 package geom
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -128,16 +127,9 @@ func (f GeoJSONFeature) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(fms) == 0 || fms[0] != '{' {
-		return nil, errors.New("ForeignMembers must marshal to a JSON object")
-	}
-	if bytes.Equal(fms, []byte("{}")) {
-		// {} is a special case due to the ',' that would be added below.
-		return buf, nil
-	}
 	buf = buf[:len(buf)-1] // remove trailing '}'
 	buf = append(buf, ',')
-	buf = append(buf, fms[1:]...) // skip leading '{'
+	buf = append(buf, fms[1:]...) // skip leading '{' (must be a JSON object due to construction)
 	return buf, nil
 }
 


### PR DESCRIPTION
## Description

`ForeignMembers` in `GeoJSONFeature` is guaranteed to marshal to a JSON object, because it's a `map[string]interface{}`. So there's no need to check if it marshals to an object. Furthermore, it cannot be empty, since this is already checked.


## Check List

Have you:

- Added unit tests? N/A (no functional change)

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/661
