### PR TITLE
Add support for GeoJSON Feature Collections foreign members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Breaking change:** Adds support for foreign members in GeoJSON Feature
+  Collections. This necessitates a breaking change to the
+  `geom.GeoJSONFeatureCollection` type. It was previously defined as
+  `[]geom.GeoJSONFeature`, but is now defined as a struct with a `Features
+  []geom.GeoJSONFeature` field and a `ForeignMembers
+  map[string]json.RawMessage` field.
+
 - Simplifies some internals for GeoJSON marshalling. This change is not
   detectable externally.
 

--- a/geom/geojson_feature_collection.go
+++ b/geom/geojson_feature_collection.go
@@ -29,7 +29,7 @@ type GeoJSONFeature struct {
 }
 
 // UnmarshalJSON implements the encoding/json Unmarshaler interface by
-// unmarshalling a GeoJSON Feature Collection object.
+// unmarshalling a GeoJSON Feature.
 func (f *GeoJSONFeature) UnmarshalJSON(p []byte) error {
 	var topLevel map[string]json.RawMessage
 	if err := json.Unmarshal(p, &topLevel); err != nil {
@@ -136,37 +136,85 @@ func (f GeoJSONFeature) MarshalJSON() ([]byte, error) {
 // GeoJSONFeatureCollection is a collection of GeoJSONFeatures.
 // GeoJSONFeatureCollection values have a one to one correspondence with
 // GeoJSON FeatureCollections.
-type GeoJSONFeatureCollection []GeoJSONFeature
+type GeoJSONFeatureCollection struct {
+	Features       []GeoJSONFeature
+	ForeignMembers map[string]interface{}
+}
 
 // UnmarshalJSON implements the encoding/json Unmarshaler interface by
 // unmarshalling a GeoJSON FeatureCollection object.
 func (c *GeoJSONFeatureCollection) UnmarshalJSON(p []byte) error {
-	var topLevel struct {
-		Type     string           `json:"type"`
-		Features []GeoJSONFeature `json:"features"`
-	}
+	var topLevel map[string]json.RawMessage
 	if err := json.Unmarshal(p, &topLevel); err != nil {
-		return err
+		return fmt.Errorf("not a valid JSON object: %w", err)
 	}
-	if topLevel.Type == "" {
-		return errors.New("feature collection type field missing or empty")
+
+	typeJSON, ok := topLevel["type"]
+	if !ok {
+		return errors.New("feature collection type field missing")
 	}
-	if topLevel.Type != "FeatureCollection" {
-		return fmt.Errorf("type field not set to FeatureCollection: '%s'", topLevel.Type)
+	var typeStr string
+	if err := json.Unmarshal(typeJSON, &typeStr); err != nil {
+		return fmt.Errorf("unmarshalling type field: %w", err)
 	}
-	*c = topLevel.Features
+	if typeStr != "FeatureCollection" {
+		return fmt.Errorf("type field not set to FeatureCollection: '%s'", typeStr)
+	}
+
+	featuresJSON, ok := topLevel["features"]
+	if !ok {
+		return errors.New("feature collection features field missing")
+	}
+	var features []GeoJSONFeature
+	if err := json.Unmarshal(featuresJSON, &features); err != nil {
+		return fmt.Errorf("unmarshalling features field: %w", err)
+	}
+
+	foreignMembers := make(map[string]interface{})
+	for k, vJSON := range topLevel {
+		switch k {
+		case "type", "features":
+			continue
+		default:
+			var v interface{}
+			if err := json.Unmarshal(vJSON, &v); err != nil {
+				return fmt.Errorf("unmarshalling foreign member '%s': %w", k, err)
+			}
+			foreignMembers[k] = v
+		}
+	}
+
+	*c = GeoJSONFeatureCollection{
+		Features:       features,
+		ForeignMembers: foreignMembers,
+	}
 	return nil
 }
 
 // MarshalJSON implements the encoding/json Marshaler interface by marshalling
 // into a GeoJSON FeatureCollection object.
 func (c GeoJSONFeatureCollection) MarshalJSON() ([]byte, error) {
-	var col []GeoJSONFeature = c
-	if col == nil {
-		col = []GeoJSONFeature{}
+	if c.Features == nil {
+		c.Features = []GeoJSONFeature{}
 	}
-	return json.Marshal(struct {
+
+	buf, err := json.Marshal(struct {
 		Type     string           `json:"type"`
 		Features []GeoJSONFeature `json:"features"`
-	}{"FeatureCollection", col})
+	}{"FeatureCollection", c.Features})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(c.ForeignMembers) == 0 {
+		return buf, nil
+	}
+	fms, err := json.Marshal(c.ForeignMembers)
+	if err != nil {
+		return nil, err
+	}
+	buf = buf[:len(buf)-1] // remove trailing '}'
+	buf = append(buf, ',')
+	buf = append(buf, fms[1:]...) // skip leading '{' (must be a JSON object due to construction)
+	return buf, nil
 }

--- a/geom/geojson_feature_collection_test.go
+++ b/geom/geojson_feature_collection_test.go
@@ -59,9 +59,9 @@ func TestGeoJSONFeatureCollectionValidUnmarshal(t *testing.T) {
 	err := json.NewDecoder(strings.NewReader(input)).Decode(&fc)
 	expectNoErr(t, err)
 
-	expectIntEq(t, len(fc), 2)
-	f0 := fc[0]
-	f1 := fc[1]
+	expectIntEq(t, len(fc.Features), 2)
+	f0 := fc.Features[0]
+	f1 := fc.Features[1]
 
 	expectStringEq(t, f0.ID.(string), "id0")
 	expectBoolEq(t, reflect.DeepEqual(f0.Properties, map[string]interface{}{"prop0": "value0", "prop1": "value1"}), true)
@@ -138,30 +138,35 @@ func TestGeoJSONFeatureCollectionEmpty(t *testing.T) {
 }
 
 func TestGeoJSONFeatureCollectionNil(t *testing.T) {
-	out, err := json.Marshal(geom.GeoJSONFeatureCollection(nil))
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection{
+		Features:       nil,
+		ForeignMembers: nil,
+	})
 	expectNoErr(t, err)
 	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[]}`)
 }
 
 func TestGeoJSONFeatureCollectionAndPropertiesNil(t *testing.T) {
-	out, err := json.Marshal(geom.GeoJSONFeatureCollection{{Geometry: geomFromWKT(t, "POINT(1 2)")}})
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection{Features: []geom.GeoJSONFeature{{Geometry: geomFromWKT(t, "POINT(1 2)")}}})
 	expectNoErr(t, err)
 	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{}}]}`)
 }
 
 func TestGeoJSONFeatureCollectionAndPropertiesSet(t *testing.T) {
-	out, err := json.Marshal(geom.GeoJSONFeatureCollection{{
-		Geometry: geomFromWKT(t, "POINT(1 2)"),
-		ID:       "myid",
-		Properties: map[string]interface{}{
-			"foo": "bar",
-		},
-	}})
+	out, err := json.Marshal(geom.GeoJSONFeatureCollection{
+		Features: []geom.GeoJSONFeature{{
+			Geometry: geomFromWKT(t, "POINT(1 2)"),
+			ID:       "myid",
+			Properties: map[string]interface{}{
+				"foo": "bar",
+			},
+		}},
+	})
 	expectNoErr(t, err)
 	expectStringEq(t, string(out), `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"id":"myid","properties":{"foo":"bar"}}]}`)
 }
 
-func TestGeoJSONForeignMembers(t *testing.T) {
+func TestGeoJSONFeatureForeignMembers(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		members map[string]interface{}
@@ -209,6 +214,59 @@ func TestGeoJSONForeignMembers(t *testing.T) {
 				expectNoErr(t, err)
 				if len(feat.ForeignMembers) != 0 || len(tc.members) != 0 {
 					expectDeepEq(t, feat.ForeignMembers, tc.members)
+				}
+			})
+		})
+	}
+}
+
+func TestGeoJSONFeatureCollectionForeignMembers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		members map[string]interface{}
+		json    string
+	}{
+		{
+			name:    "nil foreign members",
+			members: nil,
+			json:    `{"type":"FeatureCollection","features":[]}`,
+		},
+		{
+			name:    "empty foreign members",
+			members: map[string]interface{}{},
+			json:    `{"type":"FeatureCollection","features":[]}`,
+		},
+		{
+			name:    "one foreign member",
+			members: map[string]interface{}{"foo": "bar"},
+			json:    `{"type":"FeatureCollection","features":[],"foo":"bar"}`,
+		},
+		{
+			name:    "two foreign members",
+			members: map[string]interface{}{"foo": "bar", "baz": 42.0},
+			json:    `{"type":"FeatureCollection","features":[],"baz":42,"foo":"bar"}`,
+		},
+		{
+			name:    "nested",
+			members: map[string]interface{}{"metadata": map[string]interface{}{"foo": "bar", "baz": 42.0}},
+			json:    `{"type":"FeatureCollection","features":[],"metadata":{"baz":42,"foo":"bar"}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("marshal", func(t *testing.T) {
+				fc := geom.GeoJSONFeatureCollection{
+					ForeignMembers: tc.members,
+				}
+				got, err := json.Marshal(fc)
+				expectNoErr(t, err)
+				expectStringEq(t, string(got), tc.json)
+			})
+			t.Run("unmarshal", func(t *testing.T) {
+				var fc geom.GeoJSONFeatureCollection
+				err := json.Unmarshal([]byte(tc.json), &fc)
+				expectNoErr(t, err)
+				if len(fc.ForeignMembers) != 0 || len(tc.members) != 0 {
+					expectDeepEq(t, fc.ForeignMembers, tc.members)
 				}
 			})
 		})


### PR DESCRIPTION
## Description

This change adds support for foreign members at the GeoJSON Feature Collection level (foreign members are already supported at the GeoJSON Feature level).

This necessitates a breaking change to the `geom.GeoJSONFeatureCollection` type. It was previously defined as `[]geom.GeoJSONFeature`, but is now defined as a struct with a `Features []geom.GeoJSONFeature` field and a `ForeignMembers` `map[string]json.RawMessage` field. The breaking change is necessary because otherwise there is no where to put the foreign members.

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) Yes.

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/649
