### PR TITLE
Use `any` instead of `interface{}` throughout the codebase

### DIFF
--- a/.ci/compose-cmppg.yaml
+++ b/.ci/compose-cmppg.yaml
@@ -9,7 +9,7 @@ services:
       timeout: '1s'
       retries: 50
   tests:
-    image: golang:1.17
+    image: golang:1.18
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./internal/cmprefimpl/cmppg
     volumes:

--- a/.ci/compose-pgscan.yaml
+++ b/.ci/compose-pgscan.yaml
@@ -9,7 +9,7 @@ services:
       timeout: '1s'
       retries: 50
   tests:
-    image: golang:1.17
+    image: golang:1.18
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: go test -test.count=1 -test.timeout=30m -test.run=. ./internal/pgscan
     volumes:

--- a/.ci/compose-unit.yaml
+++ b/.ci/compose-unit.yaml
@@ -1,6 +1,6 @@
 services:
   tests:
-    image: golang:1.17
+    image: golang:1.18
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: go test -covermode=count -coverprofile=coverage.out -test.count=1 -test.run=. ./geom ./rtree
     volumes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   that `reflect.DeepEqual` now works correctly for exactly comparing
   geometries.
 
+- Replaces all occurrences of `interface{}` with `any` throughout the codebase.
+  This includes function parameters, return types, struct fields, and type
+  assertions.
+
+- **Breaking change:** The minimum required Go version is now 1.18 (previously
+  1.17). This is required to support the `any` keyword.
+
 ## v0.55.0
 
 2025-10-10

--- a/geom/dcel_debug.go
+++ b/geom/dcel_debug.go
@@ -155,12 +155,12 @@ func lstoa(locs [2]location) string {
 }
 
 //nolint:unused
-func ptoa(ptr interface{}) string {
+func ptoa(ptr any) string {
 	return fmt.Sprintf("%p", ptr)
 }
 
 //nolint:unused
-func ptrLess(ptr1, ptr2 interface{}) bool {
+func ptrLess(ptr1, ptr2 any) bool {
 	return ptoa(ptr1) < ptoa(ptr2)
 }
 

--- a/geom/errors.go
+++ b/geom/errors.go
@@ -2,7 +2,7 @@ package geom
 
 import "fmt"
 
-func wrap(err error, format string, args ...interface{}) error {
+func wrap(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/geom/geojson_feature_collection.go
+++ b/geom/geojson_feature_collection.go
@@ -15,17 +15,17 @@ type GeoJSONFeature struct {
 	// ID is an identifier to refer to the feature. If an identifier isn't
 	// applicable, ID can be left as nil. If it's set, then its value should
 	// marshal into a JSON string or number (this is not enforced).
-	ID interface{}
+	ID any
 
 	// Properties are free-form properties that are associated with the
 	// feature. If there are no properties associated with the feature, then it
 	// can either be set to an empty map or left as nil.
-	Properties map[string]interface{}
+	Properties map[string]any
 
 	// ForeignMembers are additional fields that are not explicitly described
 	// in the GeoJSON specification, but are allowed (as per the specification)
 	// to be present at the top level of GeoJSON features nonetheless.
-	ForeignMembers map[string]interface{}
+	ForeignMembers map[string]any
 }
 
 // UnmarshalJSON implements the encoding/json Unmarshaler interface by
@@ -58,7 +58,7 @@ func (f *GeoJSONFeature) UnmarshalJSON(p []byte) error {
 	}
 
 	idJSON, ok := topLevel["id"]
-	var id interface{}
+	var id any
 	if ok {
 		if err := json.Unmarshal(idJSON, &id); err != nil {
 			return err
@@ -66,20 +66,20 @@ func (f *GeoJSONFeature) UnmarshalJSON(p []byte) error {
 	}
 
 	propsJSON, ok := topLevel["properties"]
-	var props map[string]interface{}
+	var props map[string]any
 	if ok {
 		if err := json.Unmarshal(propsJSON, &props); err != nil {
 			return err
 		}
 	}
 
-	foreignMembers := make(map[string]interface{})
+	foreignMembers := make(map[string]any)
 	for k, vJSON := range topLevel {
 		switch k {
 		case "type", "geometry", "id", "properties":
 			continue
 		default:
-			var v interface{}
+			var v any
 			if err := json.Unmarshal(vJSON, &v); err != nil {
 				return err
 			}
@@ -102,14 +102,14 @@ func (f GeoJSONFeature) MarshalJSON() ([]byte, error) {
 	props := f.Properties
 	if props == nil {
 		// As per the GeoJSON spec, the properties field must be an object (not null).
-		props = map[string]interface{}{}
+		props = map[string]any{}
 	}
 
 	buf, err := json.Marshal(struct {
-		Type       string                 `json:"type"`
-		Geometry   Geometry               `json:"geometry"`
-		ID         interface{}            `json:"id,omitempty"`
-		Properties map[string]interface{} `json:"properties"`
+		Type       string         `json:"type"`
+		Geometry   Geometry       `json:"geometry"`
+		ID         any            `json:"id,omitempty"`
+		Properties map[string]any `json:"properties"`
 	}{
 		"Feature",
 		f.Geometry,
@@ -143,7 +143,7 @@ func (f GeoJSONFeature) MarshalJSON() ([]byte, error) {
 // GeoJSON FeatureCollections.
 type GeoJSONFeatureCollection struct {
 	Features       []GeoJSONFeature
-	ForeignMembers map[string]interface{}
+	ForeignMembers map[string]any
 }
 
 // UnmarshalJSON implements the encoding/json Unmarshaler interface by
@@ -175,13 +175,13 @@ func (c *GeoJSONFeatureCollection) UnmarshalJSON(p []byte) error {
 		return fmt.Errorf("unmarshalling features field: %w", err)
 	}
 
-	foreignMembers := make(map[string]interface{})
+	foreignMembers := make(map[string]any)
 	for k, vJSON := range topLevel {
 		switch k {
 		case "type", "features":
 			continue
 		default:
-			var v interface{}
+			var v any
 			if err := json.Unmarshal(vJSON, &v); err != nil {
 				return fmt.Errorf("unmarshalling foreign member '%s': %w", k, err)
 			}

--- a/geom/geojson_feature_collection_test.go
+++ b/geom/geojson_feature_collection_test.go
@@ -65,11 +65,11 @@ func TestGeoJSONFeatureCollectionValidUnmarshal(t *testing.T) {
 	f1 := fc.Features[1]
 
 	expectStringEq(t, f0.ID.(string), "id0")
-	expectBoolEq(t, reflect.DeepEqual(f0.Properties, map[string]interface{}{"prop0": "value0", "prop1": "value1"}), true)
+	expectBoolEq(t, reflect.DeepEqual(f0.Properties, map[string]any{"prop0": "value0", "prop1": "value1"}), true)
 	expectGeomEq(t, f0.Geometry, geomFromWKT(t, "LINESTRING(102 0,103 1,104 0,105 1)"))
 
 	expectStringEq(t, f1.ID.(string), "id1")
-	expectBoolEq(t, reflect.DeepEqual(f1.Properties, map[string]interface{}{"prop0": "value2", "prop1": "value3"}), true)
+	expectBoolEq(t, reflect.DeepEqual(f1.Properties, map[string]any{"prop0": "value2", "prop1": "value3"}), true)
 	expectGeomEq(t, f1.Geometry, geomFromWKT(t, "POLYGON((100 0,101 0,101 1,100 1,100 0))"))
 }
 
@@ -158,7 +158,7 @@ func TestGeoJSONFeatureCollectionAndPropertiesSet(t *testing.T) {
 		Features: []geom.GeoJSONFeature{{
 			Geometry: geomFromWKT(t, "POINT(1 2)"),
 			ID:       "myid",
-			Properties: map[string]interface{}{
+			Properties: map[string]any{
 				"foo": "bar",
 			},
 		}},
@@ -170,7 +170,7 @@ func TestGeoJSONFeatureCollectionAndPropertiesSet(t *testing.T) {
 func TestGeoJSONFeatureForeignMembers(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
-		members map[string]interface{}
+		members map[string]any
 		json    string
 	}{
 		{
@@ -180,22 +180,22 @@ func TestGeoJSONFeatureForeignMembers(t *testing.T) {
 		},
 		{
 			name:    "empty foreign members",
-			members: map[string]interface{}{},
+			members: map[string]any{},
 			json:    `{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{}}`,
 		},
 		{
 			name:    "one foreign member",
-			members: map[string]interface{}{"foo": "bar"},
+			members: map[string]any{"foo": "bar"},
 			json:    `{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{},"foo":"bar"}`,
 		},
 		{
 			name:    "two foreign members",
-			members: map[string]interface{}{"foo": "bar", "baz": 42.0},
+			members: map[string]any{"foo": "bar", "baz": 42.0},
 			json:    `{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{},"baz":42,"foo":"bar"}`,
 		},
 		{
 			name:    "nested",
-			members: map[string]interface{}{"metadata": map[string]interface{}{"foo": "bar", "baz": 42.0}},
+			members: map[string]any{"metadata": map[string]any{"foo": "bar", "baz": 42.0}},
 			json:    `{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{},"metadata":{"baz":42,"foo":"bar"}}`,
 		},
 	} {
@@ -224,23 +224,23 @@ func TestGeoJSONFeatureForeignMembers(t *testing.T) {
 func TestGeoJSONFeatureForeignMembersForbidden(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
-		members map[string]interface{}
+		members map[string]any
 	}{
 		{
 			name:    "has type foreign member",
-			members: map[string]interface{}{"type": "dummy"},
+			members: map[string]any{"type": "dummy"},
 		},
 		{
 			name:    "has geometry foreign member",
-			members: map[string]interface{}{"geometry": "dummy"},
+			members: map[string]any{"geometry": "dummy"},
 		},
 		{
 			name:    "has properties foreign member",
-			members: map[string]interface{}{"properties": "dummy"},
+			members: map[string]any{"properties": "dummy"},
 		},
 		{
 			name:    "has id foreign member",
-			members: map[string]interface{}{"id": "dummy"},
+			members: map[string]any{"id": "dummy"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -256,7 +256,7 @@ func TestGeoJSONFeatureForeignMembersForbidden(t *testing.T) {
 func TestGeoJSONFeatureCollectionForeignMembers(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
-		members map[string]interface{}
+		members map[string]any
 		json    string
 	}{
 		{
@@ -266,22 +266,22 @@ func TestGeoJSONFeatureCollectionForeignMembers(t *testing.T) {
 		},
 		{
 			name:    "empty foreign members",
-			members: map[string]interface{}{},
+			members: map[string]any{},
 			json:    `{"type":"FeatureCollection","features":[]}`,
 		},
 		{
 			name:    "one foreign member",
-			members: map[string]interface{}{"foo": "bar"},
+			members: map[string]any{"foo": "bar"},
 			json:    `{"type":"FeatureCollection","features":[],"foo":"bar"}`,
 		},
 		{
 			name:    "two foreign members",
-			members: map[string]interface{}{"foo": "bar", "baz": 42.0},
+			members: map[string]any{"foo": "bar", "baz": 42.0},
 			json:    `{"type":"FeatureCollection","features":[],"baz":42,"foo":"bar"}`,
 		},
 		{
 			name:    "nested",
-			members: map[string]interface{}{"metadata": map[string]interface{}{"foo": "bar", "baz": 42.0}},
+			members: map[string]any{"metadata": map[string]any{"foo": "bar", "baz": 42.0}},
 			json:    `{"type":"FeatureCollection","features":[],"metadata":{"baz":42,"foo":"bar"}}`,
 		},
 	} {
@@ -309,15 +309,15 @@ func TestGeoJSONFeatureCollectionForeignMembers(t *testing.T) {
 func TestGeoJSONFeatureCollectionForeignMembersForbidden(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
-		members map[string]interface{}
+		members map[string]any
 	}{
 		{
 			name:    "has type foreign member",
-			members: map[string]interface{}{"type": "dummy"},
+			members: map[string]any{"type": "dummy"},
 		},
 		{
 			name:    "has features foreign member",
-			members: map[string]interface{}{"features": "dummy"},
+			members: map[string]any{"features": "dummy"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/geom/geojson_unmarshal.go
+++ b/geom/geojson_unmarshal.go
@@ -101,10 +101,10 @@ type geojsonMultiPolygon struct {
 }
 
 type geojsonGeometryCollection struct {
-	geoms []interface{}
+	geoms []any
 }
 
-func decodeGeoJSON(node geojsonNode) (interface{}, error) {
+func decodeGeoJSON(node geojsonNode) (any, error) {
 	switch node.Type {
 	case "Point":
 		c, err := extract1DimFloat64s(node.Coords)
@@ -126,7 +126,7 @@ func decodeGeoJSON(node geojsonNode) (interface{}, error) {
 		return geojsonMultiPolygon{c}, err
 	case "GeometryCollection":
 		parent := geojsonGeometryCollection{
-			geoms: make([]interface{}, len(node.Geoms)),
+			geoms: make([]any, len(node.Geoms)),
 		}
 		for i, g := range node.Geoms {
 			child, err := decodeGeoJSON(g)
@@ -169,7 +169,7 @@ func geojsonInvalidCoordinatesLengthError(n int) error {
 	return geojsonSyntaxError{fmt.Sprintf("invalid geojson coordinate length: %d", n)}
 }
 
-func detectCoordinatesLengths(node interface{}, hasLength map[int]struct{}) error {
+func detectCoordinatesLengths(node any, hasLength map[int]struct{}) error {
 	switch node := node.(type) {
 	case geojsonPoint:
 		n := len(node.coords)
@@ -244,7 +244,7 @@ func detectCoordinatesLengths(node interface{}, hasLength map[int]struct{}) erro
 	}
 }
 
-func geojsonNodeToGeometry(node interface{}, ctype CoordinatesType) Geometry {
+func geojsonNodeToGeometry(node any, ctype CoordinatesType) Geometry {
 	switch node := node.(type) {
 	case geojsonPoint:
 		coords, ok := oneDimFloat64sToCoordinates(node.coords, ctype)

--- a/geom/sql_test.go
+++ b/geom/sql_test.go
@@ -71,7 +71,7 @@ func TestSQLScanConcrete(t *testing.T) {
 		wkt      string
 		concrete interface {
 			AsText() string
-			Scan(interface{}) error
+			Scan(any) error
 		}
 	}{
 		{"POINT(0 1)", new(geom.Point)},

--- a/geom/type_geometry.go
+++ b/geom/type_geometry.go
@@ -261,7 +261,7 @@ func (g *Geometry) UnmarshalJSON(p []byte) error {
 // unmarshalGeoJSONAsType unmarshals GeoJSON directly into the concrete
 // geometry specified by dst (which should be a pointer to the concrete
 // geometry type).
-func unmarshalGeoJSONAsType(p []byte, dst interface{}) error {
+func unmarshalGeoJSONAsType(p []byte, dst any) error {
 	g, err := UnmarshalGeoJSON(p)
 	if err != nil {
 		return err
@@ -313,7 +313,7 @@ func (g Geometry) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (g *Geometry) Scan(src interface{}) error {
+func (g *Geometry) Scan(src any) error {
 	var wkb []byte
 	switch src := src.(type) {
 	case []byte:
@@ -340,7 +340,7 @@ func (g *Geometry) Scan(src interface{}) error {
 // geometry types. The src should be the input to Scan, typ should be the
 // concrete geometry type, and dst should be a pointer to the concrete geometry
 // to update (e.g. *LineString).
-func scanAsType(src interface{}, dst interface{}) error {
+func scanAsType(src any, dst any) error {
 	var g Geometry
 	if err := g.Scan(src); err != nil {
 		return err
@@ -356,7 +356,7 @@ func scanAsType(src interface{}, dst interface{}) error {
 // assignToConcrete assigns the geometry stored in g to the concrete geometry
 // pointed to by dst (i.e. dst must be a pointer to a concrete geometry). It
 // panics if the type of dst doesn't match the geometry stored in g.
-func assignToConcrete(dst interface{}, g Geometry) {
+func assignToConcrete(dst any, g Geometry) {
 	switch g.Type() {
 	case TypeGeometryCollection:
 		*dst.(*GeometryCollection) = g.MustAsGeometryCollection()

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -183,7 +183,7 @@ func (c GeometryCollection) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (c *GeometryCollection) Scan(src interface{}) error {
+func (c *GeometryCollection) Scan(src any) error {
 	return scanAsType(src, c)
 }
 

--- a/geom/type_line_string.go
+++ b/geom/type_line_string.go
@@ -244,7 +244,7 @@ func (s LineString) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (s *LineString) Scan(src interface{}) error {
+func (s *LineString) Scan(src any) error {
 	return scanAsType(src, s)
 }
 

--- a/geom/type_multi_line_string.go
+++ b/geom/type_multi_line_string.go
@@ -269,7 +269,7 @@ func (m MultiLineString) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (m *MultiLineString) Scan(src interface{}) error {
+func (m *MultiLineString) Scan(src any) error {
 	return scanAsType(src, m)
 }
 

--- a/geom/type_multi_point.go
+++ b/geom/type_multi_point.go
@@ -145,7 +145,7 @@ func (m MultiPoint) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (m *MultiPoint) Scan(src interface{}) error {
+func (m *MultiPoint) Scan(src any) error {
 	return scanAsType(src, m)
 }
 

--- a/geom/type_multi_polygon.go
+++ b/geom/type_multi_polygon.go
@@ -273,7 +273,7 @@ func (m MultiPolygon) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (m *MultiPolygon) Scan(src interface{}) error {
+func (m *MultiPolygon) Scan(src any) error {
 	return scanAsType(src, m)
 }
 

--- a/geom/type_null_geometry.go
+++ b/geom/type_null_geometry.go
@@ -11,7 +11,7 @@ type NullGeometry struct {
 }
 
 // Scan implements the database/sql.Scanner interface.
-func (ng *NullGeometry) Scan(value interface{}) error {
+func (ng *NullGeometry) Scan(value any) error {
 	if value == nil {
 		ng.Geometry = Geometry{}
 		ng.Valid = false

--- a/geom/type_point.go
+++ b/geom/type_point.go
@@ -122,7 +122,7 @@ func (p Point) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (p *Point) Scan(src interface{}) error {
+func (p *Point) Scan(src any) error {
 	return scanAsType(src, p)
 }
 

--- a/geom/type_polygon.go
+++ b/geom/type_polygon.go
@@ -276,7 +276,7 @@ func (p Polygon) Value() (driver.Value, error) {
 // error will be returned if the geometry is invalid). If this validation isn't
 // needed or is undesirable, then the WKB should be scanned into a byte slice
 // and then UnmarshalWKB called manually (passing in NoValidate{}).
-func (p *Polygon) Scan(src interface{}) error {
+func (p *Polygon) Scan(src any) error {
 	return scanAsType(src, p)
 }
 

--- a/geom/util_test.go
+++ b/geom/util_test.go
@@ -105,7 +105,7 @@ func expectErrIs(tb testing.TB, err, want error) {
 	}
 }
 
-func expectErrAs(tb testing.TB, err error, target interface{}) {
+func expectErrAs(tb testing.TB, err error, target any) {
 	tb.Helper()
 	if !errors.As(err, target) {
 		targetType := reflect.ValueOf(target).Elem().Interface()
@@ -132,7 +132,7 @@ func expectValidity(tb testing.TB, g interface{ Validate() error }, rv geom.Rule
 	expectValidationErrWithReason(tb, err, rv)
 }
 
-func expectDeepEq(tb testing.TB, got, want interface{}) {
+func expectDeepEq(tb testing.TB, got, want any) {
 	tb.Helper()
 	if !reflect.DeepEqual(got, want) {
 		tb.Errorf("\ngot:  %v\nwant: %v\n", got, want)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peterstace/simplefeatures
 
-go 1.17
+go 1.18
 
 retract v0.45.0 // Due to bug: https://github.com/peterstace/simplefeatures/pull/554
 

--- a/internal/rawgeos/errors.go
+++ b/internal/rawgeos/errors.go
@@ -5,7 +5,7 @@ import "fmt"
 // #include "geos_c.h"
 import "C"
 
-func wrap(err error, format string, args ...interface{}) error {
+func wrap(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -23,7 +23,7 @@ func Err(tb testing.TB, err error) {
 	}
 }
 
-func ErrAs(tb testing.TB, err error, target interface{}) {
+func ErrAs(tb testing.TB, err error, target any) {
 	tb.Helper()
 	if !errors.As(err, target) {
 		tb.Fatalf("expected error '%v' to be 'As' of type %T", err, target)
@@ -44,14 +44,14 @@ func NotExactEquals(tb testing.TB, g1, g2 geom.Geometry, opts ...geom.ExactEqual
 	}
 }
 
-func DeepEqual(tb testing.TB, a, b interface{}) {
+func DeepEqual(tb testing.TB, a, b any) {
 	tb.Helper()
 	if !reflect.DeepEqual(a, b) {
 		tb.Fatalf("values should be deeply equal:\n  a: %#v\n  b: %#v", a, b)
 	}
 }
 
-func NotDeepEqual(tb testing.TB, a, b interface{}) {
+func NotDeepEqual(tb testing.TB, a, b any) {
 	tb.Helper()
 	if reflect.DeepEqual(a, b) {
 		tb.Fatalf("values should not be deeply equal:\n  a: %#v\n  b: %#v", a, b)

--- a/rtree/nearest.go
+++ b/rtree/nearest.go
@@ -73,11 +73,11 @@ func (q *entriesQueue) Swap(i int, j int) {
 	q.entries[i], q.entries[j] = q.entries[j], q.entries[i]
 }
 
-func (q *entriesQueue) Push(x interface{}) {
+func (q *entriesQueue) Push(x any) {
 	q.entries = append(q.entries, x.(*entry))
 }
 
-func (q *entriesQueue) Pop() interface{} {
+func (q *entriesQueue) Pop() any {
 	e := q.entries[len(q.entries)-1]
 	q.entries = q.entries[:len(q.entries)-1]
 	return e


### PR DESCRIPTION
## Description

Replaces all occurrences of `interface{}` with the `any` keyword throughout the codebase. This modernizes the code to use Go 1.18+ idioms and improves readability.

A follow up change will start to use other features that were introduced in Go 1.18 (e.g. generics).



## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A.

- Updated release notes? (if appropriate?) Yes.
