### PR TITLE
Optimize overlay operations with envelope checks and R-Tree indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Optimize Intersection to return early when input envelopes are disjoint.
+
+- Optimize overlay operations (Intersection, Difference) for GeometryCollections
+  by using R-Tree indexing to reduce O(M×N) to O(M log N) complexity.
+
 ## v0.57.0
 
 2026-01-30

--- a/geom/util.go
+++ b/geom/util.go
@@ -7,7 +7,14 @@ import (
 	"sort"
 )
 
-// TODO: Remove this when we require Go 1.21 (the max builtin can be used instead).
+// TODO: Remove these when we require Go 1.21 (the min/max builtins can be used instead).
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func maxInt(a, b int) int {
 	if a > b {
 		return a


### PR DESCRIPTION
## Description

Add early exit for Intersection when envelopes are disjoint, returning an empty result of the appropriate dimension without calling the JTS port.

Replace `O(M*N)` nested loops in gcAwareIntersection and gcAwareDifference with R-Tree indexed lookups for O(M log N) complexity.



## Check List

Have you:

- Added unit tests? N/A (optimization, no functional change)

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

- Updated the README.md (if new functionality is added?) N/A

## Related Issue

- https://github.com/peterstace/simplefeatures/issues/684

## Benchmark Results

TODO

<details>

<summary>Click to expand</summary>

```
PASTE BENCHMARKS HERE
```

</details>
