### PR TITLE
Return dimension-appropriate empty geometries from overlay operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Change `GeometryCollection.Dimension()` to return -1 for empty geometry
+  collections (previously returned 0). This change is consistent with GEOS.
+
+- Fix overlay operations (Union, Intersection, Difference, SymmetricDifference)
+  to return dimension-appropriate empty geometries. For example, the difference
+  of two equal polygons now returns `POLYGON EMPTY` rather than
+  `GEOMETRYCOLLECTION EMPTY`.
+
 - Optimize Intersection to return early when input envelopes are disjoint.
 
 - Optimize overlay operations (Intersection, Difference) for GeometryCollections

--- a/geom/attr_test.go
+++ b/geom/attr_test.go
@@ -38,7 +38,7 @@ func TestIsEmptyDimension(t *testing.T) {
 		{"MULTIPOLYGON(((0 0,1 0,1 1,0 0)))", false, 2},
 		{"MULTIPOLYGON(((0 0,1 0,1 1,0 0)))", false, 2},
 		{"MULTIPOLYGON(EMPTY)", true, 2},
-		{"GEOMETRYCOLLECTION EMPTY", true, 0},
+		{"GEOMETRYCOLLECTION EMPTY", true, -1},
 		{"GEOMETRYCOLLECTION(POINT EMPTY)", true, 0},
 		{"GEOMETRYCOLLECTION(POLYGON EMPTY)", true, 2},
 		{"GEOMETRYCOLLECTION(POINT(1 1))", false, 0},

--- a/geom/type_geometry_collection.go
+++ b/geom/type_geometry_collection.go
@@ -118,12 +118,12 @@ func (c GeometryCollection) IsEmpty() bool {
 	return true
 }
 
-// Dimension returns the maximum dimension over the collection, or 0 if the
-// collection is the empty collection. [Point]s and [MultiPoint]s have dimension 0,
-// [LineString]s and [MultiLineString]s have dimension 1, and [Polygon]s and
+// Dimension returns the maximum dimension over the collection, or -1 if the
+// collection contains no elements. [Point]s and [MultiPoint]s have dimension
+// 0, [LineString]s and [MultiLineString]s have dimension 1, and [Polygon]s and
 // [MultiPolygon]s have dimension 2.
 func (c GeometryCollection) Dimension() int {
-	dim := 0
+	dim := -1
 	for _, g := range c.geoms {
 		dim = maxInt(dim, g.Dimension())
 	}

--- a/geom/type_geometry_test.go
+++ b/geom/type_geometry_test.go
@@ -39,7 +39,7 @@ func TestZeroGeometry(t *testing.T) {
 	_, err = z.Value()
 	expectNoErr(t, err)
 
-	expectIntEq(t, z.Dimension(), 0)
+	expectIntEq(t, z.Dimension(), -1)
 }
 
 func TestGeometryType(t *testing.T) {

--- a/internal/cmprefimpl/cmpgeos/checks.go
+++ b/internal/cmprefimpl/cmpgeos/checks.go
@@ -229,18 +229,9 @@ func checkIsEmpty(g geom.Geometry, log *log.Logger) error {
 }
 
 func checkDimension(g geom.Geometry, log *log.Logger) error {
-	var want int
-	if !containsOnlyGeometryCollections(g) {
-		// Libgeos gives -1 dimension for GeometryCollection trees that only
-		// contain other GeometryCollections (all the way to the leaf nodes).
-		// This is weird behaviour, and the dimension should actually be zero.
-		// So we don't get 'want' from libgeos in that case (and allow want to
-		// default to 0).
-		var err error
-		want, err = rawgeos.Dimension(g)
-		if err != nil {
-			return err
-		}
+	want, err := rawgeos.Dimension(g)
+	if err != nil {
+		return err
 	}
 	got := g.Dimension()
 

--- a/internal/cmprefimpl/cmpgeos/util.go
+++ b/internal/cmprefimpl/cmpgeos/util.go
@@ -35,19 +35,6 @@ func containsCollectionWithOnlyEmptyElements(g geom.Geometry) bool {
 	}
 }
 
-func containsOnlyGeometryCollections(g geom.Geometry) bool {
-	if !g.IsGeometryCollection() {
-		return false
-	}
-	gc := g.MustAsGeometryCollection()
-	for i := 0; i < gc.NumGeometries(); i++ {
-		if !containsOnlyGeometryCollections(gc.GeometryN(i)) {
-			return false
-		}
-	}
-	return true
-}
-
 func containsMultiPolygonWithEmptyPolygon(g geom.Geometry) bool {
 	switch {
 	case g.IsMultiPolygon():

--- a/internal/cmprefimpl/cmppg/checks.go
+++ b/internal/cmprefimpl/cmppg/checks.go
@@ -378,18 +378,6 @@ func checkIsEmpty(t *testing.T, want UnaryResult, g geom.Geometry) {
 	})
 }
 
-func checkDimension(t *testing.T, want UnaryResult, g geom.Geometry) {
-	t.Run("CheckDimension", func(t *testing.T) {
-		got := g.Dimension()
-		want := want.Dimension
-		if got != want {
-			t.Logf("got:  %v", got)
-			t.Logf("want: %v", want)
-			t.Error("mismatch")
-		}
-	})
-}
-
 func checkEnvelope(t *testing.T, want UnaryResult, g geom.Geometry) {
 	t.Run("CheckEnvelope", func(t *testing.T) {
 		got := g.Envelope().AsGeometry()

--- a/internal/cmprefimpl/cmppg/fuzz_test.go
+++ b/internal/cmprefimpl/cmppg/fuzz_test.go
@@ -53,7 +53,6 @@ func TestFuzz(t *testing.T) {
 			checkWKB(t, want, g)
 			checkGeoJSON(t, want, g)
 			checkIsEmpty(t, want, g)
-			checkDimension(t, want, g)
 			checkEnvelope(t, want, g)
 			checkConvexHull(t, want, g)
 			checkIsRing(t, want, g)

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -52,18 +52,27 @@ func ErrAs(tb testing.TB, err error, target any) {
 	}
 }
 
-func ExactEquals(tb testing.TB, g1, g2 geom.Geometry, opts ...geom.ExactEqualsOption) {
+func ExactEquals(tb testing.TB, got, want geom.Geometry, opts ...geom.ExactEqualsOption) {
 	tb.Helper()
-	if !geom.ExactEquals(g1, g2, opts...) {
-		tb.Fatalf("geometries should be exactly equal:\n  g1: %v\n  g2: %v", g1.AsText(), g2.AsText())
+	if !geom.ExactEquals(got, want, opts...) {
+		tb.Fatalf("geometries should be exactly equal:\n got: %v\nwant: %v", got.AsText(), want.AsText())
 	}
 }
 
-func NotExactEquals(tb testing.TB, g1, g2 geom.Geometry, opts ...geom.ExactEqualsOption) {
+func NotExactEquals(tb testing.TB, got, want geom.Geometry, opts ...geom.ExactEqualsOption) {
 	tb.Helper()
-	if geom.ExactEquals(g1, g2, opts...) {
-		tb.Fatalf("geometries should not be exactly equal:\n  g1: %v\n  g2: %v", g1.AsText(), g2.AsText())
+	if geom.ExactEquals(got, want, opts...) {
+		tb.Fatalf("geometries should not be exactly equal:\n got: %v\nwant: %v", got.AsText(), want.AsText())
 	}
+}
+
+func ExactEqualsWKT(tb testing.TB, got geom.Geometry, wantWKT string, opts ...geom.ExactEqualsOption) {
+	tb.Helper()
+	want, err := geom.UnmarshalWKT(wantWKT)
+	if err != nil {
+		tb.Fatalf("failed to unmarshal WKT '%s': %v", wantWKT, err)
+	}
+	ExactEquals(tb, got, want, opts...)
 }
 
 func DeepEqual(tb testing.TB, a, b any) {


### PR DESCRIPTION
## Description

Change `GeometryCollection.Dimension()` to return -1 for empty geometry collections (previously 0), distinguishing them from empty Points. This is consistent with GEOS.

Update overlay operations (Union, Intersection, Difference, SymmetricDifference) to return empty geometries matching the expected result dimension (e.g. POLYGON EMPTY instead of GEOMETRYCOLLECTION EMPTY).

## Check List

Have you:

- Added unit tests? Yes.

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) Yes.

- Updated the README.md (if new functionality is added?) N/A

## Fixes

- https://github.com/peterstace/simplefeatures/issues/694