### PR TITLE
Fix coverage numbers by instrumenting all packages

### DIFF
--- a/.ci/compose-unit.yaml
+++ b/.ci/compose-unit.yaml
@@ -3,7 +3,7 @@ services:
     image: golang:1.18
     working_dir: /go/src/github.com/peterstace/simplefeatures
     entrypoint: >-
-      go test -covermode=count -coverprofile=coverage.out -test.count=1 -test.run=.
+      go test -covermode=count -coverpkg=./... -coverprofile=coverage.out -test.count=1 -test.run=.
       ./carto
       ./geom
       ./internal/jtsport/...


### PR DESCRIPTION
## Description

Add `-coverpkg=./...` to the unit test command so that cross-package test coverage is counted. Previously, tests in packages like `xmltest` that exercise code in other packages (e.g. `jts`) didn't contribute to the coverage profile.


## Check List

Have you:

- Added unit tests? N/A

- Add cmprefimpl tests? (if appropriate?) N/A

- Updated release notes? (if appropriate?) N/A

- Updated the README.md (if new functionality is added?) N/A
